### PR TITLE
Automatic sparsity detection for matrix-free operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Documentation: <https://jx-wang-s-group.github.io/JAX-AMG/>
 - **Automatic Differentiation**: Supports adjoint-based gradient computation and integrates seamlessly with JAX for end-to-end differentiable workflows.
 - **JIT Compilation**: Built as a native JAX primitive, fully compatible with Just-in-Time compilation (`jax.jit`) for efficient, low-overhead execution.
 - **MPI Support**: Enables distributed linear solves across multiple GPUs, with GPU-aware MPI support.
+- **Matrix-Free Operators**: Beyond explicit matrices, `A` can be a callable operator. The library recovers the exact sparsity pattern in a single pass by tracing the operator's computation graph, then assembles the matrix the solver needs.
 
 ## Prerequisites
 

--- a/demo/mpi_large_3d_poisson_operator_optimization.py
+++ b/demo/mpi_large_3d_poisson_operator_optimization.py
@@ -1,0 +1,106 @@
+"""
+Demo: MPI-distributed optimization of a large matrix-free 3D Poisson operator.
+
+A 3D Poisson operator with a learnable diagonal-shift `theta`, run as a large
+200^3 (8M-unknown) problem across 4 MPI ranks: the library detects the operator's
+sparsity and coloring once, then we differentiate through the distributed solve
+in an optimization loop.
+
+Usage:
+    mpirun -n 4 python demo/mpi_large_3d_poisson_operator_optimization.py
+"""
+
+import jax
+import jax.numpy as jnp
+from mpi4py import MPI
+
+import jaxamg
+from jaxamg.matrices import poisson3d_operator, rhs_ones
+from jaxamg.mpi_utils import (
+    get_partition_info,
+    partition_operator,
+)
+
+
+def main():
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    nranks = comm.Get_size()
+
+    gpus = jax.devices()
+    jax.config.update("jax_default_device", gpus[rank % len(gpus)])
+
+    grid = 200
+    n_global = grid**3
+    row_start, row_end, n_local = get_partition_info(n_global, rank, nranks)
+
+    b_local = rhs_ones(n_local)
+    target_local = jnp.full(n_local, 0.2)  # synthetic per-rank target
+
+    if rank == 0:
+        print("Matrix-free 3D Poisson operator optimization")
+        print(f"Grid {grid}^3 = {n_global / 1e6:.1f}M unknowns, MPI ranks: {nranks}\n")
+    comm.Barrier()
+    print(f"  rank {rank} -> {gpus[rank % len(gpus)]}: {n_local / 1e6:.1f}M local rows")
+    comm.Barrier()
+
+    config = {
+        "solver": "PBICGSTAB",
+        "preconditioner": {"solver": "AMG"},
+        "communicator": "MPI_DIRECT",
+        "tolerance": 1e-6,
+    }
+
+    # 3D Poisson operator with a learnable diagonal-shift parameter theta.
+    def make_operator(theta):
+        base = poisson3d_operator(robin=2.0)
+        return lambda u: base(u) + theta * u
+
+    # Detect coloring + MPI metadata once; the pattern is the same for every theta
+    # (a diagonal shift), so it is reused across the loop.
+    dummy_op, _, _ = partition_operator(make_operator(1.0), n_global, rank, nranks)
+    coloring_cache = jaxamg.cache_coloring(dummy_op, shape=(n_local, n_global))
+    mpi_cache = jaxamg.cache_mpi_metadata(
+        config, comm, n_global, (row_start, row_end), dummy_op
+    )
+    if rank == 0:
+        print(f"  detected operator: {coloring_cache[3]} colors\n")
+
+    # Per-rank loss over this rank's rows; the scalar loss and gradient are
+    # reduced across ranks below.
+    def loss_local(theta, b_loc):
+        op, _, _ = partition_operator(make_operator(theta), n_global, rank, nranks)
+        A = jaxamg.with_cache(op, coloring=coloring_cache, mpi=mpi_cache)
+        x_loc, _ = jaxamg.solve(A, b_loc)
+        return jnp.sum((x_loc - target_local) ** 2) / n_global
+
+    loss_and_grad = jax.jit(jax.value_and_grad(loss_local))
+
+    theta = 2.0
+    lr = 5.0
+    if rank == 0:
+        print(f"{'epoch':<6}{'theta':<12}{'loss':<18}{'gradient':<14}")
+        print("-" * 50)
+
+    for epoch in range(100):
+        loss_loc, grad_loc = loss_and_grad(theta, b_local)
+        loss = comm.allreduce(float(loss_loc), op=MPI.SUM)
+        grad_global = comm.allreduce(float(grad_loc), op=MPI.SUM)
+        if rank == 0:
+            print(f"{epoch:<6}{theta:<12.4f}{loss:<18.10f}{grad_global:<14.6f}")
+        theta -= lr * grad_global
+
+        if loss < 1e-3:
+            if rank == 0:
+                print(f"\nConverged at epoch {epoch} with loss {loss:.6e}")
+            break
+
+    if rank == 0:
+        print(f"\nDone. Final theta: {theta:.4f}")
+
+    comm.Barrier()
+    jaxamg.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/mpi_poisson_operator_optimization.py
+++ b/demo/mpi_poisson_operator_optimization.py
@@ -13,12 +13,8 @@ import jax.numpy as jnp
 from mpi4py import MPI
 
 import jaxamg
-from jaxamg.matrices import (
-    poisson_operator,
-    poisson_operator_distributed,
-    rhs_ones,
-)
-from jaxamg.mpi_utils import get_partition_info
+from jaxamg.matrices import poisson_operator, rhs_ones
+from jaxamg.mpi_utils import get_partition_info, partition_operator
 
 jax.config.update("jax_enable_x64", True)
 
@@ -79,8 +75,10 @@ def main():
         "tolerance": 1e-6,
     }
 
