### PR TITLE
Implement make_lineax_preconditioner for Lineax operators

### DIFF
--- a/demo/preconditioned_solver.py
+++ b/demo/preconditioned_solver.py
@@ -77,14 +77,10 @@ def main():
 
     operator = lx.FunctionLinearOperator(
         lambda x: A @ x,
-        input_structure=jax.ShapeDtypeStruct(b.shape, b.dtype),
+        b,
         tags=(lx.symmetric_tag, lx.positive_semidefinite_tag),
     )
-    preconditioner = lx.FunctionLinearOperator(
-        M,
-        input_structure=jax.ShapeDtypeStruct(b.shape, b.dtype),
-        tags=(lx.symmetric_tag, lx.positive_semidefinite_tag),
-    )
+    preconditioner = jaxamg.make_lineax_preconditioner(operator)
     run_lineax_solver(
         "Lineax CG",
         lx.CG(rtol=tol, atol=tol, max_steps=maxiter),
@@ -132,12 +128,9 @@ def main():
 
         nonsym_operator = lx.FunctionLinearOperator(
             lambda x, A_nonsym=A_nonsym: A_nonsym @ x,
-            input_structure=jax.ShapeDtypeStruct(b.shape, b.dtype),
+            b,
         )
-        nonsym_preconditioner = lx.FunctionLinearOperator(
-            M_nonsym,
-            input_structure=jax.ShapeDtypeStruct(b.shape, b.dtype),
-        )
+        nonsym_preconditioner = jaxamg.make_lineax_preconditioner(nonsym_operator)
 
         run_lineax_solver(
             "Lineax BiCGStab",

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,12 @@ This page documents the public API of JAX-AMG.
         show_source: false
         heading_level: 3
 
+::: jaxamg.make_lineax_preconditioner
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
 ## Runtime Utilities
 
 ::: jaxamg.clear_solver_cache

--- a/docs/config.md
+++ b/docs/config.md
@@ -53,6 +53,10 @@ to specify what you want to change.  For example,
 `config={"preconditioner": {"solver": "AMG"}}` inherits all the Classical AMG
 settings above.
 
+!!! note "Preconditioner default differs"
+
+    The default above is for `jaxamg.solve(...)`, a full Krylov solve (`PBICGSTAB`) preconditioned by AMG. `jaxamg.make_preconditioner(...)` (and `make_lineax_preconditioner(...)`) instead default to a *single* AMG V-cycle (`solver="AMG"`, `max_iters=1`) used as an approximate inverse, since there the outer Krylov method owns the iteration. Override via their own `config`/`kwargs`.
+
 JAX-AMG also enables residual tracking internally (`monitor_residual=1`,
 `store_res_history=1`) so `info["residual"]` is always available.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -170,7 +170,9 @@ You can also use JAX-AMG only for the preconditioner application, while a native
 
 ### Using JAX-AMG as a preconditioner for Lineax
 
-If you use [Lineax](https://docs.kidger.site/lineax/), you can also wrap the callable returned by `jaxamg.make_preconditioner(...)` as a `lineax.FunctionLinearOperator` and pass it through Lineax's `options={"preconditioner": ...}` interface.
+If you use [Lineax](https://docs.kidger.site/lineax/), `jaxamg.make_lineax_preconditioner(...)` turns a `lineax.AbstractLinearOperator` into an AMG preconditioner operator in a single call, ready to pass through Lineax's `options={"preconditioner": ...}` interface.
+
+It folds the `jaxamg.make_preconditioner(...)` plus `lineax.FunctionLinearOperator` wiring into one step, detecting and caching the operator's sparsity pattern up front and inheriting the operator's tags.
 
 === "Python"
 
@@ -188,20 +190,14 @@ If you use [Lineax](https://docs.kidger.site/lineax/), you can also wrap the cal
     A = poisson_matrix(n, skew=2.0)
     b = rhs_ones(n * n)
 
-    operator = lx.FunctionLinearOperator(
-        lambda x: A @ x,
-        input_structure=jax.ShapeDtypeStruct(b.shape, b.dtype),
-    )
-    M = lx.FunctionLinearOperator(
-        jaxamg.make_preconditioner(A),
-        input_structure=jax.ShapeDtypeStruct(b.shape, b.dtype),
-    )
+    operator = lx.FunctionLinearOperator(lambda x: A @ x, b)
+    preconditioner = jaxamg.make_lineax_preconditioner(operator)
 
     solution = lx.linear_solve(
         operator,
         b,
         solver=lx.BiCGStab(rtol=1e-6, atol=1e-6, max_steps=100),
-        options={"preconditioner": M},
+        options={"preconditioner": preconditioner},
     )
     residual = jnp.linalg.norm(b - A @ solution.value) / jnp.linalg.norm(b)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -139,6 +139,10 @@ See [Solver Configuration](config.md) for full details.
 
 You can also use JAX-AMG only for the preconditioner application, while a native JAX Krylov method owns the outer iterations.
 
+!!! note
+
+    `make_preconditioner` (and `make_lineax_preconditioner`, shown below) apply a single AMG V-cycle as an approximate inverse (not a full solve); the outer Krylov method (here `cg`) owns the iterations. See [Default config](config.md#default-config) for how this differs from `jaxamg.solve`.
+
 === "Python"
 
     ```python
@@ -170,9 +174,7 @@ You can also use JAX-AMG only for the preconditioner application, while a native
 
 ### Using JAX-AMG as a preconditioner for Lineax
 
-If you use [Lineax](https://docs.kidger.site/lineax/), `jaxamg.make_lineax_preconditioner(...)` turns a `lineax.AbstractLinearOperator` into an AMG preconditioner operator in a single call, ready to pass through Lineax's `options={"preconditioner": ...}` interface.
-
-It folds the `jaxamg.make_preconditioner(...)` plus `lineax.FunctionLinearOperator` wiring into one step, detecting and caching the operator's sparsity pattern up front and inheriting the operator's tags.
+If you use [Lineax](https://docs.kidger.site/lineax/), `jaxamg.make_lineax_preconditioner(...)` wraps a `lineax.AbstractLinearOperator` as an AMG preconditioner operator, ready to pass to `options={"preconditioner": ...}`.
 
 === "Python"
 

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -10,7 +10,7 @@ from .jaxamg import (
     get_solver_cache_info,
     solve,
 )
-from .preconditioners import make_preconditioner
+from .preconditioners import make_lineax_preconditioner, make_preconditioner
 from .sparsity import cache_coloring
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "cache_mpi_metadata",
     "AMGXStatus",
     "make_preconditioner",
+    "make_lineax_preconditioner",
     "clear_solver_cache",
     "get_solver_cache_info",
     "finalize",

--- a/jaxamg/preconditioners.py
+++ b/jaxamg/preconditioners.py
@@ -2,13 +2,18 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import jax
+import jax.numpy as jnp
 
 from .config import _AMG_DEFAULTS, _prepare_solver_config_dict
 from .jaxamg import solve
 from .utils import MatrixOrOperator, deep_merge
 
 if TYPE_CHECKING:
+    import lineax
     from mpi4py.MPI import Comm
+
+# Sentinel: by default the Lineax preconditioner inherits the operator's tags.
+_INHERIT_TAGS = object()
 
 _DEFAULT_PRECONDITIONER_SOLVER_CONFIG = {
     **deep_merge({}, _AMG_DEFAULTS),
@@ -81,3 +86,106 @@ def make_preconditioner(
         return x
 
     return apply
+
+
+def make_lineax_preconditioner(
+    operator: "lineax.AbstractLinearOperator",
+    config: dict[str, Any] | None = None,
+    *,
+    tags: Any = _INHERIT_TAGS,
+    comm: "Comm | None" = None,
+    nglobal: int | None = None,
+    partition_info: tuple[int, int] | None = None,
+    save_stats_file: str | None = None,
+    **kwargs: Any,
+) -> "lineax.FunctionLinearOperator":
+    """Wrap a Lineax operator as an AMG preconditioner operator.
+
+    This is the operator->operator counterpart of `make_preconditioner`: it maps a
+    system operator ``A`` (a `lineax.AbstractLinearOperator`) to a preconditioner
+    operator ``M`` with ``M.mv(r) ≈ A⁻¹ r``, ready to hand to a Lineax solver via
+    ``options={"preconditioner": M}``. It folds the usual ``make_preconditioner``
+    plus `FunctionLinearOperator` wiring into a single call.
+
+    The operator's matrix-free action (`operator.mv`) is handed to JAX-AMG, whose
+    sparsity detection assembles the explicit matrix AmgX needs (traced in one pass
+    when possible, probed otherwise). The pattern is detected and cached eagerly
+    here, since Lineax solvers apply the preconditioner under `jax.jit` where
+    on-the-fly detection is impossible. A `MatrixLinearOperator` is assembled
+    directly from its concrete matrix instead.
+
+    Args:
+        operator: The system operator to precondition.
+        config: Optional AmgX configuration (see `make_preconditioner`).
+        tags: Lineax tags for the returned preconditioner. By default the operator's
+            own tags are inherited (``A⁻¹`` shares ``A``'s symmetry/definiteness),
+            which CG needs in order to accept the preconditioner. Pass an explicit
+            value (e.g. ``()``) to override.
+        comm: Optional MPI communicator for distributed solves.
+        nglobal: Global matrix row count for MPI mode.
+        partition_info: Local row partition ``(row_start, row_end)`` for MPI mode.
+        save_stats_file: Optional stats output path passed to `jaxamg.solve(...)`.
+        **kwargs: Additional solver config overrides forwarded to `make_preconditioner`.
+
+    Returns:
+        A `lineax.FunctionLinearOperator` approximating ``A⁻¹``.
+    """
+    try:
+        import lineax as lx
+    except ImportError as e:  # pragma: no cover - exercised only without lineax
+        raise ImportError(
+            "make_lineax_preconditioner requires the optional `lineax` package "
+            "(`pip install lineax`)."
+        ) from e
+
+    if not isinstance(operator, lx.AbstractLinearOperator):
+        raise TypeError(
+            "make_lineax_preconditioner expects a lineax.AbstractLinearOperator; got "
+            f"{type(operator).__name__}. Wrap a matrix with lineax.MatrixLinearOperator(A), "
+            "or use jaxamg.make_preconditioner(A) for the non-Lineax path."
+        )
+
+    in_structure = operator.in_structure()
+    leaves = jax.tree_util.tree_leaves(in_structure)
+    if len(leaves) != 1 or getattr(leaves[0], "ndim", None) != 1:
+        raise ValueError(
+            "make_lineax_preconditioner supports operators acting on a single 1D "
+            f"vector; got input structure {in_structure}."
+        )
+
+    if tags is _INHERIT_TAGS:
+        tags = getattr(operator, "tags", ())
+
+    # A MatrixLinearOperator already holds the assembled matrix, so hand it over
+    # directly; otherwise wrap the matrix-free action in a plain function (the bound
+    # `operator.mv` cannot hold the coloring cache) and pre-scan it now, so the
+    # sparsity pattern is detected and cached before Lineax applies it under JIT.
+    if isinstance(operator, lx.MatrixLinearOperator):
+        amg_input: MatrixOrOperator = operator.as_matrix()
+    else:
+        mv = operator.mv
+        in_dtype = leaves[0].dtype
+
+        # Cast probes to the operator's declared input dtype: sparsity detection
+        # and JAX-AMG's materialization feed one-hot vectors through this action,
+        # and a closure-converted Lineax operator rejects a mismatched dtype.
+        def _action(x: jax.Array) -> jax.Array:
+            return mv(jnp.asarray(x, dtype=in_dtype))
+
+        if comm is None:
+            from .sparsity import cache_coloring
+
+            n = int(leaves[0].shape[0])
+            cache_coloring(_action, (n, n))
+        amg_input = _action
+
+    apply = make_preconditioner(
+        amg_input,
+        config,
+        comm=comm,
+        nglobal=nglobal,
+        partition_info=partition_info,
+        save_stats_file=save_stats_file,
+        **kwargs,
+    )
+    return lx.FunctionLinearOperator(apply, in_structure, tags=tags)

--- a/jaxamg/preconditioners.py
+++ b/jaxamg/preconditioners.py
@@ -51,9 +51,16 @@ def make_preconditioner(
     The returned callable can be passed directly as the `M` argument to
     `jax.scipy.sparse.linalg.cg(...)` or `jax.scipy.sparse.linalg.bicgstab(...)`.
 
+    By default the approximate inverse is a *single* AMG V-cycle (`solver="AMG"`,
+    `max_iters=1`), so each application is one cheap AMG sweep. This is deliberately
+    different from `jaxamg.solve`, whose default is a full Krylov solve (`PBICGSTAB`)
+    preconditioned by AMG: here AMG *is* the preconditioner and the outer Krylov
+    method owns the iteration. Pass `config`/`kwargs` for a stronger inner
+    application (e.g. more sweeps, a W-cycle, or `max_iters=2`).
+
     Args:
         A: Matrix or callable operator to precondition.
-        config: Optional AmgX configuration. If omitted, an AMG-only
+        config: Optional AmgX configuration. If omitted, a single-cycle AMG
             approximate-inverse config is used.
         comm: Optional MPI communicator for distributed solves. If `A` already
             has MPI metadata attached via `jaxamg.with_cache(..., mpi=...)`, this

--- a/tests/test_preconditioners.py
+++ b/tests/test_preconditioners.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -6,6 +7,8 @@ from jax.scipy.sparse.linalg import bicgstab
 import jaxamg
 from jaxamg import preconditioners
 from jaxamg.matrices import poisson_matrix, rhs_ones
+
+lx = pytest.importorskip("lineax")
 
 
 def test_make_preconditioner_uses_amg_defaults(monkeypatch):
@@ -127,3 +130,92 @@ def test_make_preconditioner_with_native_jax_bicgstab(skew):
     x, _ = bicgstab(A, b, M=M, tol=1e-6, maxiter=50)
 
     np.testing.assert_allclose(b, A @ x, rtol=1e-5)
+
+
+def test_make_lineax_preconditioner_returns_tagged_operator(monkeypatch):
+    """`make_lineax_preconditioner` wraps a Lineax operator into a preconditioner
+    operator: it inherits the operator's tags, exposes the same input structure,
+    and `.mv(r)` applies the AMG approximate inverse to the operator's action."""
+
+    calls = []
+
+    def fake_solve(A, b, config=None, **kwargs):
+        calls.append({"A": A, "b": b})
+        return b + 1.0, {"iterations": 1, "residual": 0.0, "status": 0}
+
+    monkeypatch.setattr(preconditioners, "solve", fake_solve)
+
+    structure = jax.ShapeDtypeStruct((3,), jnp.float32)
+    mat = jnp.array([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]])
+    operator = lx.FunctionLinearOperator(
+        lambda x: mat @ x,
+        structure,
+        tags=(lx.symmetric_tag, lx.positive_semidefinite_tag),
+    )
+
+    M = jaxamg.make_lineax_preconditioner(operator)
+
+    assert isinstance(M, lx.FunctionLinearOperator)
+    assert M.in_structure() == structure
+    # A⁻¹ shares A's symmetry/definiteness, so the tags are carried over (CG needs this).
+    assert M.tags == operator.tags
+
+    r = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+    out = M.mv(r)
+    # fake_solve hands the operator's mv straight through and returns rhs + 1.
+    assert jnp.allclose(out, r + 1.0)
+    assert callable(calls[0]["A"])  # the operator's matrix-free action was forwarded
+
+
+def test_make_lineax_preconditioner_tag_override_and_validation(monkeypatch):
+    """Explicit `tags` override the inherited ones, and non-1D / non-operator
+    inputs are rejected with clear errors."""
+
+    monkeypatch.setattr(
+        preconditioners,
+        "solve",
+        lambda A, b, config=None, **kwargs: (b, {"status": 0}),
+    )
+
+    structure = jax.ShapeDtypeStruct((4,), jnp.float32)
+    operator = lx.FunctionLinearOperator(
+        lambda x: x, structure, tags=(lx.symmetric_tag,)
+    )
+
+    M = jaxamg.make_lineax_preconditioner(operator, tags=())
+    assert M.tags == frozenset()
+
+    with pytest.raises(TypeError):
+        jaxamg.make_lineax_preconditioner(lambda x: x)  # not a Lineax operator
+
+    matrix_2d = lx.FunctionLinearOperator(
+        lambda x: x, jax.ShapeDtypeStruct((2, 2), jnp.float32)
+    )
+    with pytest.raises(ValueError):
+        jaxamg.make_lineax_preconditioner(matrix_2d)  # acts on a 2D structure
+
+
+@pytest.mark.parametrize("skew", [0.0, 2.0])
+def test_make_lineax_preconditioner_with_lineax_solver(skew):
+    """End-to-end: an AMG preconditioner built from a Lineax operator accelerates a
+    Lineax Krylov solve of a (possibly skewed) Poisson problem."""
+
+    n = 8
+    A = poisson_matrix(n, skew=skew)
+    b = rhs_ones(n * n)
+    structure = jax.ShapeDtypeStruct(b.shape, b.dtype)
+
+    symmetric = skew == 0.0
+    op_tags = (lx.symmetric_tag, lx.positive_semidefinite_tag) if symmetric else ()
+    operator = lx.FunctionLinearOperator(lambda x: A @ x, structure, tags=op_tags)
+
+    M = jaxamg.make_lineax_preconditioner(operator)
+    # CG for the SPD case; GMRES for the skewed (nonsymmetric) one.
+    solver = (
+        lx.CG(rtol=1e-6, atol=1e-6, max_steps=200)
+        if symmetric
+        else lx.GMRES(rtol=1e-6, atol=1e-6, max_steps=200)
+    )
+    sol = lx.linear_solve(operator, b, solver=solver, options={"preconditioner": M})
+
+    np.testing.assert_allclose(b, A @ sol.value, rtol=1e-5)


### PR DESCRIPTION
Add `make_lineax_preconditioner` to wrap a Lineax operator as an AMG preconditioner operator in one call (sparsity detected and cached up front, operator tags inherited), with tests, demo, and docs.