### PR TITLE
Add build-time option to compile without MPI

### DIFF
--- a/docs/environ.md
+++ b/docs/environ.md
@@ -7,7 +7,7 @@
 | `AMGX_BUILD` | Installation | Path to AmgX build dir (defaults to `$AMGX_ROOT/build`) |
 | `CUDA_HOME` | Installation | Path to CUDA toolkit (auto-detected if not set) |
 | `MPI_HOME` | Installation | Path to custom MPI installation (optional) |
-| `JAXAMG_ENABLE_MPI` | Installation | Force MPI linkage (optional, usually auto-detected) |
+| `JAXAMG_ENABLE_MPI` | Installation | Native MPI build mode (auto-detected from AmgX by default): `1` forces MPI on (build aborts if MPI is unavailable — no MPI compiler, or AmgX built without MPI), `0` forces a clean non-MPI build (no MPI toolchain needed), unset auto-enables MPI only if AmgX requires it |
 | `LD_LIBRARY_PATH` | Runtime | Need to include AmgX and CUDA library paths |
 | `JAXAMG_CACHE_SIZE` | Runtime | Native AmgX resource cache size: `0` disables resource caching (isolated mode), positive values (default is `1`) enables caching for performance improvement |
 | `OMPI_MCA_opal_cuda_support` | Runtime | Set to `true` for GPU-aware MPI (when using OpenMPI) |

--- a/jaxamg/_amgx.cc
+++ b/jaxamg/_amgx.cc
@@ -20,7 +20,9 @@
 #include <unordered_map>
 #include <functional>
 #include <utility>
+#ifdef JAXAMG_WITH_MPI
 #include <mpi.h>
+#endif
 #include "_amgx_utils.h"
 #include "_amgx_solvers.h"
 
@@ -79,6 +81,7 @@ namespace
           .Attr<int32_t>("return_stats")            // return stats flag
   );
 
+#ifdef JAXAMG_WITH_MPI
   // Register MPI handlers
   XLA_FFI_DEFINE_HANDLER(
       AmgxSolveMPI,
@@ -141,6 +144,7 @@ namespace
           .Arg<ffi::Buffer<ffi::S32>>() // comm_ptr
           .Ret<ffi::Buffer<ffi::F64>>() // recvbuf
   );
+#endif // JAXAMG_WITH_MPI
 
 } // namespace
 
@@ -150,6 +154,7 @@ PYBIND11_MODULE(_amgx, m)
         { return py::capsule(reinterpret_cast<void *>(AmgxSolve)); });
   m.def("get_amgx_solve_double_handler", []()
         { return py::capsule(reinterpret_cast<void *>(AmgxSolveDouble)); });
+#ifdef JAXAMG_WITH_MPI
   m.def("get_amgx_solve_mpi_handler", []()
         { return py::capsule(reinterpret_cast<void *>(AmgxSolveMPI)); });
   m.def("get_amgx_solve_mpi_double_handler", []()
@@ -158,6 +163,10 @@ PYBIND11_MODULE(_amgx, m)
         { return py::capsule(reinterpret_cast<void *>(AmgxAllGather)); });
   m.def("get_amgx_allgather_double_handler", []()
         { return py::capsule(reinterpret_cast<void *>(AmgxAllGatherDouble)); });
+  m.attr("mpi_enabled") = py::bool_(true);
+#else
+  m.attr("mpi_enabled") = py::bool_(false);
+#endif
 
   m.def("initialize", &EnsureAmgxInitialized);
   m.def("finalize", &AmgxFinalize);

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -10,7 +10,9 @@
 #include <cusparse.h>
 #include <amgx_c.h>
 #include <xla/ffi/api/ffi.h>
+#ifdef JAXAMG_WITH_MPI
 #include <mpi.h>
+#endif
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -359,6 +361,7 @@ namespace
     return ffi::Error::Success();
   }
 