-    # Create dummy operator for caching
-    dummy_op = poisson_operator_distributed(grid_size, row_start, row_end, skew=1.0)
+    # Create local dummy operator for caching
+    dummy_op, _, _ = partition_operator(
+        poisson_operator(skew=1.0), n_global, rank, nranks
+    )
 
     # Cache MPI metadata
     mpi_cache = jaxamg.cache_mpi_metadata(
@@ -94,9 +92,10 @@ def main():
         print("\nStarting optimization...")
 
     # Define loss function
-    # @jax.jit
     def loss_local(skew, b_loc, x_true_loc):
-        op = poisson_operator_distributed(grid_size, row_start, row_end, skew=skew)
+        op, _, _ = partition_operator(
+            poisson_operator(skew=skew), n_global, rank, nranks
+        )
         A = jaxamg.with_cache(op, coloring=coloring_cache, mpi=mpi_cache)
 
         x_pred_loc, info = jaxamg.solve(A, b_loc)

--- a/demo/mpi_poisson_operator_optimization_global.py
+++ b/demo/mpi_poisson_operator_optimization_global.py
@@ -13,12 +13,12 @@ import jax.numpy as jnp
 from mpi4py import MPI
 
 import jaxamg
-from jaxamg.matrices import (
-    poisson_operator,
-    poisson_operator_distributed,
-    rhs_ones,
+from jaxamg.matrices import poisson_operator, rhs_ones
+from jaxamg.mpi_utils import (
+    get_partition_info,
+    make_allgather_vector,
+    partition_operator,
 )
-from jaxamg.mpi_utils import get_partition_info, make_allgather_vector
 
 jax.config.update("jax_enable_x64", True)
 
@@ -82,8 +82,10 @@ def main():
         "tolerance": 1e-6,
     }
 
-    # Create dummy operator for caching
-    dummy_op = poisson_operator_distributed(grid_size, row_start, row_end, skew=1.0)
+    # Create local dummy operator for caching
+    dummy_op, _, _ = partition_operator(
+        poisson_operator(skew=1.0), n_global, rank, nranks
+    )
 
     # Cache MPI metadata
     mpi_cache = jaxamg.cache_mpi_metadata(
@@ -106,7 +108,9 @@ def main():
     #           distributed solve.  Each rank produces its own local contribution;
     #           allreduce(SUM) in the loop assembles the full gradient.
     def loss_global(skew, b_loc):
-        op = poisson_operator_distributed(grid_size, row_start, row_end, skew=skew)
+        op, _, _ = partition_operator(
+            poisson_operator(skew=skew), n_global, rank, nranks
+        )
         A = jaxamg.with_cache(op, coloring=coloring_cache, mpi=mpi_cache)
         x_pred_loc, info = jaxamg.solve(A, b_loc)
         x_pred_global = allgather(x_pred_loc)

--- a/demo/mpi_sparsity_detection_benchmark.py
+++ b/demo/mpi_sparsity_detection_benchmark.py
@@ -1,0 +1,98 @@
+"""
+Benchmark: sparsity-detection cost -- tracing vs probing -- in an MPI setting.
+
+Before jaxamg can hand a matrix-free operator to AmgX it must recover the
+operator's sparsity pattern. ``jaxamg.sparsity`` does this two ways:
+
+  * TRACING (default): interpret the operator's jaxpr and propagate a sparse
+    connectivity structure -- the exact pattern in one host-side pass, in O(nnz)
+    memory, with no operator evaluations.
+  * PROBING (fallback): apply the operator to ``n_global`` one-hot basis vectors
+    and read off the nonzeros -- correct for any operator, but it materialises
+    large dense probe batches on the GPU and costs O(n_global) evaluations.
+
+This benchmark partitions a global 32^3 Poisson operator across 2 ranks and, on
+each rank, runs both detectors on the same local ``(n_local, n_global)`` block,
+reporting the wall time and GPU peak memory each drives. Both yield the same
+pattern; tracing is far faster at negligible GPU cost. (Much larger grids make
+probing's dense one-hot batch exceed XLA's scheduler limit and abort, which is
+exactly the regime where the tracing default earns its keep.)
+
+Usage:
+    mpirun -n 2 python demo/mpi_sparsity_detection_benchmark.py
+"""
+
+from time import perf_counter
+
+import jax
+from mpi4py import MPI
+
+from jaxamg.matrices import poisson3d_operator
+from jaxamg.mpi_utils import get_partition_info, partition_operator
+from jaxamg.sparsity import probe_sparsity_pattern, trace_sparsity_pattern
+
+jax.config.update("jax_enable_x64", True)
+
+
+def _pattern_set(res):
+    return None if res is None else set(zip(res[0].tolist(), res[1].tolist()))
+
+
+def main():
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    nranks = comm.Get_size()
+
+    gpus = jax.devices()
+    dev = gpus[rank % len(gpus)]
+    jax.config.update("jax_default_device", dev)
+
+    grid = 32
+    n_global = grid**3
+    row_start, row_end, n_local = get_partition_info(n_global, rank, nranks)
+
+    local_op, _, _ = partition_operator(
+        poisson3d_operator(robin=2.0), n_global, rank, nranks
+    )
+    shape = (n_local, n_global)
+
+    def gpu_peak_gb():
+        return dev.memory_stats().get("peak_bytes_in_use", 0) / 1e9
+
+    # Tracing: exact pattern from the jaxpr (host-side, ~no GPU).
+    base = gpu_peak_gb()
+    t0 = perf_counter()
+    traced = trace_sparsity_pattern(local_op, shape)
+    t_trace = perf_counter() - t0
+    gpu_trace = max(gpu_peak_gb() - base, 0.0)
+
+    # Probing: one-hot basis vectors on the GPU (the fallback).
+    mid = gpu_peak_gb()
+    t0 = perf_counter()
+    probed = probe_sparsity_pattern(local_op, shape)
+    t_probe = perf_counter() - t0
+    gpu_probe = max(gpu_peak_gb() - mid, 0.0)
+
+    match = _pattern_set(traced) == _pattern_set(probed)
+    speedup = t_probe / t_trace if t_trace > 0 else float("inf")
+
+    if rank == 0:
+        print(f"3D Poisson, grid {grid}^3 = {n_global:,} unknowns, {nranks} ranks\n")
+        print(
+            f"{'rank':<5}{'n_local':>10}{'trace (s)':>11}{'probe (s)':>11}"
+            f"{'speedup':>9}{'trace GPU':>11}{'probe GPU':>11}{'match':>7}"
+        )
+        print("-" * 74)
+    comm.Barrier()
+
+    for r in range(nranks):
+        if r == rank:
+            print(
+                f"{rank:<5}{n_local:>10}{t_trace:>11.3f}{t_probe:>11.3f}"
+                f"{speedup:>8.0f}x{gpu_trace:>10.2f}G{gpu_probe:>10.2f}G{str(match):>7}"
+            )
+        comm.Barrier()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -33,6 +33,13 @@ When to use each option:
     - It is especially helpful in iterative loops where the operator structure stays
       the same while values change.
     - In practice, pass the result of `cache_coloring(...)` into `with_cache(...)`.
+    - Under the hood, `cache_coloring(...)` detects the operator's sparsity pattern
+      by **tracing** its jaxpr — propagating an index-set structure through each
+      primitive to recover the exact pattern in a single trace — and falls back to
+      exhaustive **probing** with basis vectors for operators it cannot trace
+      (opaque calls, data-dependent indexing). The tracing method follows
+      [Hill & Dalle (2025)](https://arxiv.org/abs/2501.17737); their Julia package
+      is [SparseConnectivityTracer.jl](https://github.com/adrhill/SparseConnectivityTracer.jl).
 
 - `mpi=...`
     - This reuses MPI metadata such as counts, displacements, communicator pointer,

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,7 +46,7 @@ ranks; assign a distinct GPU to each via `CUDA_VISIBLE_DEVICES`:
 ```bash
 CUDA_VISIBLE_DEVICES=0,1 \
 OMPI_MCA_opal_cuda_support=true MPI4JAX_USE_CUDA_MPI=1 \
-mpirun -n 2 python -m pytest tests/test_mpi.py --with-mpi
+mpirun -n 2 python -m pytest --only-mpi tests/
 ```
 
 - `--only-mpi` runs *only* the MPI-marked tests.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -52,7 +52,9 @@ The input matrix can be a sparse matrix (from JAX or SciPy) of various types, or
 
 You can also solve using a callable operator instead of an explicit matrix.
 
-Note: The solve still requires an internal matrix representation, so this is not fully matrix-free backend execution.
+!!! note
+
+    AmgX still needs an explicit matrix, so the operator is materialized internally — its sparsity pattern is detected automatically (by tracing the operator's jaxpr, with basis-vector probing as a fallback) and the values are assembled via graph-colored probing. This is cached, so it happens once. See [Caching](caching.md) for details.
 
 === "Python"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 - **Automatic Differentiation**: Supports adjoint-based gradient computation and integrates seamlessly with JAX for end-to-end differentiable workflows.
 - **JIT Compilation**: Built as a native JAX primitive, fully compatible with Just-in-Time compilation (`jax.jit`) for efficient, low-overhead execution.
 - **MPI Support**: Enables distributed linear solves across multiple GPUs, with GPU-aware MPI support.
+- **Matrix-Free Operators**: Beyond explicit matrices, `A` can be a callable operator. The library recovers the exact sparsity pattern in a single pass by tracing the operator's computation graph, then assembles the matrix the solver needs.
 
 ## Dependencies
 

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -1,5 +1,4 @@
 from .cache import (
-    cache_coloring,
     cache_mpi_metadata,
     with_cache,
 )
@@ -11,6 +10,7 @@ from .jaxamg import (
     solve,
 )
 from .preconditioners import make_preconditioner
+from .sparsity import cache_coloring
 
 __all__ = [
     "solve",

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -143,29 +143,20 @@ def cache_mpi_metadata(
     elif callable(A):
         # For distributed operators, we need to use global size for proper materialization
         # The operator shape is (n_local, n_global): takes global vector, returns local portion
-        from .utils import (
-            get_column_coloring,
-            get_sparsity_pattern,
-            materialize_sparse_matrix,
-        )
+        from .sparsity import cache_coloring, materialize_sparse_matrix
 
         # Check if operator already has cached coloring
         cached_info = getattr(A, "_coloring_info", None)
 
-        if cached_info is not None:
-            # Use cached sparsity pattern
-            rows, cols, column_colors, n_colors, shape = cached_info
-            A_materialized = materialize_sparse_matrix(
-                A, shape, rows, cols, column_colors, n_colors
-            )
-        else:
-            # Compute sparsity pattern with correct shape for distributed operator
-            shape = (n_local, nglobal)
-            rows, cols = get_sparsity_pattern(A, shape)
-            column_colors, n_colors = get_column_coloring(rows, cols, shape)
-            A_materialized = materialize_sparse_matrix(
-                A, shape, rows, cols, column_colors, n_colors
-            )
+        if cached_info is None:
+            # Detect + colour via cache_coloring (tracing, then one-hot probing as
+            # fallback) using the distributed (n_local, n_global) shape.
+            cached_info = cache_coloring(A, (n_local, nglobal))
+
+        rows, cols, column_colors, n_colors, shape = cached_info
+        A_materialized = materialize_sparse_matrix(
+            A, shape, rows, cols, column_colors, n_colors
+        )
 
         local_nnz = len(A_materialized.data)
     else:
@@ -188,50 +179,3 @@ def cache_mpi_metadata(
     }
 
     return cache_dict
-
-
-def cache_coloring(
-    operator: Any, shape: tuple[int, int] | int
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, int, tuple[int, int]]:
-    """
-    Compute and cache coloring information for an operator.
-
-    This function computes the sparsity pattern and graph coloring for a callable
-    operator, enabling efficient use inside JIT-compiled functions.
-
-    Args:
-        operator: A callable operator A(x) that returns `A @ x`.
-        shape: Shape of the operator (n, m) or int size (for n×n matrix).
-
-    Returns:
-        Cached coloring information that can be reattached with `with_cache(..., coloring=...)`.
-    """
-    if isinstance(shape, int):
-        shape = (shape, shape)
-
-    # Check if already cached
-    existing_cache = getattr(operator, "_coloring_info", None)
-    if existing_cache is not None:
-        # Verify size matches
-        cached_shape = existing_cache[4]
-        if cached_shape == shape:
-            return existing_cache
-        else:
-            raise ValueError(
-                f"Operator already has cached coloring for shape {cached_shape}, "
-                f"but requested shape {shape}. Create a new operator instance."
-            )
-
-    # Compute sparsity pattern and coloring
-    rows, cols = get_sparsity_pattern(operator, shape)
-    column_colors, n_colors = get_column_coloring(rows, cols, shape)
-
-    cache = (rows, cols, column_colors, n_colors, shape)
-
-    # Try to attach to operator for convenience
-    try:
-        setattr(operator, "_coloring_info", cache)
-    except Exception:
-        pass  # Ignore if caching fails
-
-    return cache

--- a/jaxamg/matrices.py
+++ b/jaxamg/matrices.py
@@ -616,6 +616,64 @@ def poisson_operator_distributed(
     return matvec
 
 
+def poisson3d_operator(
+    robin: float = 0.0, diagonal_value: float = 6.0, dtype: DTypeLike | None = None
+) -> Callable:
+    """Create a matrix-free 3D Poisson operator (7-point stencil).
+
+    The operator discretizes -Δu on a regular n×n×n grid, applied via stencil
+    shifts (no matrix is formed). The input is a flattened length-n³ vector; the
+    output is A @ u. The default is homogeneous Dirichlet BCs.
+
+    Args:
+        robin: Robin boundary coefficient. With ``robin == 0`` (the default) the
+            operator uses homogeneous Dirichlet BCs (off-grid neighbors dropped,
+            uniform interior diagonal). With ``robin > 0`` each boundary cell gets
+            ``robin`` added to its diagonal per off-grid face, so boundary rows
+            carry heterogeneous, larger diagonals -- a non-trivial, non-singular,
+            diagonally dominant operator.
+        diagonal_value: The (interior) diagonal entry. Defaults to ``6.0``, the
+            standard 7-point Laplacian (one per face neighbor). Setting it away
+            from 6 shifts the diagonal, e.g. ``diagonal_value = 6 + theta`` gives a
+            diagonally-shifted, more strongly dominant operator.
+
+    Returns:
+        Callable matvec mapping a flattened 3D field to the global result.
+    """
+
+    def matvec(u_flat):
+        size = u_flat.shape[0]
+        n = round(size ** (1.0 / 3.0))
+        while n * n * n < size:
+            n += 1
+        while n * n * n > size:
+            n -= 1
+
+        u = u_flat.reshape((n, n, n))
+        out = diagonal_value * u
+        # Subtract the six face neighbors; entries off the grid are zero
+        # (Dirichlet), so each shifted contribution is added only where valid.
+        out = out.at[1:, :, :].add(-u[:-1, :, :])
+        out = out.at[:-1, :, :].add(-u[1:, :, :])
+        out = out.at[:, 1:, :].add(-u[:, :-1, :])
+        out = out.at[:, :-1, :].add(-u[:, 1:, :])
+        out = out.at[:, :, 1:].add(-u[:, :, :-1])
+        out = out.at[:, :, :-1].add(-u[:, :, 1:])
+
+        if robin != 0.0:
+            # Robin BC: add `robin` to the diagonal for every off-grid face a
+            # cell touches, so boundary rows get heterogeneous larger diagonals.
+            bw = jnp.zeros((n, n, n))
+            bw = bw.at[0].add(1.0).at[-1].add(1.0)
+            bw = bw.at[:, 0].add(1.0).at[:, -1].add(1.0)
+            bw = bw.at[:, :, 0].add(1.0).at[:, :, -1].add(1.0)
+            out = out + robin * bw * u
+
+        return out.ravel()
+
+    return matvec
+
+
 def convection_diffusion_matrix_2d(
     n: int,
     epsilon: float = 1.0,

--- a/jaxamg/matrices.py
+++ b/jaxamg/matrices.py
@@ -567,55 +567,6 @@ def poisson_operator(skew: float = 0.0, dtype: DTypeLike | None = None) -> Calla
     return matvec
 
 
-def poisson_operator_distributed(
-    n_side: int,
-    row_start: int,
-    row_end: int,
-    skew: float = 0.0,
-    dtype: DTypeLike | None = None,
-) -> Callable:
-    """
-    Create a distributed Poisson operator.
-
-    The operator takes a global vector u, applies the Poisson stencil,
-    and returns the local portion of the result (rows [row_start, row_end)).
-
-    Args:
-        n_side: Grid size (results in n_side^2 global size)
-        row_start: Starting global row index for this rank
-        row_end: Ending global row index for this rank (exclusive)
-        skew: Skew-symmetric coefficient (default 0.0)
-        dtype: Data type of the operator
-
-    Returns:
-        Callable operator u_global_flat -> local_segment_flat
-    """
-    # Create kernel with skew parameter
-    # Standard symmetric: [[0, -1, 0], [-1, 4, -1], [0, -1, 0]]
-    kernel = jnp.array(
-        [
-            [0.0, -1.0 - skew / 2.0, 0.0],
-            [-1.0 - skew / 2.0, 4.0, -1.0 + skew / 2.0],
-            [0.0, -1.0 + skew / 2.0, 0.0],
-        ],
-        dtype=dtype,
-    )
-
-    def matvec(u_flat):
-        # Reshape flat global vector to 2D grid
-        u = u_flat.reshape((n_side, n_side))
-
-        # Apply convolution with zero padding (Dirichlet BCs)
-        Au = jax.scipy.signal.convolve2d(
-            u, kernel, mode="same", boundary="fill", fillvalue=0.0
-        )
-
-        # Flatten and extract local rows
-        return Au.ravel()[row_start:row_end]
-
-    return matvec
-
-
 def poisson3d_operator(
     robin: float = 0.0, diagonal_value: float = 6.0, dtype: DTypeLike | None = None
 ) -> Callable:

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -278,10 +278,15 @@ def _mpi4jax_alltoallv_transpose(
     at_cols = recv_rows_flat  # Column index in A^T (global row in A)
 
     # Sort by (row, col) for CSR format
-    # Create composite key for sorting: row * n_global + col
+    # Create composite key for sorting: row * n_global + col. This must be int64:
+    # for large grids row*n_global overflows int32 (e.g. 48^3 -> ~6.1e9 > 2.1e9),
+    # which would scramble the row ordering and produce a malformed A^T.
     n_global = sum(recvcounts_tuple)  # Static Python int
-    sort_key = at_rows_local * n_global + at_cols
-    sort_idx = jnp.argsort(sort_key)
+    with temp_enable_x64():
+        sort_key = at_rows_local.astype(jnp.int64) * n_global + at_cols.astype(
+            jnp.int64
+        )
+        sort_idx = jnp.argsort(sort_key)
 
     r_sorted = at_rows_local[sort_idx]
     c_sorted = at_cols[sort_idx]

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -358,6 +358,39 @@ def partition_csr_matrix(
     return A_local, row_start, row_end
 
 
+def partition_operator(
+    operator: Callable, nglobal: int, rank: int, nranks: int
+) -> tuple[Callable, int, int]:
+    """Partition a global matrix-free operator across MPI ranks (row-based).
+
+    Wraps a global operator -- a callable mapping a length-``nglobal`` vector to
+    the global result ``A @ x`` -- into this rank's row-local operator, which
+    returns only the rows ``[row_start, row_end)`` this rank owns. That is the
+    ``(n_local, nglobal)`` form the distributed solve expects, so a user can pass
+    a single global operator instead of writing a distributed one by hand.
+
+    No global matrix is formed: each rank materializes only its local block.
+
+    Args:
+        operator: Global operator ``A(x)`` mapping a length-``nglobal`` vector to
+            a length-``nglobal`` result.
+        nglobal: Global problem size (total rows across all ranks).
+        rank: MPI rank (0-indexed).
+        nranks: Total number of MPI ranks.
+
+    Returns:
+        local_operator: Callable mapping the global vector to this rank's rows.
+        row_start: Starting row index (global).
+        row_end: Ending row index (global, exclusive).
+    """
+    row_start, row_end, _ = get_partition_info(nglobal, rank, nranks)
+
+    def local_operator(x_global: ArrayLike) -> jax.Array:
+        return operator(x_global)[row_start:row_end]
+
+    return local_operator, row_start, row_end
+
+
 def validate_partition(
     A_local: jsp.BCSR, nglobal: int, row_start: int, row_end: int
 ) -> None:

--- a/jaxamg/sparsity.py
+++ b/jaxamg/sparsity.py
@@ -40,6 +40,8 @@ from jax import lax
 from jax.extend.core import Literal
 from jax.typing import ArrayLike
 
+from .utils import temp_enable_x64
+
 # --- Tracing-based detection: interpret the operator's jaxpr ---
 # Element-wise primitives: output element depends on the union of its operands'
 # elements at the same (broadcast) position. Unary ops preserve connectivity
@@ -146,13 +148,8 @@ _UNKNOWN = object()  # sentinel: a value that depends on the operator input
 def _host_exact():
     """Run host-side index/position binds on CPU with x64 enabled, so position
     arithmetic stays exact regardless of the global precision config."""
-    prev = jax.config.jax_enable_x64
-    jax.config.update("jax_enable_x64", True)
-    try:
-        with jax.default_device(_CPU):
-            yield
-    finally:
-        jax.config.update("jax_enable_x64", prev)
+    with temp_enable_x64(), jax.default_device(_CPU):
+        yield
 
 
 class _BailOut(Exception):

--- a/jaxamg/sparsity.py
+++ b/jaxamg/sparsity.py
@@ -1,0 +1,1063 @@
+"""Sparsity detection and assembly for matrix-free operators.
+
+Turns a callable operator ``A(x)`` into its sparse matrix: (1) detect the sparsity
+pattern, (2) colour the columns, (3) materialise the values with one operator
+evaluation per colour. ``cache_coloring`` orchestrates it, tries the two detection
+methods in order, and verifies the result -- so it is correct for ANY operator:
+
+- **Tracing** (``trace_sparsity_pattern``): interpret the operator's jaxpr and
+  propagate a connectivity (index-set) structure through each primitive to recover
+  the EXACT *global* sparsity pattern in a single trace. Returns ``None`` for
+  operators that can't be traced structurally (opaque calls, data-dependent
+  indexing). This is the JAX-native analogue of the operator-overloading sparsity
+  detection of SparseConnectivityTracer.jl [1, 2]: JAX is trace-based rather than
+  dispatch-based, so instead of overloading a custom number type we trace the
+  function to a jaxpr and interpret it.
+- **Probing** (``probe_sparsity_pattern``): exhaustive one-hot basis-vector
+  probing; the always-correct fallback when tracing is unavailable.
+
+References:
+    [1] A. Hill and G. Dalle, "Sparser, Better, Faster, Stronger: Sparsity
+        Detection for Efficient Automatic Differentiation," arXiv:2501.17737
+        (2025).
+    [2] SparseConnectivityTracer.jl,
+        https://github.com/adrhill/SparseConnectivityTracer.jl
+"""
+
+from __future__ import annotations
+
+import contextlib
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import jax
+import jax.experimental.sparse as jsp
+import jax.numpy as jnp
+import numpy as np
+import scipy.sparse as sp
+from jax import lax
+from jax.extend.core import Literal
+from jax.typing import ArrayLike
+
+# --- Tracing-based detection: interpret the operator's jaxpr ---
+# Element-wise primitives: output element depends on the union of its operands'
+# elements at the same (broadcast) position. Unary ops preserve connectivity
+# (value-dependence), incl. nominally derivative-zero ones (sign/floor/...) since
+# we detect VALUE dependence to match probing-based materialization.
+_ELEMENTWISE = {
+    # n-ary
+    "add",
+    "sub",
+    "mul",
+    "div",
+    "pow",
+    "atan2",
+    "max",
+    "min",
+    "rem",
+    "nextafter",
+    "and",
+    "or",
+    "xor",
+    "add_any",
+    "select_n",
+    "select",
+    "eq",
+    "ne",
+    "lt",
+    "gt",
+    "le",
+    "ge",
+    # unary
+    "neg",
+    "abs",
+    "exp",
+    "exp2",
+    "expm1",
+    "log",
+    "log1p",
+    "sin",
+    "cos",
+    "tan",
+    "asin",
+    "acos",
+    "atan",
+    "sinh",
+    "cosh",
+    "tanh",
+    "asinh",
+    "acosh",
+    "atanh",
+    "sqrt",
+    "rsqrt",
+    "cbrt",
+    "square",
+    "integer_pow",
+    "logistic",
+    "erf",
+    "erfc",
+    "erf_inv",
+    "sign",
+    "floor",
+    "ceil",
+    "round",
+    "real",
+    "imag",
+    "conj",
+    "is_finite",
+    "not",
+    "convert_element_type",
+    "copy",
+    "reduce_precision",
+    "stop_gradient",
+    "clamp",
+}
+
+# Higher-order primitives whose sub-jaxpr(s) we interpret recursively.
+_CALL_PRIMS = {
+    "pjit",
+    "jit",
+    "closed_call",
+    "core_call",
+    "xla_call",
+    "custom_jvp_call",
+    "custom_vjp_call",
+    "remat2",
+    "remat_call",
+    "remat",
+}
+
+# Opaque -> cannot trace structure -> signal fallback to probing.
+_OPAQUE = {
+    "custom_call",
+    "pure_callback",
+    "io_callback",
+    "ffi_call",
+    "while",  # data-dependent iteration count -> not traced
+}
+
+_CPU = jax.devices("cpu")[0]
+
+_UNKNOWN = object()  # sentinel: a value that depends on the operator input
+
+
+@contextlib.contextmanager
+def _host_exact():
+    """Run host-side index/position binds on CPU with x64 enabled, so position
+    arithmetic stays exact regardless of the global precision config."""
+    prev = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        with jax.default_device(_CPU):
+            yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+class _BailOut(Exception):
+    """Raised when the operator cannot be traced structurally; caller falls back."""
+
+
+def _empty(n_rows, n_global):
+    return sp.csr_matrix((n_rows, n_global), dtype=np.int8)
+
+
+def _is_empty(C):
+    return C.nnz == 0
+
+
+def _index_operand_positions(prim, n_operands):
+    """Operand positions that are indices/offsets rather than data, for a movement
+    primitive. Their values steer where data lands but never flow into the output,
+    so they are bound as concrete values (not connectivity id blocks)."""
+    if prim == "dynamic_slice":
+        return set(range(1, n_operands))  # operand, then one start index per dim
+    if prim == "gather":
+        return {1}  # operand, indices
+    return set()  # pad: both operand and padding value are data
+
+
+def _movement_rowmap(prim, params, in_shapes, in_vals):
+    """Return (rowmap, n_combined): for movement primitives, rowmap[o] is the
+    source row (in the vstack of all operands) feeding output element o.
+
+    Each operand element is labelled by its row in the vstacked connectivity, so
+    binding the primitive on those labels recovers, per output element, which
+    source element it came from. Index operands (slice offsets, gather indices)
+    are bound as their concrete values instead -- and we bail if such an index is
+    itself input-dependent (data-dependent indexing is not structurally traceable).
+    """
+    sizes = [int(np.prod(s)) for s in in_shapes]
+    offsets = np.concatenate([[0], np.cumsum(sizes)])
+    blocks = [
+        np.arange(offsets[i], offsets[i + 1]).reshape(in_shapes[i])
+        for i in range(len(in_shapes))
+    ]
+
+    if prim == "reshape":
+        rowmap = blocks[0].reshape(-1)
+    elif prim in ("squeeze", "expand_dims"):
+        rowmap = blocks[0].reshape(-1)
+    elif prim == "transpose":
+        rowmap = np.transpose(blocks[0], params["permutation"]).reshape(-1)
+    elif prim == "rev":
+        rowmap = np.flip(blocks[0], params["dimensions"]).reshape(-1)
+    elif prim == "slice":
+        sl = tuple(
+            slice(s, l, (params["strides"][k] if params["strides"] else 1))
+            for k, (s, l) in enumerate(
+                zip(params["start_indices"], params["limit_indices"])
+            )
+        )
+        rowmap = blocks[0][sl].reshape(-1)
+    elif prim == "broadcast_in_dim":
+        out_shape = tuple(params["shape"])
+        bdims = tuple(params["broadcast_dimensions"])
+        in_shape = in_shapes[0]
+        full = [1] * len(out_shape)
+        for k, d in enumerate(bdims):
+            full[d] = in_shape[k]
+        rowmap = np.broadcast_to(blocks[0].reshape(full), out_shape).reshape(-1)
+    elif prim == "concatenate":
+        rowmap = np.concatenate(blocks, axis=params["dimension"]).reshape(-1)
+    else:
+        # pad / dynamic_slice / gather: let JAX compute the element map. Data
+        # operands are bound as id blocks; index operands as concrete values.
+        prim_obj = _PRIM_BY_NAME.get(prim)
+        if prim_obj is None:
+            raise _BailOut(f"no movement rule for {prim}")
+        index_positions = _index_operand_positions(prim, len(blocks))
+        args = []
+        for i, block in enumerate(blocks):
+            if i in index_positions:
+                if in_vals[i] is _UNKNOWN:
+                    raise _BailOut(f"{prim} with data-dependent indices")
+                args.append(jnp.asarray(in_vals[i]))
+            else:
+                args.append(jnp.asarray(block))
+        with _host_exact():
+            out = prim_obj.bind(*args, **params)
+        rowmap = np.asarray(out).reshape(-1)
+    return rowmap.astype(np.int64), int(offsets[-1])
+
+
+# Lazily-built name->primitive table for the rare bind path.
+_PRIM_BY_NAME: dict = {}
+
+
+def _build_prim_table():
+    for name in ("pad", "dynamic_slice", "gather"):
+        obj = getattr(lax, f"{name}_p", None)
+        if obj is not None:
+            _PRIM_BY_NAME[str(obj)] = obj
+
+
+_build_prim_table()
+
+
+def _reduce_map(params, in_shape, out_shape):
+    """Map each operand element to its reduced output element (reduce_* ops)."""
+    axes = set(params["axes"])
+    keep = [d for d in range(len(in_shape)) if d not in axes]
+    op_size = int(np.prod(in_shape))
+    mesh = np.unravel_index(np.arange(op_size), in_shape)
+    out_multi = tuple(mesh[d] for d in keep)
+    out_shape = tuple(out_shape)
+    if out_multi:
+        out_flat = np.ravel_multi_index(out_multi, out_shape)
+    else:
+        out_flat = np.zeros(op_size, dtype=np.int64)
+    return out_flat.astype(np.int64), int(np.prod(out_shape) if out_shape else 1)
+
+
+def _interp(jaxpr, consts, n_global, arg_conns, arg_vals=None):
+    """Interpret one (sub-)jaxpr, returning the connectivity of each outvar.
+
+    arg_vals carries known concrete values of the inputs (or _UNKNOWN), so that
+    constant-folding (e.g. of convolution kernels or scatter indices) works across
+    call boundaries.
+    """
+    env = {}
+    vals = {}  # concrete values of input-INDEPENDENT vars (constant-folding)
+    if arg_vals is None:
+        arg_vals = [_UNKNOWN] * len(arg_conns)
+
+    def read(v):
+        if isinstance(v, Literal):
+            return _empty(int(np.prod(np.shape(v.val))) or 1, n_global)
+        return env[v]
+
+    def val_of(v):
+        if isinstance(v, Literal):
+            return np.asarray(v.val)
+        return vals.get(v, _UNKNOWN)
+
+    def shape_of(v):
+        return tuple(v.aval.shape)
+
+    for v, C, val in zip(jaxpr.invars, arg_conns, arg_vals):
+        env[v] = C
+        if val is not _UNKNOWN:
+            vals[v] = val
+    for cv, c in zip(jaxpr.constvars, consts):
+        env[cv] = _empty(int(np.prod(np.shape(c))) or 1, n_global)
+        vals[cv] = np.asarray(c)
+
+    for eqn in jaxpr.eqns:
+        prim = str(eqn.primitive)
+        in_Cs = [read(v) for v in eqn.invars]
+        out_shapes = [shape_of(v) for v in eqn.outvars]
+        out_sizes = [int(np.prod(s)) or 1 for s in out_shapes]
+
+        # Constant-fold input-independent vars (e.g. iota-built scatter indices,
+        # precomputed grid metrics, convolution kernels) so they can be resolved
+        # later. Pure call primitives (jit) fold too when all inputs are known.
+        if prim not in _OPAQUE:
+            in_vals = [val_of(v) for v in eqn.invars]
+            if in_vals and all(x is not _UNKNOWN for x in in_vals):
+                try:
+                    with _host_exact():
+                        outs = eqn.primitive.bind(
+                            *[jnp.asarray(x) for x in in_vals], **eqn.params
+                        )
+                    outs = outs if eqn.primitive.multiple_results else [outs]
+                    for ov, o in zip(eqn.outvars, outs):
+                        vals[ov] = np.asarray(o)
+                except Exception:
+                    pass
+
+        if prim in _OPAQUE:
+            raise _BailOut(f"opaque primitive: {prim}")
+
+        # Shortcut: if no operand carries any input dependence, outputs are empty.
+        if all(_is_empty(C) for C in in_Cs):
+            for v, sz in zip(eqn.outvars, out_sizes):
+                env[v] = _empty(sz, n_global)
+            continue
+
+        if prim in _CALL_PRIMS:
+            sub = eqn.params.get("jaxpr") or eqn.params.get("call_jaxpr")
+            if sub is None:
+                raise _BailOut(f"call primitive without jaxpr: {prim}")
+            sub_jaxpr = getattr(sub, "jaxpr", sub)
+            sub_consts = getattr(sub, "consts", [])
+            in_vals = [val_of(v) for v in eqn.invars]
+            outs = _interp(sub_jaxpr, sub_consts, n_global, in_Cs, in_vals)
+            for v, C in zip(eqn.outvars, outs):
+                env[v] = C
+            continue
+
+        if prim == "cond":
+            # invars: [index, *operands]; branches: tuple of ClosedJaxpr.
+            branch_conns = in_Cs[1:]
+            branch_vals = [val_of(v) for v in eqn.invars[1:]]
+            acc = None
+            for br in eqn.params["branches"]:
+                bj = getattr(br, "jaxpr", br)
+                bc = getattr(br, "consts", [])
+                outs = _interp(bj, bc, n_global, branch_conns, branch_vals)
+                acc = outs if acc is None else [a.maximum(o) for a, o in zip(acc, outs)]
+            for v, C in zip(eqn.outvars, acc):
+                env[v] = C
+            continue
+
+        if prim in _ELEMENTWISE:
+            out_shape = out_shapes[0]
+            out_size = out_sizes[0]
+            acc = _empty(out_size, n_global)
+            for v, C in zip(eqn.invars, in_Cs):
+                if _is_empty(C):
+                    continue
+                s = shape_of(v)
+                if tuple(s) == tuple(out_shape):
+                    contrib = C
+                else:
+                    bpos = np.broadcast_to(
+                        np.arange(int(np.prod(s)) or 1).reshape(s), out_shape
+                    ).reshape(-1)
+                    contrib = C[bpos]
+                acc = acc + contrib
+            env[eqn.outvars[0]] = acc
+            continue
+
+        if prim.startswith("reduce_") and "axes" in eqn.params:
+            (C,) = in_Cs
+            in_shape = shape_of(eqn.invars[0])
+            out_flat, out_size = _reduce_map(eqn.params, in_shape, out_shapes[0])
+            op_size = C.shape[0]
+            M = sp.csr_matrix(
+                (np.ones(op_size, dtype=np.int8), (out_flat, np.arange(op_size))),
+                shape=(out_size, op_size),
+            )
+            env[eqn.outvars[0]] = M @ C
+            continue
+
+        if prim in ("scatter-add", "scatter", "add_jaxvals"):
+            idx_val = val_of(eqn.invars[1])
+            if idx_val is _UNKNOWN:
+                raise _BailOut("scatter with data-dependent indices")
+            env[eqn.outvars[0]] = _scatter_add(
+                eqn, in_Cs, np.asarray(idx_val), n_global
+            )
+            continue
+
+        if prim == "conv_general_dilated":
+            env[eqn.outvars[0]] = _conv(eqn, in_Cs, val_of, out_sizes[0], n_global)
+            continue
+
+        if prim == "dot_general":
+            env[eqn.outvars[0]] = _dot_general(eqn, in_Cs, val_of, n_global)
+            continue
+
+        if prim == "scan":
+            outs = _scan(eqn, in_Cs, [val_of(v) for v in eqn.invars], n_global)
+            for v, C in zip(eqn.outvars, outs):
+                env[v] = C
+            continue
+
+        # Movement primitives (single output).
+        try:
+            in_shapes = [shape_of(v) for v in eqn.invars]
+            in_vals = [val_of(v) for v in eqn.invars]
+            rowmap, n_comb = _movement_rowmap(prim, eqn.params, in_shapes, in_vals)
+            combined = sp.vstack(in_Cs, format="csr") if len(in_Cs) > 1 else in_Cs[0]
+            if combined.shape[0] != n_comb:
+                raise _BailOut(f"shape mismatch in {prim}")
+            env[eqn.outvars[0]] = combined[rowmap]
+            continue
+        except _BailOut:
+            raise
+        except Exception as e:
+            raise _BailOut(f"unhandled primitive {prim}: {e}")
+
+    return [read(v) for v in jaxpr.outvars]
+
+
+def _scatter_add(eqn, in_Cs, idx_val, n_global):
+    """Connectivity of operand.at[idx].add(updates): operand OR scattered updates.
+
+    Handles the common non-overlapping case (static indices); bails otherwise.
+    """
+    operand_C, _idx_C, updates_C = in_Cs
+    operand_shape = tuple(eqn.invars[0].aval.shape)
+    updates_shape = tuple(eqn.invars[2].aval.shape)
+    dnums = eqn.params["dimension_numbers"]
+    op_size = int(np.prod(operand_shape)) or 1
+    upd_size = int(np.prod(updates_shape)) or 1
+    # Map each update element to its operand position via an overwrite-scatter of
+    # update ids; detect overlap (would lose contributions) and bail if found.
+    with _host_exact():
+        op_ids = jnp.full(operand_shape, -1, dtype=jnp.int64)
+        upd_ids = jnp.arange(upd_size, dtype=jnp.int64).reshape(updates_shape)
+        mapped = lax.scatter(
+            op_ids,
+            jnp.asarray(idx_val),
+            upd_ids,
+            dnums,
+            indices_are_sorted=eqn.params.get("indices_are_sorted", False),
+            unique_indices=eqn.params.get("unique_indices", False),
+            mode=eqn.params.get("mode"),
+        )
+    targets = np.asarray(mapped).reshape(-1)  # op position -> update id (or -1)
+    has = targets >= 0
+    if np.unique(targets[has]).size != int(has.sum()):
+        raise _BailOut("overlapping scatter-add")
+    rows = np.nonzero(has)[0]
+    M = sp.csr_matrix(
+        (np.ones(rows.size, dtype=np.int8), (rows, targets[has])),
+        shape=(op_size, upd_size),
+    )
+    return operand_C + M @ updates_C
+
+
+def _conv(eqn, in_Cs, val_of, out_size, n_global):
+    """Connectivity of a convolution with a constant kernel: each output element
+    depends on the union of input elements in its receptive field. Computed by
+    probing each nonzero kernel tap with a 1-hot kernel to get the shift map
+    (1-based positions; 0 marks padding), so it is exact for any stride/pad/
+    dilation. Bails if both operands are input-dependent or the kernel is unknown.
+    """
+    lhs_C, rhs_C = in_Cs
+    lhs_v, rhs_v = eqn.invars
+    lhs_empty, rhs_empty = _is_empty(lhs_C), _is_empty(rhs_C)
+    if lhs_empty == rhs_empty:
+        raise _BailOut("conv needs exactly one constant operand")
+    if rhs_empty:  # standard case: lhs=data, rhs=kernel
+        data_C, data_shape, data_is_lhs = lhs_C, tuple(lhs_v.aval.shape), True
+        kernel = val_of(rhs_v)
+        kernel_shape = tuple(rhs_v.aval.shape)
+    else:
+        data_C, data_shape, data_is_lhs = rhs_C, tuple(rhs_v.aval.shape), False
+        kernel = val_of(lhs_v)
+        kernel_shape = tuple(lhs_v.aval.shape)
+    if kernel is _UNKNOWN:
+        raise _BailOut("conv with non-constant kernel")
+    kernel = np.asarray(kernel)
+    data_size = int(np.prod(data_shape)) or 1
+    # 1-based float positions (exact in float64 for realistic sizes); 0 = padding.
+    pos = (np.arange(data_size, dtype=np.float64) + 1.0).reshape(data_shape)
+    taps = np.argwhere(np.abs(kernel) > 0)
+    acc = _empty(out_size, n_global)
+    with _host_exact():
+        pos_j = jnp.asarray(pos)
+        for tap in taps:
+            onehot = np.zeros(kernel_shape, dtype=np.float64)
+            onehot[tuple(tap)] = 1.0
+            oh = jnp.asarray(onehot)
+            args = (pos_j, oh) if data_is_lhs else (oh, pos_j)
+            m = np.asarray(lax.conv_general_dilated_p.bind(*args, **eqn.params))
+            m = np.rint(m.reshape(-1)).astype(np.int64)
+            valid = m > 0
+            if not valid.any():
+                continue
+            rows_out = np.nonzero(valid)[0]
+            cols_in = m[valid] - 1
+            M = sp.csr_matrix(
+                (np.ones(rows_out.size, dtype=np.int8), (rows_out, cols_in)),
+                shape=(out_size, data_size),
+            )
+            acc = acc + M @ data_C
+    return acc
+
+
+def _scan(eqn, in_Cs, in_vals, n_global):
+    """Connectivity through a scan, by unrolling: thread the carry connectivity
+    step by step and stack the per-step outputs. Bails on very long scans.
+    """
+    p = eqn.params
+    body = p["jaxpr"]
+    body_jaxpr, body_consts = getattr(body, "jaxpr", body), getattr(body, "consts", [])
+    nconsts, ncarry, length = p["num_consts"], p["num_carry"], p["length"]
+    reverse = p.get("reverse", False)
+    if length > 4096:
+        raise _BailOut("scan too long to unroll")
+
+    consts_C = list(in_Cs[:nconsts])
+    carry_C = list(in_Cs[nconsts : nconsts + ncarry])
+    xs_C = list(in_Cs[nconsts + ncarry :])
+    consts_V = list(in_vals[:nconsts])
+    xs_V = list(in_vals[nconsts + ncarry :])
+    xs_vars = eqn.invars[nconsts + ncarry :]
+    x_rest = [int(np.prod(v.aval.shape[1:])) or 1 for v in xs_vars]
+
+    nys = len(body_jaxpr.outvars) - ncarry
+    y_steps = [[None] * length for _ in range(nys)]
+    order = range(length - 1, -1, -1) if reverse else range(length)
+    for t in order:
+        x_slice_C = [
+            xs_C[i][t * x_rest[i] : (t + 1) * x_rest[i]] for i in range(len(xs_C))
+        ]
+        x_slice_V = [(_UNKNOWN if v is _UNKNOWN else np.asarray(v)[t]) for v in xs_V]
+        args_C = consts_C + carry_C + x_slice_C
+        args_V = consts_V + [_UNKNOWN] * ncarry + x_slice_V
+        outs = _interp(body_jaxpr, body_consts, n_global, args_C, args_V)
+        carry_C = list(outs[:ncarry])
+        for j in range(nys):
+            y_steps[j][t] = outs[ncarry + j]
+
+    result = list(carry_C)
+    for j in range(nys):
+        result.append(
+            sp.vstack(y_steps[j], format="csr") if length else _empty(0, n_global)
+        )
+    return result
+
+
+def _dot_general(eqn, in_Cs, val_of, n_global):
+    """Connectivity of a contraction (dot_general / matmul / einsum) with one
+    constant operand: each output element depends on the union of the data
+    operand's elements over the contracted fibre where the constant is nonzero.
+    Built directly from the constant's nonzero structure. Bails if both operands
+    are input-dependent, the constant is unknown, or the dense edge count is huge.
+    """
+    lhs_C, rhs_C = in_Cs
+    lhs_v, rhs_v = eqn.invars
+    (lc, rc), (lb, rb) = eqn.params["dimension_numbers"]
+    lc, rc, lb, rb = tuple(lc), tuple(rc), tuple(lb), tuple(rb)
+    le, re_ = _is_empty(lhs_C), _is_empty(rhs_C)
+    if le == re_:
+        raise _BailOut("dot_general needs exactly one constant operand")
+    if re_:  # lhs is data, rhs is constant
+        data_C, ds = lhs_C, tuple(lhs_v.aval.shape)
+        d_contract, d_batch = lc, lb
+        const, cs, c_contract, c_batch = val_of(rhs_v), tuple(rhs_v.aval.shape), rc, rb
+        data_is_lhs = True
+    else:
+        data_C, ds = rhs_C, tuple(rhs_v.aval.shape)
+        d_contract, d_batch = rc, rb
+        const, cs, c_contract, c_batch = val_of(lhs_v), tuple(lhs_v.aval.shape), lc, lb
+        data_is_lhs = False
+    if const is _UNKNOWN:
+        raise _BailOut("dot_general with non-constant operand")
+    const = np.asarray(const)
+
+    d_free = [d for d in range(len(ds)) if d not in d_contract and d not in d_batch]
+    c_free = [d for d in range(len(cs)) if d not in c_contract and d not in c_batch]
+    out_shape = tuple(eqn.outvars[0].aval.shape)
+    out_size = int(np.prod(out_shape)) or 1
+    data_size = int(np.prod(ds)) or 1
+    dfree_size = int(np.prod([ds[d] for d in d_free])) or 1
+
+    nz = np.argwhere(np.abs(const) > 0)  # (cnnz, len(cs))
+    cnnz = nz.shape[0]
+    if cnnz == 0:
+        return _empty(out_size, n_global)
+    if cnnz * dfree_size > 50_000_000:
+        raise _BailOut("dot_general too large (dense)")
+
+    def _cols(arr, dims):
+        return arr[:, list(dims)] if dims else np.zeros((arr.shape[0], 0), np.int64)
+
+    cb_idx, cc_idx, cf_idx = (
+        _cols(nz, c_batch),
+        _cols(nz, c_contract),
+        _cols(nz, c_free),
+    )
+    dfree_shape = [ds[d] for d in d_free]
+    dfree_grid = (
+        np.array(list(np.ndindex(*dfree_shape)), dtype=np.int64).reshape(
+            dfree_size, len(d_free)
+        )
+        if d_free
+        else np.zeros((1, 0), np.int64)
+    )
+
+    R, S = cnnz, dfree_size
+    rr = np.repeat(np.arange(R), S)
+    ss = np.tile(np.arange(S), R)
+
+    data_multi = np.zeros((R * S, len(ds)), dtype=np.int64)
+    for j, d in enumerate(d_batch):
+        data_multi[:, d] = cb_idx[rr, j]
+    for j, d in enumerate(d_contract):
+        data_multi[:, d] = cc_idx[rr, j]
+    for j, d in enumerate(d_free):
+        data_multi[:, d] = dfree_grid[ss, j]
+    data_flat = (
+        np.ravel_multi_index([data_multi[:, d] for d in range(len(ds))], ds)
+        if ds
+        else np.zeros(R * S, np.int64)
+    )
+
+    lhs_free = dfree_grid[ss] if data_is_lhs else cf_idx[rr]
+    rhs_free = cf_idx[rr] if data_is_lhs else dfree_grid[ss]
+    out_multi = np.concatenate([cb_idx[rr], lhs_free, rhs_free], axis=1)
+    out_flat = (
+        np.ravel_multi_index(
+            [out_multi[:, k] for k in range(out_multi.shape[1])], out_shape
+        )
+        if out_multi.shape[1]
+        else np.zeros(R * S, np.int64)
+    )
+
+    M = sp.csr_matrix(
+        (np.ones(out_flat.size, dtype=np.int8), (out_flat, data_flat)),
+        shape=(out_size, data_size),
+    )
+    return M @ data_C
+
+
+def trace_sparsity_pattern(operator, shape):
+    """Recover (rows, cols) of a JAX operator's sparsity, or None to fall back.
+
+    Traces the operator to a jaxpr and propagates a connectivity (index-set)
+    structure through each primitive, recovering the exact *global* sparsity
+    pattern in one trace -- the JAX-native analogue of SparseConnectivityTracer.jl
+    (Hill & Dalle, arXiv:2501.17737, 2025); see the module docstring.
+
+    Args:
+        operator: callable ``A(x)`` mapping a length-``n_global`` vector to a
+            length-``n_local`` vector (the local row block for distributed use).
+        shape: ``(n_local, n_global)``.
+
+    Returns:
+        ``(rows, cols)`` int32 arrays of the local block's nonzero pattern, or
+        ``None`` if the operator cannot be traced structurally (opaque or
+        unsupported primitive, data-dependent indexing, etc.).
+    """
+    n_local, n_global = shape
+    try:
+        closed = jax.make_jaxpr(operator)(jnp.ones(n_global))
+    except Exception:
+        return None
+    jaxpr = closed.jaxpr
+    if len(jaxpr.invars) != 1:
+        return None
+    seed = sp.identity(n_global, dtype=np.int8, format="csr")
+    try:
+        outs = _interp(jaxpr, closed.consts, n_global, [seed])
+    except _BailOut:
+        return None
+    except Exception:
+        return None
+    if len(outs) != 1:
+        return None
+    out_C = outs[0].tocoo()
+    if out_C.shape != (n_local, n_global):
+        return None
+    order = np.lexsort((out_C.col, out_C.row))
+    return out_C.row[order].astype(np.int32), out_C.col[order].astype(np.int32)
+
+
+# --- Probing-based detection: exhaustive one-hot basis-vector probing ---
+def _probe_columns(
+    A_callable: Callable, shape: tuple[int, int], tol: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Exhaustive probing with one-hot basis vectors (correct for any operator).
+
+    Probes columns in batches and extracts the non-zeros per block (the full
+    (m, n) matrix is never assembled), halving the batch on OOM. O(m) probes.
+    """
+    n, m = shape
+    vmapped_A = jax.vmap(A_callable)
+
+    def _eval_batch(start: int, size: int) -> tuple[np.ndarray, np.ndarray]:
+        indices = jnp.arange(start, start + size)
+        basis = jax.nn.one_hot(indices, m, dtype=jnp.float32)  # (size, m)
+        out = vmapped_A(basis)  # (size, n)
+        if out.shape != (size, n):
+            raise ValueError(
+                f"Operator returned shape {out.shape}, expected ({size}, {n})."
+            )
+        # out[c, i] = A(e_{start+c})[i] = A[i, start + c].
+        col_local, row = np.where(np.abs(np.array(out)) > tol)
+        return row.astype(np.int32), (start + col_local).astype(np.int32)
+
+    def _run(batch_size: int) -> tuple[np.ndarray, np.ndarray]:
+        blocks = [
+            _eval_batch(start, min(batch_size, m - start))
+            for start in range(0, m, batch_size)
+        ]
+        rows = np.concatenate([b[0] for b in blocks])
+        cols = np.concatenate([b[1] for b in blocks])
+        return rows, cols
+
+    def _is_oom(e: Exception) -> bool:
+        s = str(e).lower()
+        return "resource exhausted" in s or "out of memory" in s or "oom" in s
+
+    batch_size = m
+    result: tuple[np.ndarray, np.ndarray] | None = None
+    while result is None and batch_size >= 1:
+        try:
+            result = _run(batch_size)
+        except Exception as e:
+            if _is_oom(e):
+                batch_size //= 2
+                if batch_size >= 1:
+                    warnings.warn(
+                        f"OOM in probe_sparsity_pattern; retrying with batch_size={batch_size}.",
+                        stacklevel=2,
+                    )
+            else:
+                raise
+
+    if result is None:
+        raise RuntimeError("OOM even with batch_size=1; operator may be too large.")
+    return result
+
+
+def probe_sparsity_pattern(
+    A_callable: Callable,
+    shape: tuple[int, int],
+    tol: float = 1e-10,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Determine the sparsity pattern of a linear operator by one-hot probing.
+
+    Probes the operator with batches of one-hot basis vectors and extracts the
+    nonzeros per block (the full (m, n) matrix is never assembled), halving the
+    batch on OOM. Correct for any operator; this is the fallback used when
+    jaxpr tracing is unavailable (opaque or data-dependent operators).
+
+    Must be run outside of JIT compilation. Returns (rows, cols).
+    """
+    n, m = shape
+    if n == 0 or m == 0:
+        return np.array([], dtype=np.int32), np.array([], dtype=np.int32)
+    return _probe_columns(A_callable, shape, tol)
+
+
+# --- Column coloring and value materialization ---
+def get_column_coloring(
+    rows: np.ndarray, cols: np.ndarray, shape: tuple[int, int]
+) -> tuple[np.ndarray, int]:
+    """
+    Compute a coloring of the columns such that no two columns with the same color
+    share a non-zero row, enabling simultaneous evaluation.
+
+    Builds the column conflict graph via a sparse A^T A product (replaces the O(nnz²)
+    Python loop), then runs the Jones-Plassman parallel greedy coloring: each round
+    selects a maximal independent set (MIS) using a vectorized JAX scatter-max over
+    random weights, assigns the current color to the whole MIS, and repeats.
+
+    Returns:
+        colors: array of shape (m,) where colors[j] is the color ID of column j.
+        n_colors: total number of colors used.
+    """
+    n, m = shape
+
+    if len(rows) == 0:
+        return np.full(m, -1, dtype=np.int32), 0
+
+    # Build column conflict graph: ATA[c1, c2] > 0 iff columns c1 and c2 share a row.
+    ones = np.ones(len(rows), dtype=np.float32)
+    A_bool = sp.csr_matrix((ones, (rows, cols)), shape=(n, m))
+    ATA = (A_bool.T @ A_bool).tocsr()
+    ATA.setdiag(0)
+    ATA.eliminate_zeros()
+
+    # Flat edge list: edge k goes from src_nodes[k] to dst_nodes[k].
+    # Precomputed once; used every round for the scatter-max.
+    nnz_per_col = np.diff(ATA.indptr)
+    src_nodes = jnp.array(np.repeat(np.arange(m), nnz_per_col), dtype=jnp.int32)
+    dst_nodes = jnp.array(ATA.indices, dtype=jnp.int32)
+    has_edges = len(src_nodes) > 0
+
+    # Jones-Plassman coloring
+    # Each round: assign random weights, find MIS (nodes whose weight beats every
+    # uncolored neighbor), color MIS with the current color, mark them done.
+    colors = np.full(m, -1, dtype=np.int32)
+    in_pattern = np.zeros(m, dtype=bool)
+    in_pattern[np.unique(cols)] = True
+    uncolored = in_pattern.copy()  # numpy mask; updated each round
+
+    key = jax.random.PRNGKey(0)
+    color_id = 0
+
+    while uncolored.any():
+        key, subkey = jax.random.split(key)
+        # Weights in (0, 1] for uncolored nodes; 0 for already-colored nodes so
+        # they can never dominate an uncolored neighbor in the max comparison.
+        w = jax.random.uniform(subkey, (m,), minval=1e-7, maxval=1.0)
+        w = w * jnp.array(uncolored, dtype=jnp.float32)
+
+        # neighbor_max[c] = max weight among all neighbors of c.
+        # Scatter-max over the flat edge list: O(nnz), no Python loops.
+        if has_edges:
+            neighbor_max = jnp.full(m, -jnp.inf).at[src_nodes].max(w[dst_nodes])
+        else:
+            neighbor_max = jnp.full(m, -jnp.inf)
+
+        # MIS: uncolored nodes that beat every neighbor → valid independent set.
+        mis_np = np.array(jnp.array(uncolored) & (w > neighbor_max))
+
+        colors[mis_np] = color_id
+        uncolored[mis_np] = False
+        color_id += 1
+
+    return colors, color_id
+
+
+def materialize_sparse_matrix(
+    A_callable: Callable,
+    shape: tuple[int, int],
+    rows: ArrayLike,
+    cols: ArrayLike,
+    column_colors: ArrayLike,
+    n_colors: int,
+) -> jsp.BCSR:
+    """
+    Materialize the values of a sparse matrix inside JIT using graph coloring.
+
+    This reduces the number of operator evaluations from N (columns) to C (colors).
+
+    Args:
+        A_callable: The function A(x) -> y. Can be differentiated through.
+        shape: (n, m)
+        rows, cols: Fixed sparsity pattern indices (JAX or Numpy arrays).
+        column_colors: Array mapping column index to color ID.
+        n_colors: Number of colors.
+
+    Returns:
+        A_bcsr: jax.experimental.sparse.BCSR matrix containing the values from A_callable.
+    """
+    n, m = shape
+
+    # The sparsity pattern (rows/cols/colours) is static -- known at cache time.
+    # Compute the CSR ordering and row pointers on the host with NumPy so XLA
+    # receives them as ready constants, instead of constant-folding a large
+    # lexsort inside JIT (which dominates compile time at scale). Only the values
+    # (the operator evaluations) stay traced. Falls back to the JAX path if the
+    # indices arrive as tracers (not the normal case).
+    try:
+        rows_np = np.asarray(rows).astype(np.int32)
+        cols_np = np.asarray(cols).astype(np.int32)
+        colors_np = np.asarray(column_colors).astype(np.int32)
+        static = True
+    except Exception:
+        static = False
+
+    column_colors = jnp.array(column_colors, dtype=jnp.int32)
+
+    def evaluate_color(color_id):
+        # Create probe vector v_c such that v_c[j] = 1 if color[j] == c, else 0
+        mask = column_colors == color_id
+        v = mask.astype(jnp.float32)
+        w = A_callable(v)
+        return w
+
+    # Map over all colors: (n_colors, n)
+    # Use lax.map instead of vmap to support primitives without batching rules (e.g. CSR matvec)
+    w_matrix = jax.lax.map(evaluate_color, jnp.arange(n_colors))
+
+    if static:
+        # Host-side static CSR construction; only `values_sorted` is traced.
+        order = np.lexsort((cols_np, rows_np))
+        rows_sorted = rows_np[order]
+        cols_sorted_np = cols_np[order]
+        colors_for_cols_sorted = colors_np[cols_sorted_np]
+        indptr_np = np.zeros(int(n) + 1, dtype=np.int32)
+        indptr_np[1:] = np.cumsum(np.bincount(rows_sorted, minlength=int(n)))
+        values_sorted = w_matrix[
+            jnp.asarray(colors_for_cols_sorted), jnp.asarray(rows_sorted)
+        ]
+        return jsp.BCSR(
+            (values_sorted, jnp.asarray(cols_sorted_np), jnp.asarray(indptr_np)),
+            shape=shape,
+        )
+
+    # Fallback: indices are traced -> do the sort in JAX.
+    rows = jnp.array(rows, dtype=jnp.int32)
+    cols = jnp.array(cols, dtype=jnp.int32)
+    colors_for_cols = column_colors[cols]
+    values = w_matrix[colors_for_cols, rows]
+    sort_idx = jnp.lexsort((cols, rows))
+    cols_sorted = cols[sort_idx]
+    values_sorted = values[sort_idx]
+    indptr = jnp.zeros(int(n) + 1, dtype=jnp.int32)
+    row_counts = jnp.bincount(rows[sort_idx], length=n)
+    indptr = indptr.at[1:].set(jnp.cumsum(row_counts).astype(jnp.int32))
+    return jsp.BCSR((values_sorted, cols_sorted, indptr), shape=shape)
+
+
+# --- Verification and orchestration (cache_coloring) ---
+def _drop_zeros(A_bcsr, tol=1e-9):
+    """Return (BCSR, rows, cols) with near-zero entries removed."""
+    data = np.asarray(A_bcsr.data)
+    indices = np.asarray(A_bcsr.indices)
+    indptr = np.asarray(A_bcsr.indptr)
+    n_rows = A_bcsr.shape[0]
+    keep = np.abs(data) > tol
+    row_of = np.repeat(np.arange(n_rows, dtype=np.int32), np.diff(indptr))
+    new_indptr = np.zeros(n_rows + 1, dtype=np.int32)
+    new_indptr[1:] = np.cumsum(np.bincount(row_of[keep], minlength=n_rows))
+    A = jsp.BCSR(
+        (
+            jnp.asarray(data[keep]),
+            jnp.asarray(indices[keep], dtype=jnp.int32),
+            jnp.asarray(new_indptr),
+        ),
+        shape=A_bcsr.shape,
+    )
+    return A, row_of[keep], indices[keep].astype(np.int32)
+
+
+def _verify_recovery(operator, A_bcsr, n_global, n_check=5):
+    """Check the recovered matrix reproduces the operator on random vectors.
+
+    If A_bcsr != A (entries missing because the operator was not really
+    translation-invariant, or boundary couplings were not captured) then
+    (A_bcsr - A) v != 0 for almost every v, so a few random probes catch it.
+
+    Probes follow the configured precision -- float64 when x64 is enabled (as in
+    the distributed solvers), float32 otherwise -- with the tolerance loosened to
+    match, so it neither warns about an unavailable dtype nor false-rejects a
+    correct float32 recovery.
+    """
+    x64 = jax.config.jax_enable_x64
+    dtype = jnp.float64 if x64 else jnp.float32
+    tol = 1e-6 if x64 else 1e-4
+    key = jax.random.PRNGKey(0)
+    for _ in range(n_check):
+        key, sub = jax.random.split(key)
+        v = jax.random.normal(sub, (n_global,), dtype=dtype)
+        y_op = np.asarray(operator(v))
+        y_rec = np.asarray(A_bcsr @ v)
+        if np.linalg.norm(y_rec - y_op) > tol * (np.linalg.norm(y_op) + 1e-30):
+            return False
+    return True
+
+
+def _try_trace_coloring(operator, n_local, n_global):
+    """Exact sparsity from the operator's jaxpr (no probing), VERIFIED against the
+    operator. Works for any JAX-expressed operator; returns None for operators
+    that can't be traced structurally (opaque calls, data-dependent indexing),
+    so the caller falls back to the probing detector.
+    """
+    try:
+        pattern = trace_sparsity_pattern(operator, (n_local, n_global))
+        if pattern is None:
+            return None
+        rows, cols = pattern
+        if rows.size == 0:
+            return None
+        column_colors, n_colors = get_column_coloring(rows, cols, (n_local, n_global))
+        A = materialize_sparse_matrix(
+            operator, (n_local, n_global), rows, cols, column_colors, n_colors
+        )
+        # The pattern is exact; drop_zeros only removes structurally-present but
+        # numerically-zero entries (e.g. a vanishing variable coefficient), and
+        # verify is the safety net in case a transfer rule is wrong.
+        A, final_rows, final_cols = _drop_zeros(A)
+        if not _verify_recovery(operator, A, n_global):
+            return None
+        return (final_rows, final_cols, column_colors, n_colors, (n_local, n_global))
+    except Exception:
+        return None  # any failure -> probing fallback (correctness preserved)
+
+
+def cache_coloring(
+    operator: Any,
+    shape: tuple[int, int] | int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int, tuple[int, int]]:
+    """
+    Compute and cache coloring information for a callable operator.
+
+    Detection uses two methods, so the result is correct for ANY operator:
+
+    1. Tracing: interpret the operator's jaxpr to recover the EXACT sparsity in
+       a single trace (no probing), then colour and materialise it. Works for any
+       JAX-expressed operator; skipped for operators that can't be traced
+       structurally (opaque calls, data-dependent indexing).
+    2. Probing (``probe_sparsity_pattern`` + ``get_column_coloring``): exhaustive
+       one-hot basis-vector probing, correct for any operator -- the fallback when
+       tracing is unavailable.
+
+    Args:
+        operator: A callable operator A(x) that returns ``A @ x``.
+        shape: Shape of the operator (n, m) or int size (for an n×n matrix). For a
+            distributed operator this is the local block ``(n_local, n_global)``.
+
+    Returns:
+        Cached coloring information for reattachment with ``with_cache(..., coloring=...)``.
+    """
+    if isinstance(shape, int):
+        shape = (shape, shape)
+
+    existing_cache = getattr(operator, "_coloring_info", None)
+    if existing_cache is not None:
+        cached_shape = existing_cache[4]
+        if cached_shape == shape:
+            return existing_cache
+        raise ValueError(
+            f"Operator already has cached coloring for shape {cached_shape}, "
+            f"but requested shape {shape}. Create a new operator instance."
+        )
+
+    n_local, n_global = shape
+
+    # 1. Tracing (exact, any JAX operator). 2. Probing (any operator). Tracing
+    # verifies before being accepted; probing is exact by construction.
+    cache = _try_trace_coloring(operator, n_local, n_global)
+    if cache is None:
+        rows, cols = probe_sparsity_pattern(operator, shape)
+        column_colors, n_colors = get_column_coloring(rows, cols, shape)
+        cache = (rows, cols, column_colors, n_colors, shape)
+
+    try:
+        setattr(operator, "_coloring_info", cache)
+    except Exception:
+        pass
+
+    return cache

--- a/jaxamg/sparsity.py
+++ b/jaxamg/sparsity.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import contextlib
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Sequence
 from typing import Any
 
 import jax
@@ -37,10 +37,16 @@ import jax.numpy as jnp
 import numpy as np
 import scipy.sparse as sp
 from jax import lax
-from jax.extend.core import Literal
+from jax.extend.core import Jaxpr, JaxprEqn, Literal, Var
 from jax.typing import ArrayLike
 
 from .utils import temp_enable_x64
+
+# A connectivity matrix ``C`` has ``C[i, j] = 1`` iff output element ``i`` depends
+# on global input ``j``; propagated through the jaxpr as a scipy CSR matrix. Typed
+# as Any since scipy.sparse ships no usable stubs -- the alias documents intent at
+# call sites without mypy trying (and failing) to check CSR internals.
+Conn = Any
 
 # --- Tracing-based detection: interpret the operator's jaxpr ---
 # Element-wise primitives: output element depends on the union of its operands'
@@ -145,7 +151,7 @@ _UNKNOWN = object()  # sentinel: a value that depends on the operator input
 
 
 @contextlib.contextmanager
-def _host_exact():
+def _host_exact() -> Iterator[None]:
     """Run host-side index/position binds on CPU with x64 enabled, so position
     arithmetic stays exact regardless of the global precision config."""
     with temp_enable_x64(), jax.default_device(_CPU):
@@ -156,15 +162,15 @@ class _BailOut(Exception):
     """Raised when the operator cannot be traced structurally; caller falls back."""
 
 
-def _empty(n_rows, n_global):
+def _empty(n_rows: int, n_global: int) -> Conn:
     return sp.csr_matrix((n_rows, n_global), dtype=np.int8)
 
 
-def _is_empty(C):
+def _is_empty(C: Conn) -> bool:
     return C.nnz == 0
 
 
-def _index_operand_positions(prim, n_operands):
+def _index_operand_positions(prim: str, n_operands: int) -> set[int]:
     """Operand positions that are indices/offsets rather than data, for a movement
     primitive. Their values steer where data lands but never flow into the output,
     so they are bound as concrete values (not connectivity id blocks)."""
@@ -175,7 +181,12 @@ def _index_operand_positions(prim, n_operands):
     return set()  # pad: both operand and padding value are data
 
 
-def _movement_rowmap(prim, params, in_shapes, in_vals):
+def _movement_rowmap(
+    prim: str,
+    params: dict[str, Any],
+    in_shapes: list[tuple[int, ...]],
+    in_vals: list[Any],
+) -> tuple[np.ndarray, int]:
     """Return (rowmap, n_combined): for movement primitives, rowmap[o] is the
     source row (in the vstack of all operands) feeding output element o.
 
@@ -243,7 +254,7 @@ def _movement_rowmap(prim, params, in_shapes, in_vals):
 _PRIM_BY_NAME: dict = {}
 
 
-def _build_prim_table():
+def _build_prim_table() -> None:
     for name in ("pad", "dynamic_slice", "gather"):
         obj = getattr(lax, f"{name}_p", None)
         if obj is not None:
@@ -253,7 +264,9 @@ def _build_prim_table():
 _build_prim_table()
 
 
-def _reduce_map(params, in_shape, out_shape):
+def _reduce_map(
+    params: dict[str, Any], in_shape: tuple[int, ...], out_shape: tuple[int, ...]
+) -> tuple[np.ndarray, int]:
     """Map each operand element to its reduced output element (reduce_* ops)."""
     axes = set(params["axes"])
     keep = [d for d in range(len(in_shape)) if d not in axes]
@@ -268,29 +281,35 @@ def _reduce_map(params, in_shape, out_shape):
     return out_flat.astype(np.int64), int(np.prod(out_shape) if out_shape else 1)
 
 
-def _interp(jaxpr, consts, n_global, arg_conns, arg_vals=None):
+def _interp(
+    jaxpr: Jaxpr,
+    consts: Sequence[Any],
+    n_global: int,
+    arg_conns: list[Conn],
+    arg_vals: list[Any] | None = None,
+) -> list[Conn]:
     """Interpret one (sub-)jaxpr, returning the connectivity of each outvar.
 
     arg_vals carries known concrete values of the inputs (or _UNKNOWN), so that
     constant-folding (e.g. of convolution kernels or scatter indices) works across
     call boundaries.
     """
-    env = {}
-    vals = {}  # concrete values of input-INDEPENDENT vars (constant-folding)
+    env: dict[Var, Conn] = {}
+    vals: dict[Var, Any] = {}  # concrete values of input-INDEPENDENT vars
     if arg_vals is None:
         arg_vals = [_UNKNOWN] * len(arg_conns)
 
-    def read(v):
+    def read(v: Var | Literal) -> Conn:
         if isinstance(v, Literal):
             return _empty(int(np.prod(np.shape(v.val))) or 1, n_global)
         return env[v]
 
-    def val_of(v):
+    def val_of(v: Var | Literal) -> Any:
         if isinstance(v, Literal):
             return np.asarray(v.val)
         return vals.get(v, _UNKNOWN)
 
-    def shape_of(v):
+    def shape_of(v: Var | Literal) -> tuple[int, ...]:
         return tuple(v.aval.shape)
 
     for v, C, val in zip(jaxpr.invars, arg_conns, arg_vals):
@@ -363,10 +382,10 @@ def _interp(jaxpr, consts, n_global, arg_conns, arg_vals=None):
             out_shape = out_shapes[0]
             out_size = out_sizes[0]
             acc = _empty(out_size, n_global)
-            for v, C in zip(eqn.invars, in_Cs):
+            for iv, C in zip(eqn.invars, in_Cs):
                 if _is_empty(C):
                     continue
-                s = shape_of(v)
+                s = shape_of(iv)
                 if tuple(s) == tuple(out_shape):
                     contrib = C
                 else:
@@ -431,7 +450,9 @@ def _interp(jaxpr, consts, n_global, arg_conns, arg_vals=None):
     return [read(v) for v in jaxpr.outvars]
 
 
-def _scatter_add(eqn, in_Cs, idx_val, n_global):
+def _scatter_add(
+    eqn: JaxprEqn, in_Cs: list[Conn], idx_val: np.ndarray, n_global: int
+) -> Conn:
     """Connectivity of operand.at[idx].add(updates): operand OR scattered updates.
 
     Handles the common non-overlapping case (static indices); bails otherwise.
@@ -468,7 +489,13 @@ def _scatter_add(eqn, in_Cs, idx_val, n_global):
     return operand_C + M @ updates_C
 
 
-def _conv(eqn, in_Cs, val_of, out_size, n_global):
+def _conv(
+    eqn: JaxprEqn,
+    in_Cs: list[Conn],
+    val_of: Callable[[Var | Literal], Any],
+    out_size: int,
+    n_global: int,
+) -> Conn:
     """Connectivity of a convolution with a constant kernel: each output element
     depends on the union of input elements in its receptive field. Computed by
     probing each nonzero kernel tap with a 1-hot kernel to get the shift map
@@ -518,7 +545,9 @@ def _conv(eqn, in_Cs, val_of, out_size, n_global):
     return acc
 
 
-def _scan(eqn, in_Cs, in_vals, n_global):
+def _scan(
+    eqn: JaxprEqn, in_Cs: list[Conn], in_vals: list[Any], n_global: int
+) -> list[Conn]:
     """Connectivity through a scan, by unrolling: thread the carry connectivity
     step by step and stack the per-step outputs. Bails on very long scans.
     """
@@ -561,7 +590,12 @@ def _scan(eqn, in_Cs, in_vals, n_global):
     return result
 
 
-def _dot_general(eqn, in_Cs, val_of, n_global):
+def _dot_general(
+    eqn: JaxprEqn,
+    in_Cs: list[Conn],
+    val_of: Callable[[Var | Literal], Any],
+    n_global: int,
+) -> Conn:
     """Connectivity of a contraction (dot_general / matmul / einsum) with one
     constant operand: each output element depends on the union of the data
     operand's elements over the contracted fibre where the constant is nonzero.
@@ -603,7 +637,7 @@ def _dot_general(eqn, in_Cs, val_of, n_global):
     if cnnz * dfree_size > 50_000_000:
         raise _BailOut("dot_general too large (dense)")
 
-    def _cols(arr, dims):
+    def _cols(arr: np.ndarray, dims: tuple[int, ...]) -> np.ndarray:
         return arr[:, list(dims)] if dims else np.zeros((arr.shape[0], 0), np.int64)
 
     cb_idx, cc_idx, cf_idx = (
@@ -655,7 +689,9 @@ def _dot_general(eqn, in_Cs, val_of, n_global):
     return M @ data_C
 
 
-def trace_sparsity_pattern(operator, shape):
+def trace_sparsity_pattern(
+    operator: Callable, shape: tuple[int, int]
+) -> tuple[np.ndarray, np.ndarray] | None:
     """Recover (rows, cols) of a JAX operator's sparsity, or None to fall back.
 
     Traces the operator to a jaxpr and propagates a connectivity (index-set)
@@ -887,7 +923,7 @@ def materialize_sparse_matrix(
 
     column_colors = jnp.array(column_colors, dtype=jnp.int32)
 
-    def evaluate_color(color_id):
+    def evaluate_color(color_id: ArrayLike) -> jax.Array:
         # Create probe vector v_c such that v_c[j] = 1 if color[j] == c, else 0
         mask = column_colors == color_id
         v = mask.astype(jnp.float32)
@@ -929,7 +965,9 @@ def materialize_sparse_matrix(
 
 
 # --- Verification and orchestration (cache_coloring) ---
-def _drop_zeros(A_bcsr, tol=1e-9):
+def _drop_zeros(
+    A_bcsr: jsp.BCSR, tol: float = 1e-9
+) -> tuple[jsp.BCSR, np.ndarray, np.ndarray]:
     """Return (BCSR, rows, cols) with near-zero entries removed."""
     data = np.asarray(A_bcsr.data)
     indices = np.asarray(A_bcsr.indices)
@@ -950,7 +988,9 @@ def _drop_zeros(A_bcsr, tol=1e-9):
     return A, row_of[keep], indices[keep].astype(np.int32)
 
 
-def _verify_recovery(operator, A_bcsr, n_global, n_check=5):
+def _verify_recovery(
+    operator: Callable, A_bcsr: jsp.BCSR, n_global: int, n_check: int = 5
+) -> bool:
     """Check the recovered matrix reproduces the operator on random vectors.
 
     If A_bcsr != A (entries missing because the operator was not really
@@ -976,7 +1016,9 @@ def _verify_recovery(operator, A_bcsr, n_global, n_check=5):
     return True
 
 
-def _try_trace_coloring(operator, n_local, n_global):
+def _try_trace_coloring(
+    operator: Callable, n_local: int, n_global: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int, tuple[int, int]] | None:
     """Exact sparsity from the operator's jaxpr (no probing), VERIFIED against the
     operator. Works for any JAX-expressed operator; returns None for operators
     that can't be traced structurally (opaque calls, data-dependent indexing),

--- a/jaxamg/sparsity.py
+++ b/jaxamg/sparsity.py
@@ -329,13 +329,24 @@ def _interp(
         # Constant-fold input-independent vars (e.g. iota-built scatter indices,
         # precomputed grid metrics, convolution kernels) so they can be resolved
         # later. Pure call primitives (jit) fold too when all inputs are known.
+        # Nullary generators like ``iota`` have no inputs (``all([])`` is True), so
+        # they fold too -- this is what lets index chains built from ``jnp.arange``
+        # resolve to concrete values for the gather/scatter/dynamic_slice rules.
         if prim not in _OPAQUE:
             in_vals = [val_of(v) for v in eqn.invars]
-            if in_vals and all(x is not _UNKNOWN for x in in_vals):
+            if all(x is not _UNKNOWN for x in in_vals):
                 try:
+                    # Cast each input to the dtype the jaxpr declares for it:
+                    # primitives with a fixed signature (e.g. pjit sub-jaxprs)
+                    # require an exact dtype match, and a host int literal would
+                    # otherwise arrive as int64 and mismatch an int32 operand.
                     with _host_exact():
                         outs = eqn.primitive.bind(
-                            *[jnp.asarray(x) for x in in_vals], **eqn.params
+                            *[
+                                jnp.asarray(x, dtype=v.aval.dtype)
+                                for v, x in zip(eqn.invars, in_vals)
+                            ],
+                            **eqn.params,
                         )
                     outs = outs if eqn.primitive.multiple_results else [outs]
                     for ov, o in zip(eqn.outvars, outs):
@@ -365,8 +376,9 @@ def _interp(
             continue
 
         if prim == "cond":
-            # invars: [index, *operands]; branches: tuple of ClosedJaxpr.
-            branch_conns = in_Cs[1:]
+            # invars: [index, *operands]; branches: tuple of ClosedJaxpr. The
+            # output is a union over branches (we don't know which is taken).
+            pred_C, branch_conns = in_Cs[0], in_Cs[1:]
             branch_vals = [val_of(v) for v in eqn.invars[1:]]
             acc = None
             for br in eqn.params["branches"]:
@@ -374,7 +386,13 @@ def _interp(
                 bc = getattr(br, "consts", [])
                 outs = _interp(bj, bc, n_global, branch_conns, branch_vals)
                 acc = outs if acc is None else [a.maximum(o) for a, o in zip(acc, outs)]
+            # The branch taken depends on the predicate, so if the predicate is
+            # itself input-dependent every output element inherits that dependence.
+            pred_dep = None if _is_empty(pred_C) else pred_C.max(axis=0).tocsr()
             for v, C in zip(eqn.outvars, acc):
+                if pred_dep is not None:
+                    ones = sp.csr_matrix(np.ones((C.shape[0], 1), dtype=np.int8))
+                    C = C + ones @ pred_dep
                 env[v] = C
             continue
 
@@ -463,24 +481,33 @@ def _scatter_add(
     dnums = eqn.params["dimension_numbers"]
     op_size = int(np.prod(operand_shape)) or 1
     upd_size = int(np.prod(updates_shape)) or 1
+    scatter_kw = dict(
+        indices_are_sorted=eqn.params.get("indices_are_sorted", False),
+        unique_indices=eqn.params.get("unique_indices", False),
+        mode=eqn.params.get("mode"),
+    )
     # Map each update element to its operand position via an overwrite-scatter of
-    # update ids; detect overlap (would lose contributions) and bail if found.
+    # update ids, and separately COUNT how many updates land on each position. A
+    # position hit by >1 update is an overlap: scatter-add would accumulate those
+    # updates, but the overwrite map keeps only one, so its connectivity would be
+    # under-counted -> bail to probing. (Counting is the reliable test; the
+    # overwrite map alone cannot detect overlap, since update ids are distinct.)
     with _host_exact():
+        idx = jnp.asarray(idx_val)
         op_ids = jnp.full(operand_shape, -1, dtype=jnp.int64)
         upd_ids = jnp.arange(upd_size, dtype=jnp.int64).reshape(updates_shape)
-        mapped = lax.scatter(
-            op_ids,
-            jnp.asarray(idx_val),
-            upd_ids,
+        mapped = lax.scatter(op_ids, idx, upd_ids, dnums, **scatter_kw)
+        counts = lax.scatter_add(
+            jnp.zeros(operand_shape, dtype=jnp.int64),
+            idx,
+            jnp.ones(updates_shape, dtype=jnp.int64),
             dnums,
-            indices_are_sorted=eqn.params.get("indices_are_sorted", False),
-            unique_indices=eqn.params.get("unique_indices", False),
-            mode=eqn.params.get("mode"),
+            **scatter_kw,
         )
+    if bool((np.asarray(counts) > 1).any()):
+        raise _BailOut("overlapping scatter-add")
     targets = np.asarray(mapped).reshape(-1)  # op position -> update id (or -1)
     has = targets >= 0
-    if np.unique(targets[has]).size != int(has.sum()):
-        raise _BailOut("overlapping scatter-add")
     rows = np.nonzero(has)[0]
     M = sp.csr_matrix(
         (np.ones(rows.size, dtype=np.int8), (rows, targets[has])),
@@ -743,12 +770,23 @@ def _probe_columns(
     (m, n) matrix is never assembled), halving the batch on OOM. O(m) probes.
     """
     n, m = shape
-    vmapped_A = jax.vmap(A_callable)
+
+    # Batch the probes with vmap when the operator supports it; fall back to a
+    # sequential lax.map for operators that have no vmap rule (e.g. pure_callback
+    # / FFI), matching materialize_sparse_matrix. Decide once via a cheap
+    # eval_shape, which trips the missing-vmap-rule error without executing.
+    try:
+        jax.eval_shape(jax.vmap(A_callable), jax.ShapeDtypeStruct((1, m), jnp.float32))
+        batched_A = jax.vmap(A_callable)
+    except Exception:
+
+        def batched_A(basis):
+            return jax.lax.map(A_callable, basis)
 
     def _eval_batch(start: int, size: int) -> tuple[np.ndarray, np.ndarray]:
         indices = jnp.arange(start, start + size)
         basis = jax.nn.one_hot(indices, m, dtype=jnp.float32)  # (size, m)
-        out = vmapped_A(basis)  # (size, n)
+        out = batched_A(basis)  # (size, n)
         if out.shape != (size, n):
             raise ValueError(
                 f"Operator returned shape {out.shape}, expected ({size}, {n})."

--- a/jaxamg/utils.py
+++ b/jaxamg/utils.py
@@ -4,8 +4,6 @@ Helper functions for BCSR matrix operations.
 
 import contextlib
 import os
-import warnings
-from collections import defaultdict
 from collections.abc import Callable
 from typing import cast
 
@@ -95,204 +93,6 @@ def to_scipy(A: jsp.BCSR, format: str = "csr") -> sp.spmatrix:
         raise ValueError(
             f"Unsupported format: {format}. Supported formats: csr, csc, coo, lil, dok, bsr"
         )
-
-
-def get_sparsity_pattern(
-    A_callable: Callable,
-    shape: tuple[int, int],
-    tol: float = 1e-10,
-) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Determine the sparsity pattern of a linear operator by applying it to basis vectors.
-    Returns (rows, cols) of non-zero entries.
-
-    Uses jax.vmap to evaluate all m columns in parallel. If the full batch
-    causes an OOM error, the batch size is halved automatically and retried
-    until a working size is found.
-
-    This function must be run outside of JIT compilation.
-    """
-    n, m = shape
-    vmapped_A = jax.vmap(A_callable)
-
-    def _eval_batch(start: int, size: int) -> np.ndarray:
-        # one_hot creates (size, m) basis rows without allocating a full m×m eye
-        indices = jnp.arange(start, start + size)
-        basis = jax.nn.one_hot(indices, m, dtype=jnp.float32)  # (size, m)
-        out = vmapped_A(basis)  # (size, n)
-        if out.shape != (size, n):
-            raise ValueError(
-                f"Operator returned shape {out.shape}, expected ({size}, {n})."
-            )
-        return np.array(out)
-
-    def _run(batch_size: int) -> np.ndarray:
-        chunks = [
-            _eval_batch(start, min(batch_size, m - start))
-            for start in range(0, m, batch_size)
-        ]
-        return np.concatenate(chunks, axis=0)  # (m, n)
-
-    def _is_oom(e: Exception) -> bool:
-        s = str(e).lower()
-        return "resource exhausted" in s or "out of memory" in s or "oom" in s
-
-    batch_size = m
-    result: np.ndarray | None = None
-    while result is None and batch_size >= 1:
-        try:
-            result = _run(batch_size)
-        except Exception as e:
-            if _is_oom(e):
-                batch_size //= 2
-                if batch_size >= 1:
-                    warnings.warn(
-                        f"OOM in get_sparsity_pattern; retrying with batch_size={batch_size}.",
-                        stacklevel=2,
-                    )
-            else:
-                raise
-
-    if result is None:
-        raise RuntimeError("OOM even with batch_size=1; operator may be too large.")
-
-    # result[j, i] = A(e_j)[i] = A[i, j]  →  find non-zeros
-    mask = np.abs(result) > tol  # (m, n)
-    j_idx, i_idx = np.where(mask)  # j=col of A, i=row of A
-    if len(i_idx) == 0:
-        return np.array([], dtype=np.int32), np.array([], dtype=np.int32)
-    return i_idx.astype(np.int32), j_idx.astype(np.int32)
-
-
-def get_column_coloring(
-    rows: np.ndarray, cols: np.ndarray, shape: tuple[int, int]
-) -> tuple[np.ndarray, int]:
-    """
-    Compute a coloring of the columns such that no two columns with the same color
-    share a non-zero row, enabling simultaneous evaluation.
-
-    Builds the column conflict graph via a sparse A^T A product (replaces the O(nnz²)
-    Python loop), then runs the Jones-Plassman parallel greedy coloring: each round
-    selects a maximal independent set (MIS) using a vectorized JAX scatter-max over
-    random weights, assigns the current color to the whole MIS, and repeats.
-
-    Returns:
-        colors: array of shape (m,) where colors[j] is the color ID of column j.
-        n_colors: total number of colors used.
-    """
-    n, m = shape
-
-    if len(rows) == 0:
-        return np.full(m, -1, dtype=np.int32), 0
-
-    # Build column conflict graph: ATA[c1, c2] > 0 iff columns c1 and c2 share a row.
-    ones = np.ones(len(rows), dtype=np.float32)
-    A_bool = sp.csr_matrix((ones, (rows, cols)), shape=(n, m))
-    ATA = (A_bool.T @ A_bool).tocsr()
-    ATA.setdiag(0)
-    ATA.eliminate_zeros()
-
-    # Flat edge list: edge k goes from src_nodes[k] to dst_nodes[k].
-    # Precomputed once; used every round for the scatter-max.
-    nnz_per_col = np.diff(ATA.indptr)
-    src_nodes = jnp.array(np.repeat(np.arange(m), nnz_per_col), dtype=jnp.int32)
-    dst_nodes = jnp.array(ATA.indices, dtype=jnp.int32)
-    has_edges = len(src_nodes) > 0
-
-    # Jones-Plassman coloring
-    # Each round: assign random weights, find MIS (nodes whose weight beats every
-    # uncolored neighbor), color MIS with the current color, mark them done.
-    colors = np.full(m, -1, dtype=np.int32)
-    in_pattern = np.zeros(m, dtype=bool)
-    in_pattern[np.unique(cols)] = True
-    uncolored = in_pattern.copy()  # numpy mask; updated each round
-
-    key = jax.random.PRNGKey(0)
-    color_id = 0
-
-    while uncolored.any():
-        key, subkey = jax.random.split(key)
-        # Weights in (0, 1] for uncolored nodes; 0 for already-colored nodes so
-        # they can never dominate an uncolored neighbor in the max comparison.
-        w = jax.random.uniform(subkey, (m,), minval=1e-7, maxval=1.0)
-        w = w * jnp.array(uncolored, dtype=jnp.float32)
-
-        # neighbor_max[c] = max weight among all neighbors of c.
-        # Scatter-max over the flat edge list: O(nnz), no Python loops.
-        if has_edges:
-            neighbor_max = (
-                jnp.full(m, -jnp.inf).at[src_nodes].max(w[dst_nodes])
-            )
-        else:
-            neighbor_max = jnp.full(m, -jnp.inf)
-
-        # MIS: uncolored nodes that beat every neighbor → valid independent set.
-        mis_np = np.array(jnp.array(uncolored) & (w > neighbor_max))
-
-        colors[mis_np] = color_id
-        uncolored[mis_np] = False
-        color_id += 1
-
-    return colors, color_id
-
-
-def materialize_sparse_matrix(
-    A_callable: Callable,
-    shape: tuple[int, int],
-    rows: ArrayLike,
-    cols: ArrayLike,
-    column_colors: ArrayLike,
-    n_colors: int,
-) -> jsp.BCSR:
-    """
-    Materialize the values of a sparse matrix inside JIT using graph coloring.
-
-    This reduces the number of operator evaluations from N (columns) to C (colors).
-
-    Args:
-        A_callable: The function A(x) -> y. Can be differentiated through.
-        shape: (n, m)
-        rows, cols: Fixed sparsity pattern indices (JAX or Numpy arrays).
-        column_colors: Array mapping column index to color ID.
-        n_colors: Number of colors.
-
-    Returns:
-        A_bcsr: jax.experimental.sparse.BCSR matrix containing the values from A_callable.
-    """
-    n, m = shape
-
-    # Ensure indices are JAX arrays
-    rows = jnp.array(rows, dtype=jnp.int32)
-    cols = jnp.array(cols, dtype=jnp.int32)
-    column_colors = jnp.array(column_colors, dtype=jnp.int32)
-
-    def evaluate_color(color_id):
-        # Create probe vector v_c such that v_c[j] = 1 if color[j] == c, else 0
-        mask = column_colors == color_id
-        v = mask.astype(jnp.float32)
-        w = A_callable(v)
-        return w
-
-    # Map over all colors: (n_colors, n)
-    # Use lax.map instead of vmap to support primitives without batching rules (e.g. CSR matvec)
-    w_matrix = jax.lax.map(evaluate_color, jnp.arange(n_colors))
-
-    # Extract values: w_matrix[color[j], row] corresponds to A[row, j]
-    colors_for_cols = column_colors[cols]
-    values = w_matrix[colors_for_cols, rows]
-
-    # Reconstruct BCSR matrix with sorted indices
-    sort_idx = jnp.lexsort((cols, rows))
-    rows_sorted = rows[sort_idx]
-    cols_sorted = cols[sort_idx]
-    values_sorted = values[sort_idx]
-
-    # CHANGED
-    indptr = jnp.zeros(int(n) + 1, dtype=jnp.int32)
-    row_counts = jnp.bincount(rows_sorted, length=n)
-    indptr = indptr.at[1:].set(jnp.cumsum(row_counts).astype(jnp.int32))
-
-    return jsp.BCSR((values_sorted, cols_sorted, indptr), shape=shape)
 
 
 def get_preferred_dtype(A: MatrixOrOperator, b: ArrayLike) -> DTypeLike:
@@ -415,6 +215,8 @@ def to_bcsr_matrix(
     # 1. Handle Callables (materialize via graph coloring)
     if callable(A):
         A = cast(Callable, A)
+        from .sparsity import cache_coloring, materialize_sparse_matrix
+
         # Check for cached coloring info attached to the callable
         cached_info = getattr(A, "_coloring_info", None)
 
@@ -449,22 +251,18 @@ def to_bcsr_matrix(
                     "Call solve(A, b) once outside of JIT to compute and cache the sparsity pattern."
                 )
 
-            # Outside JIT: Compute sparsity and coloring (expensive O(N))
-            rows, cols = get_sparsity_pattern(A, shape)
-            column_colors, n_colors = get_column_coloring(rows, cols, shape)
-
-            cached_info = (rows, cols, column_colors, n_colors, shape)
-            try:
-                setattr(A, "_coloring_info", cached_info)
-            except Exception:
-                pass  # Ignore if caching fails (e.g. on partials or immutable objects)
+            # Outside JIT: detect the sparsity + colouring via cache_coloring,
+            # which traces the operator's jaxpr (exact, in one trace) and falls
+            # back to one-hot probing only when tracing is unavailable. It also
+            # attaches `_coloring_info` to A for reuse.
+            cached_info = cache_coloring(A, shape)
 
         rows, cols, column_colors, n_colors, cached_shape = cached_info
 
         if shape != cached_shape:
             raise ValueError(f"Operator shape changed from {cached_shape} to {shape}.")
 
-        # Materialize using graph coloring (works efficienty inside JIT)
+        # Materialize using graph coloring (works efficiently inside JIT)
         # Note: materialize_sparse_matrix already returns a BCSR
         A_bcsr = materialize_sparse_matrix(
             A, shape, rows, cols, column_colors, n_colors

--- a/tests/test_graph_coloring.py
+++ b/tests/test_graph_coloring.py
@@ -2,12 +2,25 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from jaxamg.matrices import tridiagonal_operator
+from jaxamg.matrices import poisson3d_operator, tridiagonal_operator
 from jaxamg.sparsity import (
     get_column_coloring,
     materialize_sparse_matrix,
     probe_sparsity_pattern,
+    trace_sparsity_pattern,
 )
+
+
+def _assert_valid_coloring(rows, cols, colors):
+    """No two columns sharing a row may share a color."""
+    rows, cols = np.asarray(rows), np.asarray(cols)
+    for r in np.unique(rows):
+        cols_in_row = cols[rows == r]
+        row_colors = colors[cols_in_row].tolist()
+        assert len(set(row_colors)) == len(cols_in_row), (
+            f"invalid coloring: row {r} columns {cols_in_row.tolist()} "
+            f"have repeated colors {row_colors}"
+        )
 
 
 class TestGraphColoring:
@@ -25,19 +38,10 @@ class TestGraphColoring:
         # Compute coloring
         colors, n_colors = get_column_coloring(rows, cols, shape)
 
-        # The coloring must be VALID: any two columns sharing a non-zero row
-        # must get different colors (so they can be probed together). Check this
-        # invariant per row -- it holds deterministically for any correct
-        # coloring, independent of how many colors the algorithm chooses (the
-        # color count itself is algorithm-dependent and not asserted here).
-        rows_arr, cols_arr = np.asarray(rows), np.asarray(cols)
-        for r in np.unique(rows_arr):
-            cols_in_row = cols_arr[rows_arr == r]
-            row_colors = colors[cols_in_row].tolist()
-            assert len(set(row_colors)) == len(cols_in_row), (
-                f"invalid coloring: row {r} columns {cols_in_row.tolist()} "
-                f"have repeated colors {row_colors}"
-            )
+        # The coloring must be VALID: any two columns sharing a non-zero row must
+        # get different colors (so they can be probed together). The color *count*
+        # is algorithm-dependent and not asserted here.
+        _assert_valid_coloring(rows, cols, colors)
 
         # Materialize (verifying JIT compatibility)
         @jax.jit
@@ -92,3 +96,39 @@ class TestGraphColoring:
         grad_analytical = 2 * theta_val * sum_sq_L
 
         np.testing.assert_allclose(grad_jax, grad_analytical)
+
+    def test_valid_coloring_on_dense_3d_stencil(self):
+        # A denser pattern (3D 7-point, ~7 nonzeros/row) exercises the
+        # Jones-Plassman coloring over many rounds; the result must stay valid.
+        n = 5**3
+        op = poisson3d_operator(robin=2.0)
+        rows, cols = trace_sparsity_pattern(op, (n, n))
+        colors, n_colors = get_column_coloring(rows, cols, (n, n))
+        _assert_valid_coloring(rows, cols, colors)
+        assert n_colors >= 7  # at least max nonzeros per row
+
+
+class TestColoringEdgeCases:
+    def test_empty_pattern(self):
+        # No nonzeros -> every column uncolored (-1), zero colors used.
+        m = 8
+        colors, n_colors = get_column_coloring(
+            np.array([], dtype=int), np.array([], dtype=int), (m, m)
+        )
+        assert n_colors == 0
+        assert colors.shape == (m,)
+        assert (colors == -1).all()
+
+
+class TestProbing:
+    def test_recovers_tridiagonal_pattern(self):
+        n = 10
+        op = tridiagonal_operator(-2.0)
+        rows, cols = probe_sparsity_pattern(op, (n, n))
+        got = set(zip(np.asarray(rows).tolist(), np.asarray(cols).tolist()))
+        expected = {(i, j) for i in range(n) for j in range(n) if abs(i - j) <= 1}
+        assert got == expected
+
+    def test_empty_shape_returns_empty(self):
+        rows, cols = probe_sparsity_pattern(lambda x: x, (0, 0))
+        assert rows.size == 0 and cols.size == 0

--- a/tests/test_graph_coloring.py
+++ b/tests/test_graph_coloring.py
@@ -3,10 +3,10 @@ import jax.numpy as jnp
 import numpy as np
 
 from jaxamg.matrices import tridiagonal_operator
-from jaxamg.utils import (
+from jaxamg.sparsity import (
     get_column_coloring,
-    get_sparsity_pattern,
     materialize_sparse_matrix,
+    probe_sparsity_pattern,
 )
 
 
@@ -18,7 +18,7 @@ class TestGraphColoring:
 
         # Get sparsity pattern of a tridiagonal operator
         operator = tridiagonal_operator(-2.0)
-        rows, cols = get_sparsity_pattern(operator, shape)
+        rows, cols = probe_sparsity_pattern(operator, shape)
 
         assert len(rows) >= 3 * n - 2  # Tridiagonal nnz
 
@@ -65,7 +65,7 @@ class TestGraphColoring:
 
         # Use Laplacian to determine the fixed sparsity pattern
         L = lambda x: operator(1.0, x)
-        rows, cols = get_sparsity_pattern(L, shape)
+        rows, cols = probe_sparsity_pattern(L, shape)
         colors, n_colors = get_column_coloring(rows, cols, shape)
 
         # Define a loss function

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -16,6 +16,7 @@ from jaxamg.mpi_utils import (
     get_partition_info,
     make_allgather_vector,
     partition_csr_matrix,
+    partition_operator,
     partition_vector,
     validate_partition,
 )
@@ -349,5 +350,57 @@ def test_make_allgather_vector(mpi_context, backend):
     g = jax.jit(jax.grad(loss))(x_local)
     expected = 2.0 * (np.asarray(x_global) - np.asarray(target))[row_start:row_end]
     np.testing.assert_allclose(np.asarray(g), expected, rtol=1e-10)
+
+    jax.config.update("jax_enable_x64", False)
+
+
+@pytest.mark.mpi(min_size=2)
+def test_partition_operator(mpi_context):
+    """partition_operator turns a global operator into this rank's row-local one,
+    and materializing it reproduces exactly this rank's rows of the global matrix
+    -- only the local (n_local, n_global) block is ever formed."""
+    comm, rank, nranks = mpi_context
+
+    jax.config.update("jax_enable_x64", True)
+
+    # n_global not divisible by nranks -> exercise uneven partitions.
+    n_global = 23
+    rng = np.random.default_rng(0)
+
+    # A concrete non-symmetric sparse global matrix and its matvec operator.
+    A = rng.standard_normal((n_global, n_global))
+    A[np.abs(A) < 1.0] = 0.0  # induce sparsity
+    A[np.diag_indices(n_global)] = 5.0  # nonzero diagonal
+    A_j = jnp.asarray(A)
+    global_op = lambda x: A_j @ x
+
+    local_op, row_start, row_end = partition_operator(global_op, n_global, rank, nranks)
+
+    # Partition bounds agree with get_partition_info.
+    rs_ref, re_ref, n_local = get_partition_info(n_global, rank, nranks)
+    assert (row_start, row_end) == (rs_ref, re_ref)
+
+    # The local operator is exactly the global operator sliced to this rank's rows.
+    x = jnp.asarray(rng.standard_normal(n_global))
+    np.testing.assert_allclose(
+        np.asarray(local_op(x)),
+        np.asarray(global_op(x))[row_start:row_end],
+        rtol=1e-12,
+    )
+
+    # Materializing the local operator reproduces this rank's rows of A.
+    from jaxamg.sparsity import (
+        get_column_coloring,
+        materialize_sparse_matrix,
+        probe_sparsity_pattern,
+    )
+
+    shape = (n_local, n_global)
+    rows, cols = probe_sparsity_pattern(local_op, shape)
+    colors, n_colors = get_column_coloring(rows, cols, shape)
+    A_local = materialize_sparse_matrix(local_op, shape, rows, cols, colors, n_colors)
+    np.testing.assert_allclose(
+        np.asarray(A_local.todense()), A[row_start:row_end, :], atol=1e-10
+    )
 
     jax.config.update("jax_enable_x64", False)

--- a/tests/test_sparsity_cache.py
+++ b/tests/test_sparsity_cache.py
@@ -1,0 +1,185 @@
+"""Tests for the detect -> colour -> materialise orchestration in sparsity.py:
+``cache_coloring`` (tracing path, probing fallback, caching, shape errors),
+``materialize_sparse_matrix`` (incl. drop-zeros of structural-but-numerical
+zeros), and ``_verify_recovery``.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaxamg.matrices import poisson3d_operator
+from jaxamg.sparsity import (
+    _verify_recovery,
+    cache_coloring,
+    materialize_sparse_matrix,
+    trace_sparsity_pattern,
+)
+
+
+def _dense(op, n):
+    return np.asarray(jax.jacfwd(op)(jnp.ones(n)))
+
+
+def _dense_by_columns(op, n):
+    """Ground-truth matrix for a linear op that can't be differentiated (e.g. a
+    pure_callback): column j is op(e_j)."""
+    return np.stack([np.asarray(op(jnp.eye(n)[j])) for j in range(n)], axis=1)
+
+
+def _materialize_dense(op, cache):
+    rows, cols, colors, n_colors, shape = cache
+    A = materialize_sparse_matrix(op, shape, rows, cols, colors, n_colors)
+    return np.asarray(A.todense())
+
+
+class TestCacheColoringTracingPath:
+    def test_takes_tracing_path(self):
+        # A traceable stencil should be detected by tracing (not probing).
+        n = 6**3
+        op = poisson3d_operator(robin=2.0)
+        assert trace_sparsity_pattern(op, (n, n)) is not None
+        cache = cache_coloring(op, (n, n))
+        assert cache[4] == (n, n)
+
+    def test_materializes_correctly(self):
+        n = 6**3
+        op = poisson3d_operator(robin=2.0)
+        cache = cache_coloring(op, (n, n))
+        np.testing.assert_allclose(
+            _materialize_dense(op, cache), _dense(op, n), atol=1e-4
+        )
+
+
+class TestCacheColoringProbingFallback:
+    def test_opaque_operator_falls_back_and_is_correct(self):
+        # An opaque-to-tracing but vmap-able linear operator: tracing returns None,
+        # so cache_coloring must fall back to one-hot probing and still be exact.
+        n = 16
+
+        def opaque(u):
+            return jax.pure_callback(
+                lambda v: np.asarray(v) * 2.0 - np.roll(np.asarray(v), 1),
+                jax.ShapeDtypeStruct((n,), u.dtype),
+                u,
+                vmap_method="sequential",
+            )
+
+        assert trace_sparsity_pattern(opaque, (n, n)) is None  # tracing bails
+        cache = cache_coloring(opaque, (n, n))  # -> probing fallback
+        np.testing.assert_allclose(
+            _materialize_dense(opaque, cache), _dense_by_columns(opaque, n), atol=1e-4
+        )
+
+    def test_non_vmappable_operator_uses_sequential_fallback(self):
+        # pure_callback with the default vmap_method has NO vmap rule, so probing
+        # must fall back to a sequential lax.map (this used to raise outright).
+        n = 16
+
+        def opaque(u):
+            return jax.pure_callback(
+                lambda v: np.asarray(v) * 2.0 - np.roll(np.asarray(v), 1),
+                jax.ShapeDtypeStruct((n,), u.dtype),
+                u,  # vmap_method=None -> not vmap-able
+            )
+
+        cache = cache_coloring(opaque, (n, n))
+        np.testing.assert_allclose(
+            _materialize_dense(opaque, cache), _dense_by_columns(opaque, n), atol=1e-4
+        )
+
+
+class TestZeroOperator:
+    def test_zero_operator_materializes_to_zero(self):
+        # An operator with no input dependence traces to an empty pattern
+        # (rows.size == 0), so cache_coloring falls through to probing; the
+        # materialized matrix must be all zeros.
+        n = 12
+        op = lambda x: jnp.zeros_like(x)
+        cache = cache_coloring(op, (n, n))
+        assert len(cache[0]) == 0  # empty pattern
+        assert np.allclose(_materialize_dense(op, cache), 0.0)
+
+
+class TestOverlappingScatterFallback:
+    def test_falls_back_to_probing_and_is_correct(self):
+        # Overlapping scatter-add (segment-sum): tracing detects the overlap and
+        # bails, so cache_coloring must fall back to probing and stay exact.
+        n = 12
+        idx = jnp.repeat(jnp.arange(n // 2), 2)  # [0, 0, 1, 1, ...]
+        op = lambda x: jnp.zeros(n).at[idx].add(x)
+        assert trace_sparsity_pattern(op, (n, n)) is None
+        cache = cache_coloring(op, (n, n))
+        np.testing.assert_allclose(
+            _materialize_dense(op, cache), _dense(op, n), atol=1e-4
+        )
+
+
+class TestCacheColoringOrchestration:
+    def test_caches_and_reuses(self):
+        op = lambda x: 2.0 * x - jnp.roll(x, 1)
+        first = cache_coloring(op, (16, 16))
+        second = cache_coloring(op, (16, 16))
+        assert first is second  # reused from the attached _coloring_info
+        assert getattr(op, "_coloring_info", None) is first
+
+    def test_shape_mismatch_raises(self):
+        op = lambda x: 2.0 * x - jnp.roll(x, 1)
+        cache_coloring(op, (16, 16))
+        with pytest.raises(ValueError):
+            cache_coloring(op, (17, 17))
+
+    def test_int_shape_expands_to_square(self):
+        cache = cache_coloring(lambda x: 3.0 * x, 16)
+        assert cache[4] == (16, 16)
+
+
+class TestDropZeros:
+    def test_structural_but_numerical_zeros_removed(self):
+        # A position-dependent coefficient that is exactly zero on half the rows:
+        # those rows are structurally present in the trace but numerically zero,
+        # so drop_zeros must prune them and the cached pattern must match the
+        # dense Jacobian's nonzeros exactly.
+        n = 16
+        c = jnp.array([1.0, 0.0] * (n // 2))
+        op = lambda x: c * (2.0 * x - jnp.roll(x, 1) - jnp.roll(x, -1))
+        rows, cols, colors, n_colors, shape = cache_coloring(op, (n, n))
+        J = _dense(op, n)
+        assert len(rows) == int((np.abs(J) > 1e-9).sum())
+        np.testing.assert_allclose(
+            _materialize_dense(op, (rows, cols, colors, n_colors, shape)), J, atol=1e-4
+        )
+
+
+class TestVerifyRecovery:
+    def test_accepts_correct_rejects_perturbed(self):
+        import jax.experimental.sparse as jsp
+
+        n = 16
+        op = lambda x: 2.0 * x - jnp.roll(x, 1)
+        rows, cols, colors, n_colors, _ = cache_coloring(op, (n, n))
+        good = materialize_sparse_matrix(op, (n, n), rows, cols, colors, n_colors)
+        assert _verify_recovery(op, good, n) is True
+        # Scaling the values breaks reconstruction -> must be rejected.
+        bad = jsp.BCSR(
+            (np.asarray(good.data) * 1.5, good.indices, good.indptr), shape=(n, n)
+        )
+        assert _verify_recovery(op, bad, n) is False
+
+
+class TestMaterializeAutodiff:
+    def test_gradient_flows_through_materialize(self):
+        # Gradient of a scalar of A(theta) w.r.t. theta, materialized via coloring.
+        n = 8
+        base = poisson3d_operator(robin=1.0)
+        op1 = lambda x: base(x) + 1.0 * x
+        rows, cols, colors, n_colors, shape = cache_coloring(op1, (n, n))
+
+        def loss(theta):
+            op = lambda x: base(x) + theta * x
+            A = materialize_sparse_matrix(op, shape, rows, cols, colors, n_colors)
+            return jnp.sum(A.data**2)
+
+        g = jax.grad(loss)(2.0)
+        assert np.isfinite(float(g)) and float(g) != 0.0

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,136 @@
+"""Tests for tracing (jaxpr-tracing) sparsity detection."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaxamg.matrices import poisson3d_operator, poisson_operator, tridiagonal_operator
+from jaxamg.sparsity import (
+    _try_trace_coloring,
+    cache_coloring,
+    materialize_sparse_matrix,
+    trace_sparsity_pattern,
+)
+
+
+def _dense_pattern(op, n, tol=1e-5):
+    J = np.asarray(jax.jacfwd(op)(jnp.ones(n)))
+    r, c = np.nonzero(np.abs(J) > tol)
+    return set(zip(r.tolist(), c.tolist()))
+
+
+def _trace_set(op, shape):
+    res = trace_sparsity_pattern(op, shape)
+    if res is None:
+        return None
+    return set(zip(res[0].tolist(), res[1].tolist()))
+
+
+class TestTracingExact:
+    def test_poisson3d_scatter_add(self):
+        # 3D 7-point stencil via .at[].add -> exercises the scatter-add rule.
+        n = 6**3
+        op = poisson3d_operator(robin=2.0)
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
+
+    @pytest.mark.parametrize("opf", [tridiagonal_operator(), poisson_operator()])
+    def test_convolution_operators(self, opf):
+        # jnp.convolve -> conv_general_dilated rule.
+        n = 16
+        assert _trace_set(opf, (n, n)) == _dense_pattern(opf, n)
+
+    def test_distributed_block(self):
+        # Local row block of a distributed operator: op(x_global)[rs:re].
+        n, rs, re = 6**3, 70, 150
+        base = poisson3d_operator(robin=2.0)
+        loc = lambda xg: base(xg)[rs:re]
+        J = np.asarray(jax.jacfwd(base)(jnp.ones(n)))[rs:re]
+        r, c = np.nonzero(np.abs(J) > 1e-5)
+        assert _trace_set(loc, (re - rs, n)) == set(zip(r.tolist(), c.tolist()))
+
+    def test_variable_coefficient(self):
+        # Position-dependent (non-translation-invariant) coefficient.
+        n = 5**3
+        base = poisson3d_operator(robin=1.0)
+        c = jax.random.uniform(jax.random.PRNGKey(0), (n,)) + 0.5
+        vop = lambda u: c * base(u)
+        assert _trace_set(vop, (n, n)) == _dense_pattern(vop, n)
+
+
+class TestTracingDenseAndStructured:
+    def test_dense_matmul(self):
+        n = 12
+        W = jax.random.normal(jax.random.PRNGKey(0), (n, n))
+        op = lambda x: W @ x
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
+
+    def test_banded_matmul(self):
+        n = 12
+        Wb = np.zeros((n, n))
+        for i in range(n):
+            for j in range(n):
+                if abs(i - j) <= 1:
+                    Wb[i, j] = 1.0 + (i + 1)
+        Wj = jnp.asarray(Wb)
+        op = lambda x: Wj @ x
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
+
+    def test_matmul_along_axis(self):
+        # einsum-style: apply a small dense matrix along one axis.
+        M = jax.random.normal(jax.random.PRNGKey(2), (4, 4))
+        op = lambda x: (M @ x.reshape(4, 3)).reshape(-1)
+        assert _trace_set(op, (12, 12)) == _dense_pattern(op, 12)
+
+    def test_scan_carry_stencil(self):
+        # out[t] = x[t] + x[t-1] via a scan carry -> bidiagonal Jacobian.
+        def op(x):
+            def body(carry, xt):
+                return xt, xt + carry
+
+            _, ys = jax.lax.scan(body, 0.0, x)
+            return ys
+
+        n = 10
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
+
+    def test_cumsum_falls_back(self):
+        # cumsum has prefix dependence; must NOT be mistaken for elementwise.
+        n = 12
+        assert trace_sparsity_pattern(lambda x: jnp.cumsum(x), (n, n)) is None
+
+
+class TestTracingFallback:
+    def test_opaque_callback_returns_none(self):
+        n = 27
+
+        def op(u):
+            return jax.pure_callback(
+                lambda x: np.asarray(x) * 2.0,
+                jax.ShapeDtypeStruct((n,), u.dtype),
+                u,
+            )
+
+        assert trace_sparsity_pattern(op, (n, n)) is None
+
+    def test_data_dependent_indexing_returns_none(self):
+        n = 27
+        op = lambda u: u[jnp.argsort(u)]
+        assert trace_sparsity_pattern(op, (n, n)) is None
+
+
+class TestCacheColoringTracing:
+    def test_cache_coloring_takes_tracing_path(self):
+        n = 6**3
+        op = poisson3d_operator(robin=2.0)
+        cache = _try_trace_coloring(op, n, n)
+        assert cache is not None  # tracing succeeds for a traceable stencil
+
+    def test_cache_coloring_materializes_correctly(self):
+        n = 6**3
+        op = poisson3d_operator(robin=2.0)
+        rows, cols, column_colors, n_colors, shape = cache_coloring(op, (n, n))
+        A = materialize_sparse_matrix(op, (n, n), rows, cols, column_colors, n_colors)
+        Adense = np.asarray(A.todense())
+        J = np.asarray(jax.jacfwd(op)(jnp.ones(n)))
+        np.testing.assert_allclose(Adense, J, atol=1e-4)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,20 +1,25 @@
-"""Tests for tracing (jaxpr-tracing) sparsity detection."""
+"""Tests for jaxpr-tracing sparsity detection (``trace_sparsity_pattern``).
+
+Covers the per-primitive connectivity rules in ``_interp`` -- elementwise (linear
+and nonlinear), every movement primitive (reshape/transpose/flip/slice/
+broadcast/concatenate/pad/dynamic_slice/gather), reduce, scatter-add,
+convolution, dot_general, scan, and call (jit) -- the conservative-superset
+behaviour of cond/where, and the structural fallbacks (opaque calls,
+data-dependent indexing, unhandled primitives).
+"""
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax import lax
 
 from jaxamg.matrices import poisson3d_operator, poisson_operator, tridiagonal_operator
-from jaxamg.sparsity import (
-    _try_trace_coloring,
-    cache_coloring,
-    materialize_sparse_matrix,
-    trace_sparsity_pattern,
-)
+from jaxamg.sparsity import trace_sparsity_pattern
 
 
 def _dense_pattern(op, n, tol=1e-5):
+    """Ground-truth nonzero pattern from the dense Jacobian."""
     J = np.asarray(jax.jacfwd(op)(jnp.ones(n)))
     r, c = np.nonzero(np.abs(J) > tol)
     return set(zip(r.tolist(), c.tolist()))
@@ -27,18 +32,96 @@ def _trace_set(op, shape):
     return set(zip(res[0].tolist(), res[1].tolist()))
 
 
+# Each operator maps a length-12 vector to a length-12 vector and exercises one
+# primitive rule (named by the parametrize id); the tracer must recover its
+# Jacobian pattern EXACTLY in a single pass.
+_N = 12
+_EXACT_OPS = {
+    "elementwise_diagonal": lambda x: 2.0 * x - 0.5 * x,  # purely diagonal
+    "elementwise_nonlinear": lambda x: jnp.sin(x) + jnp.roll(x, 1),
+    "reshape_transpose": lambda x: (x.reshape(4, 3).T).reshape(-1),
+    "flip_rev": lambda x: jnp.flip(x),
+    "concatenate": lambda x: jnp.concatenate([x[1:], x[:1]]),
+    "slice_and_pad": lambda x: jnp.pad(x[1:], (0, 1)),
+    "dynamic_slice": lambda x: jnp.pad(lax.dynamic_slice(x, (2,), (5,)), (2, 5)),
+    "gather_permutation": lambda x: x[
+        jnp.array([3, 1, 0, 2, 5, 4, 7, 6, 9, 8, 11, 10])
+    ],
+    "gather_computed_index": lambda x: x[(jnp.arange(_N) + 3) % _N],  # iota-built idx
+    "reduce_then_broadcast": lambda x: jnp.repeat(x.reshape(4, 3).sum(axis=1), 3),
+    "reduce_all_axes": lambda x: x + jnp.sum(x),  # full reduction -> scalar -> dense
+    "squeeze_expand_dims": lambda x: jnp.squeeze(jnp.expand_dims(x, 1), 1)
+    + jnp.roll(x, 1),
+    "periodic_wrap": lambda x: 2.0 * x - jnp.roll(x, 1) - jnp.roll(x, -1),
+    "jit_wrapped": lambda x: jax.jit(lambda v: 2.0 * v - jnp.roll(v, 1))(x),
+    "reverse_scan": lambda x: jax.lax.scan(
+        lambda c, xt: (xt, xt + c), 0.0, x, reverse=True
+    )[1],
+}
+
+
 class TestTracingExact:
-    def test_poisson3d_scatter_add(self):
-        # 3D 7-point stencil via .at[].add -> exercises the scatter-add rule.
+    """Operators whose pattern the tracer recovers exactly in one pass."""
+
+    @pytest.mark.parametrize("op", _EXACT_OPS.values(), ids=_EXACT_OPS.keys())
+    def test_primitive_rule(self, op):
+        assert _trace_set(op, (_N, _N)) == _dense_pattern(op, _N)
+
+    def test_scatter_add_3d_stencil(self):
+        # 3D 7-point stencil via .at[].add -> scatter-add rule, Robin BC diagonal.
         n = 6**3
         op = poisson3d_operator(robin=2.0)
         assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
 
     @pytest.mark.parametrize("opf", [tridiagonal_operator(), poisson_operator()])
-    def test_convolution_operators(self, opf):
+    def test_convolution(self, opf):
         # jnp.convolve -> conv_general_dilated rule.
         n = 16
         assert _trace_set(opf, (n, n)) == _dense_pattern(opf, n)
+
+    def test_dense_matmul(self):
+        # dot_general with a dense constant -> fully dense pattern.
+        n = 12
+        w = jax.random.normal(jax.random.PRNGKey(0), (n, n))
+        op = lambda x: w @ x
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
+
+    def test_banded_matmul(self):
+        n = 12
+        wb = np.zeros((n, n))
+        for i in range(n):
+            for j in range(n):
+                if abs(i - j) <= 1:
+                    wb[i, j] = 1.0 + (i + 1)
+        wj = jnp.asarray(wb)
+        op = lambda x: wj @ x
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
+
+    def test_matmul_along_axis(self):
+        # einsum-style: apply a small dense matrix along one axis of a reshape.
+        m = jax.random.normal(jax.random.PRNGKey(2), (4, 4))
+        op = lambda x: (m @ x.reshape(4, 3)).reshape(-1)
+        assert _trace_set(op, (12, 12)) == _dense_pattern(op, 12)
+
+    def test_dot_general_data_on_lhs(self):
+        # x @ W puts the data operand on the LHS of dot_general (the other
+        # dot_general tests put it on the RHS).
+        n = 12
+        w = jax.random.normal(jax.random.PRNGKey(3), (n, n))
+        op = lambda x: x @ w
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
+
+    def test_scan_carry_stencil(self):
+        # out[t] = x[t] + x[t-1] via a scan carry -> bidiagonal Jacobian.
+        def op(x):
+            def body(carry, xt):
+                return xt, xt + carry
+
+            _, ys = jax.lax.scan(body, 0.0, x)
+            return ys
+
+        n = 10
+        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
 
     def test_distributed_block(self):
         # Local row block of a distributed operator: op(x_global)[rs:re].
@@ -58,49 +141,43 @@ class TestTracingExact:
         assert _trace_set(vop, (n, n)) == _dense_pattern(vop, n)
 
 
-class TestTracingDenseAndStructured:
-    def test_dense_matmul(self):
+class TestTracingConservativeSuperset:
+    """Branching primitives: the tracer cannot know which branch is taken, so it
+    returns a safe SUPERSET (union of branches). cache_coloring later refines it
+    to the exact matrix via materialize + drop_zeros (see test_sparsity_cache)."""
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            lambda x: lax.cond(True, lambda v: jnp.roll(v, 1), lambda v: 2.0 * v, x),
+            lambda x: jnp.where(jnp.arange(12) % 2 == 0, x, jnp.roll(x, 1)),
+        ],
+        ids=["cond", "where_select"],
+    )
+    def test_trace_is_superset(self, op):
+        traced = _trace_set(op, (12, 12))
+        truth = _dense_pattern(op, 12)
+        assert traced is not None
+        assert traced >= truth  # conservative: never misses a true dependency
+        assert len(traced) > len(truth)  # and here strictly over-approximates
+
+    def test_data_dependent_cond_predicate_captured(self):
+        # The cond predicate depends on x[0], so the branch taken -- and hence
+        # every output element -- depends on x[0]. The tracer must fold that in
+        # (a safe superset), never under-approximate by ignoring the predicate.
         n = 12
-        W = jax.random.normal(jax.random.PRNGKey(0), (n, n))
-        op = lambda x: W @ x
-        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
-
-    def test_banded_matmul(self):
-        n = 12
-        Wb = np.zeros((n, n))
-        for i in range(n):
-            for j in range(n):
-                if abs(i - j) <= 1:
-                    Wb[i, j] = 1.0 + (i + 1)
-        Wj = jnp.asarray(Wb)
-        op = lambda x: Wj @ x
-        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
-
-    def test_matmul_along_axis(self):
-        # einsum-style: apply a small dense matrix along one axis.
-        M = jax.random.normal(jax.random.PRNGKey(2), (4, 4))
-        op = lambda x: (M @ x.reshape(4, 3)).reshape(-1)
-        assert _trace_set(op, (12, 12)) == _dense_pattern(op, 12)
-
-    def test_scan_carry_stencil(self):
-        # out[t] = x[t] + x[t-1] via a scan carry -> bidiagonal Jacobian.
-        def op(x):
-            def body(carry, xt):
-                return xt, xt + carry
-
-            _, ys = jax.lax.scan(body, 0.0, x)
-            return ys
-
-        n = 10
-        assert _trace_set(op, (n, n)) == _dense_pattern(op, n)
-
-    def test_cumsum_falls_back(self):
-        # cumsum has prefix dependence; must NOT be mistaken for elementwise.
-        n = 12
-        assert trace_sparsity_pattern(lambda x: jnp.cumsum(x), (n, n)) is None
+        op = lambda x: lax.cond(
+            x[0] > 0, lambda v: jnp.roll(v, 1), lambda v: jnp.roll(v, -1), x
+        )
+        res = trace_sparsity_pattern(op, (n, n))
+        got = set(zip(res[0].tolist(), res[1].tolist()))
+        assert all((i, 0) in got for i in range(n))  # predicate input in every row
 
 
 class TestTracingFallback:
+    """Operators the tracer cannot resolve structurally must return None so the
+    caller falls back to exhaustive probing."""
+
     def test_opaque_callback_returns_none(self):
         n = 27
 
@@ -114,23 +191,35 @@ class TestTracingFallback:
         assert trace_sparsity_pattern(op, (n, n)) is None
 
     def test_data_dependent_indexing_returns_none(self):
+        # Indices computed from the input (argsort) -> not structurally traceable.
         n = 27
         op = lambda u: u[jnp.argsort(u)]
         assert trace_sparsity_pattern(op, (n, n)) is None
 
+    def test_unhandled_primitive_returns_none(self):
+        # cumsum has prefix dependence; it must NOT be mistaken for elementwise,
+        # and there is no movement rule for it -> bail to probing.
+        n = 12
+        assert trace_sparsity_pattern(lambda x: jnp.cumsum(x), (n, n)) is None
 
-class TestCacheColoringTracing:
-    def test_cache_coloring_takes_tracing_path(self):
-        n = 6**3
-        op = poisson3d_operator(robin=2.0)
-        cache = _try_trace_coloring(op, n, n)
-        assert cache is not None  # tracing succeeds for a traceable stencil
+    def test_overlapping_scatter_add_returns_none(self):
+        # Two updates target the same operand position (segment-sum): scatter-add
+        # accumulates them, but the connectivity map cannot represent that, so the
+        # tracer must detect the overlap and bail rather than under-count.
+        n = 12
+        idx = jnp.repeat(jnp.arange(n // 2), 2)  # [0, 0, 1, 1, ...]
+        op = lambda x: jnp.zeros(n).at[idx].add(x)
+        assert trace_sparsity_pattern(op, (n, n)) is None
 
-    def test_cache_coloring_materializes_correctly(self):
-        n = 6**3
-        op = poisson3d_operator(robin=2.0)
-        rows, cols, column_colors, n_colors, shape = cache_coloring(op, (n, n))
-        A = materialize_sparse_matrix(op, (n, n), rows, cols, column_colors, n_colors)
-        Adense = np.asarray(A.todense())
-        J = np.asarray(jax.jacfwd(op)(jnp.ones(n)))
-        np.testing.assert_allclose(Adense, J, atol=1e-4)
+    def test_data_dependent_scatter_index_returns_none(self):
+        # Scatter target positions computed from the input -> not traceable.
+        n = 12
+        op = lambda x: jnp.zeros(n).at[jnp.argsort(x)].add(x)
+        assert trace_sparsity_pattern(op, (n, n)) is None
+
+    def test_dot_general_both_operands_data_returns_none(self):
+        # x @ x is a contraction of two input-dependent operands (nonlinear); the
+        # dot_general rule needs exactly one constant operand, so it must bail.
+        n = 12
+        op = lambda x: jnp.ones(n) * (x @ x)
+        assert trace_sparsity_pattern(op, (n, n)) is None


### PR DESCRIPTION
Recovers the sparsity pattern of matrix-free callable operators `A(x)` automatically and assembles them into the sparse matrix the solver needs.

Two detection methods:

- Tracing — interprets the operator's jaxpr to recover the exact pattern in a single trace (follows [SparseConnectivityTracer.jl](https://github.com/adrhill/SparseConnectivityTracer.jl))
- Probing — one-hot basis-vector fallback for operators that can't be traced.