+#ifdef JAXAMG_WITH_MPI
   /*
    * AmgxSolveMPIInternal: MPI-aware templated core implementation.
    * Uses AMGX_resources_create() with MPI communicator and
@@ -561,6 +564,7 @@ namespace
 
     return ffi::Error::Success();
   }
+#endif // JAXAMG_WITH_MPI
 
   // Float implementation (single-GPU)
   inline ffi::Error AmgxSolveImpl(cudaStream_t stream,
@@ -594,6 +598,7 @@ namespace
         stream, row_ptrs, col_indices, values, b, x, stats, config, transpose_solve, return_stats);
   }
 
+#ifdef JAXAMG_WITH_MPI
   // MPI Float implementation
   inline ffi::Error AmgxSolveMPIImpl(cudaStream_t stream,
                                      ffi::Buffer<ffi::DataType::S32> row_ptrs,
@@ -716,6 +721,7 @@ namespace
   {
     return AmgxAllGatherInternal<double, ffi::DataType::F64>(stream, sendbuf, recvcounts, displs, comm_ptr, recvbuf);
   }
+#endif // JAXAMG_WITH_MPI
 
 } // namespace
 

--- a/jaxamg/_amgx_utils.h
+++ b/jaxamg/_amgx_utils.h
@@ -8,7 +8,9 @@
 
 #include <cuda_runtime.h>
 #include <amgx_c.h>
+#ifdef JAXAMG_WITH_MPI
 #include <mpi.h>
+#endif
 #include <xla/ffi/api/ffi.h>
 #include <cstdio>
 #include <mutex>
@@ -442,6 +444,7 @@ namespace
       std::mutex mutex_;
   };
 
+#ifdef JAXAMG_WITH_MPI
   // Singleton for global MPI AmgX resource management. Shares one
   // AMGX_resources_handle across all MPI cache entries so multiple
   // matrix/solver pairs can coexist on the same communicator.
@@ -483,6 +486,7 @@ namespace
       AMGX_config_handle cfg_;
       std::mutex mutex_;
   };
+#endif // JAXAMG_WITH_MPI
 
   std::once_flag g_amgx_init_flag;
 
@@ -528,7 +532,9 @@ namespace
     GetSolverCache().clear(DestroyResources);
     GetMPISolverCache().clear(DestroyResources);
     GlobalResources::Get().Destroy();
+#ifdef JAXAMG_WITH_MPI
     GlobalMPIResources::Get().Destroy();
+#endif
   }
 
   // Check if CUDA-aware MPI should be used (respects MPI4JAX convention)

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -29,18 +29,25 @@ _AMGX_CALL_NAME_DOUBLE = "amgx_solve_double"
 _AMGX_CALL_NAME_MPI = "amgx_solve_mpi"
 _AMGX_CALL_NAME_MPI_DOUBLE = "amgx_solve_mpi_double"
 
+# Whether the native extension was compiled with MPI support (JAXAMG_WITH_MPI).
+# A non-MPI build omits the MPI FFI handlers entirely, so the single-GPU path
+# below must be the only thing registered at import time.
+HAS_MPI = bool(getattr(_amgx, "mpi_enabled", False))
+
 # Get the handler from C++ and register for CUDA platform
 _AMGX_HANDLER = _amgx.get_amgx_solve_handler()
 _AMGX_HANDLER_DOUBLE = _amgx.get_amgx_solve_double_handler()
-_AMGX_HANDLER_MPI = _amgx.get_amgx_solve_mpi_handler()
-_AMGX_HANDLER_MPI_DOUBLE = _amgx.get_amgx_solve_mpi_double_handler()
 
 ffi.register_ffi_target(_AMGX_CALL_NAME, _AMGX_HANDLER, platform="CUDA")
 ffi.register_ffi_target(_AMGX_CALL_NAME_DOUBLE, _AMGX_HANDLER_DOUBLE, platform="CUDA")
-ffi.register_ffi_target(_AMGX_CALL_NAME_MPI, _AMGX_HANDLER_MPI, platform="CUDA")
-ffi.register_ffi_target(
-    _AMGX_CALL_NAME_MPI_DOUBLE, _AMGX_HANDLER_MPI_DOUBLE, platform="CUDA"
-)
+
+if HAS_MPI:
+    _AMGX_HANDLER_MPI = _amgx.get_amgx_solve_mpi_handler()
+    _AMGX_HANDLER_MPI_DOUBLE = _amgx.get_amgx_solve_mpi_double_handler()
+    ffi.register_ffi_target(_AMGX_CALL_NAME_MPI, _AMGX_HANDLER_MPI, platform="CUDA")
+    ffi.register_ffi_target(
+        _AMGX_CALL_NAME_MPI_DOUBLE, _AMGX_HANDLER_MPI_DOUBLE, platform="CUDA"
+    )
 
 
 class AMGXStatus(IntEnum):
@@ -457,6 +464,13 @@ def solve(
     # Branch: MPI mode or single-GPU mode
     if mpi_cache is not None or comm is not None:
         # MPI MODE
+        if not HAS_MPI:
+            raise RuntimeError(
+                "jaxamg was built without MPI support, but an MPI solve was "
+                "requested (comm was passed or MPI metadata is attached to A). "
+                "Rebuild with MPI enabled (JAXAMG_ENABLE_MPI=1, with mpicxx on "
+                "PATH) to use distributed solves."
+            )
         if mpi_cache is None:
             # Validate parameters for non-cache path
             if nglobal is None:

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -20,17 +20,22 @@ if TYPE_CHECKING:
 _AMGX_CALL_NAME_ALLGATHER = "amgx_allgather"
 _AMGX_CALL_NAME_ALLGATHER_DOUBLE = "amgx_allgather_double"
 
-_AMGX_HANDLER_ALLGATHER = _amgx.get_amgx_allgather_handler()
-_AMGX_HANDLER_ALLGATHER_DOUBLE = _amgx.get_amgx_allgather_double_handler()
+# The AllGather FFI handlers only exist in an MPI-enabled build (JAXAMG_WITH_MPI).
+# Skip fetching/registering them otherwise so import works without MPI.
+_HAS_MPI = bool(getattr(_amgx, "mpi_enabled", False))
 
-ffi.register_ffi_target(
-    _AMGX_CALL_NAME_ALLGATHER, _AMGX_HANDLER_ALLGATHER, platform="CUDA"
-)
-ffi.register_ffi_target(
-    _AMGX_CALL_NAME_ALLGATHER_DOUBLE,
-    _AMGX_HANDLER_ALLGATHER_DOUBLE,
-    platform="CUDA",
-)
+if _HAS_MPI:
+    _AMGX_HANDLER_ALLGATHER = _amgx.get_amgx_allgather_handler()
+    _AMGX_HANDLER_ALLGATHER_DOUBLE = _amgx.get_amgx_allgather_double_handler()
+
+    ffi.register_ffi_target(
+        _AMGX_CALL_NAME_ALLGATHER, _AMGX_HANDLER_ALLGATHER, platform="CUDA"
+    )
+    ffi.register_ffi_target(
+        _AMGX_CALL_NAME_ALLGATHER_DOUBLE,
+        _AMGX_HANDLER_ALLGATHER_DOUBLE,
+        platform="CUDA",
+    )
 
 
 def _amgx_allgather_impl(

--- a/setup.py
+++ b/setup.py
@@ -265,28 +265,22 @@ def get_build_config() -> dict:
             libraries.extend(mpi_libs)
             print("\033[1;32m[setup.py] MPI support enabled\033[0m")
         else:
-            # MPI was requested -- explicitly via JAXAMG_ENABLE_MPI=1, or implied by
-            # an MPI-enabled AmgX -- but no MPI compiler is available. Abort cleanly
-            # here rather than defining JAXAMG_WITH_MPI and letting the build fail
-            # later with a cryptic "mpi.h: No such file or directory". To build
-            # without MPI, set JAXAMG_ENABLE_MPI=0.
-            if amgx_needs_mpi:
-                _fail(
-                    "AmgX (libamgxsh.so) was built with MPI, but no MPI C++ compiler "
-                    "(mpicxx/mpic++) was found on PATH.\n"
-                    "  Resolve this by one of:\n"
-                    "  1. Install an MPI dev toolchain (e.g. 'apt install libopenmpi-dev'), or\n"
-                    "  2. Set JAXAMG_ENABLE_MPI=0 to compile jaxamg without MPI (libmpi must\n"
-                    "     still be loadable at runtime for the MPI-enabled AmgX), or\n"
-                    "  3. Rebuild AmgX without MPI: cmake .. -DCMAKE_NO_MPI=ON"
-                )
-            else:
-                _fail(
-                    "JAXAMG_ENABLE_MPI=1 was set, but no MPI C++ compiler "
-                    "(mpicxx/mpic++) was found on PATH.\n"
-                    "  Install an MPI dev toolchain (e.g. 'apt install libopenmpi-dev'),\n"
-                    "  or set JAXAMG_ENABLE_MPI=0 to build without MPI."
-                )
+            # No MPI compiler found. We can only reach here with amgx_needs_mpi=True:
+            # the JAXAMG_ENABLE_MPI=1 + non-MPI-AmgX case already aborted above, so an
+            # enabled MPI build at this point always implies AmgX itself needs MPI.
+            # Abort cleanly rather than defining JAXAMG_WITH_MPI and failing later with
+            # a cryptic "mpi.h: No such file or directory".
+            _fail(
+                "AmgX (libamgxsh.so) was built with MPI, but no MPI C++ compiler "
+                "(mpicxx/mpic++) was found on PATH.\n"
+                "  Resolve this by one of:\n"
+                "  1. If MPI is already installed, put it on PATH or point to it\n"
+                "     directly with MPICXX=/path/to/mpicxx, or\n"
+                "  2. Install an MPI dev toolchain (e.g. 'apt install libopenmpi-dev'), or\n"
+                "  3. Set JAXAMG_ENABLE_MPI=0 to compile jaxamg without MPI (libmpi must\n"
+                "     still be loadable at runtime for the MPI-enabled AmgX), or\n"
+                "  4. Rebuild AmgX without MPI: cmake .. -DCMAKE_NO_MPI=ON"
+            )
     else:
         print(
             "\033[1;34m[setup.py] MPI support disabled (AmgX built without MPI)\033[0m"

--- a/setup.py
+++ b/setup.py
@@ -252,16 +252,27 @@ def get_build_config() -> dict:
             libraries.extend(mpi_libs)
             print("\033[1;32m[setup.py] MPI support enabled\033[0m")
         else:
+            # MPI was requested -- explicitly via JAXAMG_ENABLE_MPI=1, or implied by
+            # an MPI-enabled AmgX -- but no MPI compiler is available. Abort cleanly
+            # here rather than defining JAXAMG_WITH_MPI and letting the build fail
+            # later with a cryptic "mpi.h: No such file or directory". To build
+            # without MPI, set JAXAMG_ENABLE_MPI=0.
             if amgx_needs_mpi:
-                print(
-                    "\033[1;31m[setup.py] ERROR: AmgX requires MPI but mpicxx not found.\n"
-                    "  Please install MPI (e.g., 'apt install libopenmpi-dev') or\n"
-                    "  rebuild AmgX without MPI: cmake .. -DAMGX_NO_MPI=ON\033[0m"
+                _fail(
+                    "AmgX (libamgxsh.so) was built with MPI, but no MPI C++ compiler "
+                    "(mpicxx/mpic++) was found on PATH.\n"
+                    "  Resolve this by one of:\n"
+                    "  1. Install an MPI dev toolchain (e.g. 'apt install libopenmpi-dev'), or\n"
+                    "  2. Set JAXAMG_ENABLE_MPI=0 to compile jaxamg without MPI (libmpi must\n"
+                    "     still be loadable at runtime for the MPI-enabled AmgX), or\n"
+                    "  3. Rebuild AmgX without MPI: cmake .. -DCMAKE_NO_MPI=ON"
                 )
             else:
-                print(
-                    "\033[1;33m[setup.py] WARNING: JAXAMG_ENABLE_MPI=1 but mpicxx not found. "
-                    "Building without MPI linkage.\033[0m"
+                _fail(
+                    "JAXAMG_ENABLE_MPI=1 was set, but no MPI C++ compiler "
+                    "(mpicxx/mpic++) was found on PATH.\n"
+                    "  Install an MPI dev toolchain (e.g. 'apt install libopenmpi-dev'),\n"
+                    "  or set JAXAMG_ENABLE_MPI=0 to build without MPI."
                 )
     else:
         print(

--- a/setup.py
+++ b/setup.py
@@ -240,6 +240,19 @@ def get_build_config() -> dict:
         print(
             "\033[1;33m[setup.py] Auto-detected: AmgX was built with MPI support\033[0m"
         )
+    elif env_enable_mpi and not amgx_needs_mpi:
+        # MPI was explicitly forced on, but AmgX itself has no MPI. Building MPI
+        # jaxamg against a non-MPI AmgX yields an extension that reports
+        # mpi_enabled=True yet cannot run distributed solves (a non-MPI AmgX
+        # ignores the communicator and solves each rank's partition in isolation
+        # -> silently wrong results). Abort rather than ship that.
+        _fail(
+            "JAXAMG_ENABLE_MPI=1 forces MPI on, but AmgX (libamgxsh.so) has no MPI "
+            "symbols.\n"
+            "  Distributed solves require an MPI-enabled AmgX. Either:\n"
+            "  1. Rebuild AmgX with MPI, or\n"
+            "  2. Set JAXAMG_ENABLE_MPI=0 (or leave it unset) for a single-GPU build."
+        )
 
     if enable_mpi:
         mpicxx_bin = find_mpicxx()

--- a/setup.py
+++ b/setup.py
@@ -211,16 +211,32 @@ def get_build_config() -> dict:
             return False
 
     amgx_needs_mpi = amgx_requires_mpi()
-    env_enable_mpi = os.environ.get("JAXAMG_ENABLE_MPI", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
+    mpi_pref = os.environ.get("JAXAMG_ENABLE_MPI", "").strip().lower()
+    env_enable_mpi = mpi_pref in ("1", "true", "yes", "on")
+    env_disable_mpi = mpi_pref in ("0", "false", "no", "off")
 
-    # Auto-enable MPI if AmgX requires it
-    enable_mpi = env_enable_mpi or amgx_needs_mpi
+    # Resolve the MPI build mode:
+    #   JAXAMG_ENABLE_MPI=0/false/no/off -> force a clean non-MPI build, even if
+    #     AmgX itself was built with MPI (no mpi.h, no libmpi linkage, MPI entry
+    #     points raise at runtime).
+    #   JAXAMG_ENABLE_MPI=1/true/yes/on  -> force MPI on.
+    #   unset                            -> auto: on iff AmgX requires MPI.
+    if env_disable_mpi:
+        enable_mpi = False
+    else:
+        enable_mpi = env_enable_mpi or amgx_needs_mpi
 
-    if amgx_needs_mpi and not env_enable_mpi:
+    if env_disable_mpi:
+        print(
+            "\033[1;34m[setup.py] MPI explicitly disabled (JAXAMG_ENABLE_MPI=0)\033[0m"
+        )
+        if amgx_needs_mpi:
+            print(
+                "\033[1;33m[setup.py] Note: linked AmgX (libamgxsh.so) has undefined "
+                "MPI symbols, so libmpi must still be loadable at runtime even though "
+                "jaxamg's own MPI paths are compiled out.\033[0m"
+            )
+    elif amgx_needs_mpi and not env_enable_mpi:
         print(
             "\033[1;33m[setup.py] Auto-detected: AmgX was built with MPI support\033[0m"
         )
@@ -254,15 +270,22 @@ def get_build_config() -> dict:
 
     runtime_library_dirs = list(library_dirs)
 
+    # Compile the MPI code paths only when MPI is enabled. Without this macro the
+    # extension never includes <mpi.h> or references MPI symbols, so it builds and
+    # links cleanly on machines without an MPI development toolchain.
+    define_macros = [("JAXAMG_WITH_MPI", "1")] if enable_mpi else []
+
     print(f"\033[1;34m[setup.py] include_dirs: {include_dirs}\033[0m")
     print(f"\033[1;34m[setup.py] library_dirs: {library_dirs}\033[0m")
     print(f"\033[1;34m[setup.py] libraries: {libraries}\033[0m")
+    print(f"\033[1;34m[setup.py] define_macros: {define_macros}\033[0m")
 
     return {
         "include_dirs": include_dirs,
         "library_dirs": library_dirs,
         "runtime_library_dirs": runtime_library_dirs,
         "libraries": libraries,
+        "define_macros": define_macros,
     }
 
 
@@ -286,6 +309,7 @@ class BuildExt(build_ext):
                 ext.runtime_library_dirs or []
             )
             ext.libraries = cfg["libraries"] + list(ext.libraries)
+            ext.define_macros = list(ext.define_macros or []) + cfg["define_macros"]
         super().build_extensions()
 
 


### PR DESCRIPTION
The native extension previously included <mpi.h> and referenced MPI symbols (e.g. ompi_mpi_double) unconditionally, so it failed to build or import on machines without an MPI toolchain even for single-GPU use.

Guard all MPI code behind a JAXAMG_WITH_MPI macro:
- _amgx.cc / _amgx_utils.h / _amgx_solvers.h: guard <mpi.h>, the MPI/AllGather FFI handlers, AmgxSolveMPIInternal, and GlobalMPIResources. Expose `mpi_enabled` on the module so Python can detect the build mode.
- setup.py: define JAXAMG_WITH_MPI only when MPI is enabled, and honor JAXAMG_ENABLE_MPI=0/false/no/off to force a clean non-MPI build (no <mpi.h>, no libmpi linkage).
- jaxamg.py / mpi_utils.py: register MPI FFI targets only when the build has MPI; raise a clear error if an MPI solve is requested otherwise.

Single-GPU solve, AMG preconditioning, jax.grad and jax.jit all work in a non-MPI build with no libmpi on the library path; the MPI build is unchanged.