### PR TITLE
Improve distributed solve robustness and caching

### DIFF
--- a/demo/jax_sparse_solver_comparison.py
+++ b/demo/jax_sparse_solver_comparison.py
@@ -40,6 +40,7 @@ def main():
             "convergence": "RELATIVE_MAX",
         },
     )
+    x.block_until_ready()
     solve_time = time.time() - t_start
     residual = jnp.linalg.norm(b - A @ x) / jnp.linalg.norm(b)
     print(
@@ -58,6 +59,7 @@ def main():
             "convergence": "RELATIVE_MAX",
         },
     )
+    x.block_until_ready()
     solve_time = time.time() - t_start
     residual = jnp.linalg.norm(b - A @ x) / jnp.linalg.norm(b)
     print(
@@ -67,6 +69,7 @@ def main():
     # Solve with JAX (CG)
     t_start = time.time()
     x, _ = cg(A, b, tol=tolerance, maxiter=max_iters)
+    x.block_until_ready()
     solve_time = time.time() - t_start
     residual = jnp.linalg.norm(b - A @ x) / jnp.linalg.norm(b)
     print(
@@ -76,6 +79,7 @@ def main():
     # Solve with JAX (BiCGSTAB)
     t_start = time.time()
     x, _ = bicgstab(A, b, tol=tolerance, maxiter=max_iters)
+    x.block_until_ready()
     solve_time = time.time() - t_start
     residual = jnp.linalg.norm(b - A @ x) / jnp.linalg.norm(b)
     print(
@@ -101,11 +105,12 @@ def main():
     grad_fn = jax.jit(jax.grad(loss_fn))
 
     t_start = time.time()
-    grad_fn(b)
+    grad_fn(b).block_until_ready()
     warmup_time = time.time() - t_start
 
     t_start = time.time()
     grad = grad_fn(b)
+    grad.block_until_ready()
     compute_time = time.time() - t_start
     print(
         f"JAX-AMG (CG):        warmup time: {warmup_time:6.2f}s, compute time: {compute_time:.2f}s, grad norm: {jnp.linalg.norm(grad):.2e}"
@@ -128,11 +133,12 @@ def main():
     grad_fn = jax.jit(jax.grad(loss_fn))
 
     t_start = time.time()
-    grad_fn(b)
+    grad_fn(b).block_until_ready()
     warmup_time = time.time() - t_start
 
     t_start = time.time()
     grad = grad_fn(b)
+    grad.block_until_ready()
     compute_time = time.time() - t_start
     print(
         f"JAX-AMG (BiCGSTAB):  warmup time: {warmup_time:6.2f}s, compute time: {compute_time:.2f}s, grad norm: {jnp.linalg.norm(grad):.2e}"
@@ -146,11 +152,12 @@ def main():
     grad_fn = jax.jit(jax.grad(loss_fn))
 
     t_start = time.time()
-    grad_fn(b)
+    grad_fn(b).block_until_ready()
     warmup_time = time.time() - t_start
 
     t_start = time.time()
     grad = grad_fn(b)
+    grad.block_until_ready()
     compute_time = time.time() - t_start
     print(
         f"JAX     (CG):        warmup time: {warmup_time:6.2f}s, compute time: {compute_time:.2f}s, grad norm: {jnp.linalg.norm(grad):.2e}"
@@ -164,11 +171,12 @@ def main():
     grad_fn = jax.jit(jax.grad(loss_fn))
 
     t_start = time.time()
-    grad_fn(b)
+    grad_fn(b).block_until_ready()
     warmup_time = time.time() - t_start
 
     t_start = time.time()
     grad = grad_fn(b)
+    grad.block_until_ready()
     compute_time = time.time() - t_start
     print(
         f"JAX     (BiCGSTAB):  warmup time: {warmup_time:6.2f}s, compute time: {compute_time:.2f}s, grad norm: {jnp.linalg.norm(grad):.2e}"
@@ -200,6 +208,7 @@ def main():
     for _ in range(n_epochs):
         g = grad_fn(b_opt)
         b_opt = b_opt - lr * g
+    b_opt.block_until_ready()
     opt_time = time.time() - t_start
     print(f"JAX-AMG (CG):        opt time: {opt_time:.2f}s ({n_epochs} epochs)")
 
@@ -224,6 +233,7 @@ def main():
     for _ in range(n_epochs):
         g = grad_fn(b_opt)
         b_opt = b_opt - lr * g
+    b_opt.block_until_ready()
     opt_time = time.time() - t_start
     print(f"JAX-AMG (BiCGSTAB):  opt time: {opt_time:.2f}s ({n_epochs} epochs)")
 
@@ -239,6 +249,7 @@ def main():
     for _ in range(n_epochs):
         g = grad_fn(b_opt)
         b_opt = b_opt - lr * g
+    b_opt.block_until_ready()
     opt_time = time.time() - t_start
     print(f"JAX     (CG):        opt time: {opt_time:.2f}s ({n_epochs} epochs)")
 
@@ -254,6 +265,7 @@ def main():
     for _ in range(n_epochs):
         g = grad_fn(b_opt)
         b_opt = b_opt - lr * g
+    b_opt.block_until_ready()
     opt_time = time.time() - t_start
     print(f"JAX     (BiCGSTAB):  opt time: {opt_time:.2f}s ({n_epochs} epochs)")
 

--- a/demo/mpi_autodiff.py
+++ b/demo/mpi_autodiff.py
@@ -65,7 +65,7 @@ def main():
 
     # Pre-cache MPI metadata
     mpi_cache = jaxamg.cache_mpi_metadata(
-        config, comm, n_global, (row_start, row_end), A_local
+        config, comm, n_global, (row_start, row_end), A_local, is_symmetric=True
     )
 
     # Attach MPI cache to matrix

--- a/demo/mpi_preconditioned_solver.py
+++ b/demo/mpi_preconditioned_solver.py
@@ -45,6 +45,10 @@ def mpi_bicgstab(
     maxiter,
 ):
     def matvec_local(x_local):
+        # Illustrative: all-gather the full global vector, then apply the local
+        # rows. Only the columns A_local references (this rank's halo) are
+        # actually needed; for large or many-rank runs, exchange just those with
+        # a halo exchange (build_halo_plan + _mpi4jax_halo_gather) instead.
         x_global = _mpi4jax_allgatherv(x_local, recvcounts_tuple, comm)
         return A_local @ x_global
 

--- a/demo/mpi_solver_cache_benchmark.py
+++ b/demo/mpi_solver_cache_benchmark.py
@@ -97,7 +97,12 @@ def run_benchmark(n_global, n_runs=5):
     # without calling clear_solver_cache() in MPI mode.
     baseline_mpi_caches = [
         jaxamg.cache_mpi_metadata(
-            copy.deepcopy(solver_config), comm, n_global, partition_info, A_local
+            copy.deepcopy(solver_config),
+            comm,
+            n_global,
+            partition_info,
+            A_local,
+            is_symmetric=True,
         )
         for _ in range(n_runs + 1)
     ]
@@ -141,7 +146,7 @@ def run_benchmark(n_global, n_runs=5):
 
     # Single MPI metadata cache reused across iterations for resource cache hits.
     cached_mpi_cache = jaxamg.cache_mpi_metadata(
-        solver_config, comm, n_global, partition_info, A_local
+        solver_config, comm, n_global, partition_info, A_local, is_symmetric=True
     )
 
     if rank == 0:

--- a/demo/mpi_tridiagonal_matrix_optimization.py
+++ b/demo/mpi_tridiagonal_matrix_optimization.py
@@ -82,7 +82,7 @@ def main():
     )
 
     mpi_cache = jaxamg.cache_mpi_metadata(
-        config, comm, n_global, (row_start, row_end), dummy_A
+        config, comm, n_global, (row_start, row_end), dummy_A, is_symmetric=True
     )
 
     # Define loss function

--- a/jaxamg/_amgx.cc
+++ b/jaxamg/_amgx.cc
@@ -63,6 +63,7 @@ namespace
           .Attr<std::string_view>("config")         // config string
           .Attr<int32_t>("transpose_solve")         // transpose flag
           .Attr<int32_t>("return_stats")            // return stats flag
+          .Attr<int32_t>("reuse_setup")             // skip warm resetup
   );
 
   XLA_FFI_DEFINE_HANDLER(
@@ -79,6 +80,7 @@ namespace
           .Attr<std::string_view>("config")         // config string
           .Attr<int32_t>("transpose_solve")         // transpose flag
           .Attr<int32_t>("return_stats")            // return stats flag
+          .Attr<int32_t>("reuse_setup")             // skip warm resetup
   );
 
 #ifdef JAXAMG_WITH_MPI
@@ -100,6 +102,7 @@ namespace
           .Attr<std::string_view>("config")         // config string
           .Attr<int32_t>("transpose_solve")         // transpose flag
           .Attr<int32_t>("return_stats")            // return stats flag
+          .Attr<int32_t>("reuse_setup")             // skip warm resetup
   );
 
   XLA_FFI_DEFINE_HANDLER(
@@ -119,6 +122,7 @@ namespace
           .Attr<std::string_view>("config")         // config string
           .Attr<int32_t>("transpose_solve")         // transpose flag
           .Attr<int32_t>("return_stats")            // return stats flag
+          .Attr<int32_t>("reuse_setup")             // skip warm resetup
   );
 
   XLA_FFI_DEFINE_HANDLER(

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -158,29 +158,16 @@ namespace
     const int n_rows = static_cast<int>(b.dimensions().size() > 0 ? b.dimensions()[0] : 0);
     const int nnz = static_cast<int>(values.element_count());
 
-    // Cache the last key to skip the structure hash D2H on repeated calls.
-    static CacheKey last_key = {};
-    static bool last_key_valid = false;
+    // Hash both row_ptrs and col_indices: the cache-hit path only replaces
+    // values (AMGX_matrix_replace_coefficients), so the key must capture the full
+    // sparsity pattern for a changed pattern to miss and trigger a fresh setup.
+    std::vector<int> h_row_ptrs(n_rows + 1);
+    cudaMemcpy(h_row_ptrs.data(), row_ptrs_data, (n_rows + 1) * sizeof(int), cudaMemcpyDeviceToHost);
+    size_t structure_hash = fnv1a_hash(h_row_ptrs.data(), (n_rows + 1) * sizeof(int));
 
-    size_t structure_hash = 0;
-    bool fast_path = false;
-
-    if (last_key_valid &&
-        last_key.n_rows == n_rows &&
-        last_key.nnz == nnz &&
-        last_key.mode == static_cast<int>(Mode) &&
-        last_key.transpose_solve == (transpose_solve != 0) &&
-        last_key.config == std::string(config))
-    {
-      structure_hash = last_key.structure_hash;
-      fast_path = true;
-    }
-    else
-    {
-      std::vector<int> h_row_ptrs(n_rows + 1);
-      cudaMemcpy(h_row_ptrs.data(), row_ptrs_data, (n_rows + 1) * sizeof(int), cudaMemcpyDeviceToHost);
-      structure_hash = fnv1a_hash(h_row_ptrs.data(), (n_rows + 1) * sizeof(int));
-    }
+    std::vector<int> h_col_indices(nnz);
+    cudaMemcpy(h_col_indices.data(), col_indices_data, nnz * sizeof(int), cudaMemcpyDeviceToHost);
+    structure_hash = fnv1a_hash(h_col_indices.data(), nnz * sizeof(int), structure_hash);
 
     CacheKey key = {n_rows, nnz, static_cast<int>(Mode), transpose_solve != 0, structure_hash, std::string(config)};
     bool cache_hit = GetSolverCache().get(key, res);
@@ -224,9 +211,6 @@ namespace
 
       reuse_success = true;
     }
-
-    last_key = key;
-    last_key_valid = true;
 
     StatsCaptureGuard capture_guard(return_stats != 0);
 
@@ -427,28 +411,15 @@ namespace
 
     CachedResources res;
 
-    static MPICacheKey mpi_last_key = {};
-    static bool mpi_last_key_valid = false;
+    // Hash row_ptrs and the (global, int64) col_indices; see the single-GPU
+    // path for the rationale.
+    std::vector<int> h_row_ptrs(n_local + 1);
+    cudaMemcpy(h_row_ptrs.data(), row_ptrs_data, (n_local + 1) * sizeof(int), cudaMemcpyDeviceToHost);
+    size_t structure_hash = fnv1a_hash(h_row_ptrs.data(), (n_local + 1) * sizeof(int));
 
-    size_t structure_hash = 0;
-
-    if (mpi_last_key_valid &&
-        mpi_last_key.n_local == n_local &&
-        mpi_last_key.n_global == nglobal_host &&
-        mpi_last_key.nnz == nnz &&
-        mpi_last_key.lrank == lrank_host &&
-        mpi_last_key.mode == static_cast<int>(Mode) &&
-        mpi_last_key.comm_ptr == comm_ptr_val &&
-        mpi_last_key.config == std::string(config))
-    {
-      structure_hash = mpi_last_key.structure_hash;
-    }
-    else
-    {
-      std::vector<int> h_row_ptrs(n_local + 1);
-      cudaMemcpy(h_row_ptrs.data(), row_ptrs_data, (n_local + 1) * sizeof(int), cudaMemcpyDeviceToHost);
-      structure_hash = fnv1a_hash(h_row_ptrs.data(), (n_local + 1) * sizeof(int));
-    }
+    std::vector<int64_t> h_col_indices(nnz);
+    cudaMemcpy(h_col_indices.data(), col_indices_data, nnz * sizeof(int64_t), cudaMemcpyDeviceToHost);
+    structure_hash = fnv1a_hash(h_col_indices.data(), nnz * sizeof(int64_t), structure_hash);
 
     MPICacheKey key = {
         n_local,
@@ -473,9 +444,6 @@ namespace
       std::vector<T> h_x(n_local, static_cast<T>(0));
       AMGX_SAFE_CALL(AMGX_vector_upload(res.x_vec, n_local, 1, h_x.data()));
     }
-
-    mpi_last_key = key;
-    mpi_last_key_valid = true;
 
     StatsCaptureGuard capture_guard(return_stats != 0);
 

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -140,7 +140,8 @@ namespace
                                       ffi::ResultBuffer<DType> stats,
                                       std::string_view config,
                                       int32_t transpose_solve,
-                                      int32_t return_stats)
+                                      int32_t return_stats,
+                                      int32_t reuse_setup)
   {
     EnsureAmgxInitialized();
 
@@ -224,7 +225,9 @@ namespace
             res.A, n_rows, (int)values.element_count(), values_data, nullptr));
       }
 
-      AMGX_SAFE_CALL(AMGX_solver_resetup(res.solver, res.A));
+      // reuse_setup keeps the existing hierarchy while still refreshing the fine matrix.
+      if (!reuse_setup)
+        AMGX_SAFE_CALL(AMGX_solver_resetup(res.solver, res.A));
       AMGX_SAFE_CALL(AMGX_vector_upload(res.b_vec, n_rows, 1, b_data));
       AMGX_SAFE_CALL(AMGX_vector_set_zero(res.x_vec, n_rows, 1));
 
@@ -383,7 +386,8 @@ namespace
                                          ffi::ResultBuffer<DType> stats,
                                          std::string_view config,
                                          int32_t transpose_solve,
-                                         int32_t return_stats)
+                                         int32_t return_stats,
+                                         int32_t reuse_setup)
   {
     if (transpose_solve != 0)
     {
@@ -461,15 +465,16 @@ namespace
 
     if (cache_hit)
     {
-      // Warm path: replace coefficients and re-setup, reusing the cached
-      // structure and AMG hierarchy. The D2D copy is asynchronous; synchronize
-      // before AMGX reads values_buf.
+      // Refresh the cached matrix values. The D2D copy is asynchronous;
+      // synchronize before AMGX reads values_buf.
       cudaMemcpyAsync(res.values_buf, values_data, nnz * sizeof(T), cudaMemcpyDeviceToDevice, stream);
       cudaStreamSynchronize(stream);
       AMGX_SAFE_CALL(AMGX_matrix_replace_coefficients(
           res.A, n_local, nnz, res.values_buf, nullptr));
 
-      AMGX_SAFE_CALL(AMGX_solver_resetup(res.solver, res.A));
+      // reuse_setup keeps the existing hierarchy while still refreshing the fine matrix.
+      if (!reuse_setup)
+        AMGX_SAFE_CALL(AMGX_solver_resetup(res.solver, res.A));
       AMGX_SAFE_CALL(AMGX_vector_upload(res.b_vec, n_local, 1, b_data));
       std::vector<T> h_x(n_local, static_cast<T>(0));
       AMGX_SAFE_CALL(AMGX_vector_upload(res.x_vec, n_local, 1, h_x.data()));
@@ -602,10 +607,11 @@ namespace
                                   ffi::ResultBuffer<ffi::DataType::F32> stats,
                                   std::string_view config,
                                   int32_t transpose_solve,
-                                  int32_t return_stats)
+                                  int32_t return_stats,
+                                  int32_t reuse_setup)
   {
     return AmgxSolveInternal<float, ffi::DataType::F32, AMGX_mode_dFFI>(
-        stream, row_ptrs, col_indices, values, b, x, stats, config, transpose_solve, return_stats);
+        stream, row_ptrs, col_indices, values, b, x, stats, config, transpose_solve, return_stats, reuse_setup);
   }
 
   // Double implementation
@@ -618,10 +624,11 @@ namespace
                                         ffi::ResultBuffer<ffi::DataType::F64> stats,
                                         std::string_view config,
                                         int32_t transpose_solve,
-                                        int32_t return_stats)
+                                        int32_t return_stats,
+                                        int32_t reuse_setup)
   {
     return AmgxSolveInternal<double, ffi::DataType::F64, AMGX_mode_dDDI>(
-        stream, row_ptrs, col_indices, values, b, x, stats, config, transpose_solve, return_stats);
+        stream, row_ptrs, col_indices, values, b, x, stats, config, transpose_solve, return_stats, reuse_setup);
   }
 
 #ifdef JAXAMG_WITH_MPI
@@ -638,10 +645,11 @@ namespace
                                      ffi::ResultBuffer<ffi::DataType::F32> stats,
                                      std::string_view config,
                                      int32_t transpose_solve,
-                                     int32_t return_stats)
+                                     int32_t return_stats,
+                                     int32_t reuse_setup)
   {
     return AmgxSolveMPIInternal<float, ffi::DataType::F32, AMGX_mode_dFFI>(
-        stream, row_ptrs, col_indices, values, b, nglobal, comm_ptr, lrank, x, stats, config, transpose_solve, return_stats);
+        stream, row_ptrs, col_indices, values, b, nglobal, comm_ptr, lrank, x, stats, config, transpose_solve, return_stats, reuse_setup);
   }
 
   // MPI Double implementation
@@ -657,10 +665,11 @@ namespace
                                            ffi::ResultBuffer<ffi::DataType::F64> stats,
                                            std::string_view config,
                                            int32_t transpose_solve,
-                                           int32_t return_stats)
+                                           int32_t return_stats,
+                                           int32_t reuse_setup)
   {
     return AmgxSolveMPIInternal<double, ffi::DataType::F64, AMGX_mode_dDDI>(
-        stream, row_ptrs, col_indices, values, b, nglobal, comm_ptr, lrank, x, stats, config, transpose_solve, return_stats);
+        stream, row_ptrs, col_indices, values, b, nglobal, comm_ptr, lrank, x, stats, config, transpose_solve, return_stats, reuse_setup);
   }
 
   // -------------------------------------------------------------------------

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -171,15 +171,21 @@ namespace
     const int n_rows = static_cast<int>(b.dimensions().size() > 0 ? b.dimensions()[0] : 0);
     const int nnz = static_cast<int>(values.element_count());
 
-    // Hash both row_ptrs and col_indices: the cache-hit path only replaces
-    // values (AMGX_matrix_replace_coefficients), so the key must capture the full
-    // sparsity pattern for a changed pattern to miss and trigger a fresh setup.
-    std::vector<int> h_row_ptrs(n_rows + 1);
-    cudaMemcpy(h_row_ptrs.data(), row_ptrs_data, (n_rows + 1) * sizeof(int), cudaMemcpyDeviceToHost);
+    // The cache-hit path only replaces coefficient values, so the key must
+    // capture the full sparsity pattern (row_ptrs + col_indices) for a changed
+    // pattern to miss and trigger a fresh setup. Reuse host buffers across calls
+    // to avoid reallocating these large arrays on every solve.
+    static thread_local std::vector<int> h_row_ptrs, h_col_indices;
+    if (static_cast<int>(h_row_ptrs.size()) < n_rows + 1)
+      h_row_ptrs.resize(n_rows + 1);
+    if (static_cast<int>(h_col_indices.size()) < nnz)
+      h_col_indices.resize(nnz);
+    cudaMemcpyAsync(h_row_ptrs.data(), row_ptrs_data,
+                    (n_rows + 1) * sizeof(int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(h_col_indices.data(), col_indices_data,
+                    nnz * sizeof(int), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
     size_t structure_hash = fnv1a_hash(h_row_ptrs.data(), (n_rows + 1) * sizeof(int));
-
-    std::vector<int> h_col_indices(nnz);
-    cudaMemcpy(h_col_indices.data(), col_indices_data, nnz * sizeof(int), cudaMemcpyDeviceToHost);
     structure_hash = fnv1a_hash(h_col_indices.data(), nnz * sizeof(int), structure_hash);
 
     CacheKey key = {n_rows, nnz, static_cast<int>(Mode), transpose_solve != 0, structure_hash, std::string(config)};
@@ -425,13 +431,20 @@ namespace
     CachedResources res;
 
     // Hash row_ptrs and the (global, int64) col_indices; see the single-GPU
-    // path for the rationale.
-    std::vector<int> h_row_ptrs(n_local + 1);
-    cudaMemcpy(h_row_ptrs.data(), row_ptrs_data, (n_local + 1) * sizeof(int), cudaMemcpyDeviceToHost);
+    // path for the rationale. Reuse host buffers across calls to avoid
+    // reallocating these large arrays on every solve.
+    static thread_local std::vector<int> h_row_ptrs;
+    static thread_local std::vector<int64_t> h_col_indices;
+    if (static_cast<int>(h_row_ptrs.size()) < n_local + 1)
+      h_row_ptrs.resize(n_local + 1);
+    if (static_cast<int>(h_col_indices.size()) < nnz)
+      h_col_indices.resize(nnz);
+    cudaMemcpyAsync(h_row_ptrs.data(), row_ptrs_data,
+                    (n_local + 1) * sizeof(int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(h_col_indices.data(), col_indices_data,
+                    nnz * sizeof(int64_t), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
     size_t structure_hash = fnv1a_hash(h_row_ptrs.data(), (n_local + 1) * sizeof(int));
-
-    std::vector<int64_t> h_col_indices(nnz);
-    cudaMemcpy(h_col_indices.data(), col_indices_data, nnz * sizeof(int64_t), cudaMemcpyDeviceToHost);
     structure_hash = fnv1a_hash(h_col_indices.data(), nnz * sizeof(int64_t), structure_hash);
 
     MPICacheKey key = {

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -461,7 +461,11 @@ namespace
 
     if (cache_hit)
     {
-      cudaMemcpy(res.values_buf, values_data, nnz * sizeof(T), cudaMemcpyDeviceToDevice);
+      // Warm path: replace coefficients and re-setup, reusing the cached
+      // structure and AMG hierarchy. The D2D copy is asynchronous; synchronize
+      // before AMGX reads values_buf.
+      cudaMemcpyAsync(res.values_buf, values_data, nnz * sizeof(T), cudaMemcpyDeviceToDevice, stream);
+      cudaStreamSynchronize(stream);
       AMGX_SAFE_CALL(AMGX_matrix_replace_coefficients(
           res.A, n_local, nnz, res.values_buf, nullptr));
 
@@ -495,19 +499,47 @@ namespace
       AMGX_SAFE_CALL(AMGX_matrix_create(&res.A, res.rsrc, Mode));
       AMGX_SAFE_CALL(AMGX_solver_create(&res.solver, res.rsrc, Mode, res.cfg));
 
-      if (cudaMalloc(&res.values_buf, nnz * sizeof(T)) != cudaSuccess)
+      // Copy the matrix into cache-owned buffers. The cached distributed matrix
+      // and the warm-path AMGX_matrix_replace_coefficients reference these across
+      // solves, whereas the XLA inputs are released after this call. col_indices
+      // is narrowed to int32 (the low 4 bytes of each int64; valid since global
+      // indices are < nglobal_host, an int) for the 32-bit upload path below.
+      if (cudaMalloc(&res.values_buf, nnz * sizeof(T)) != cudaSuccess ||
+          cudaMalloc(&res.row_ptrs_buf, (n_local + 1) * sizeof(int)) != cudaSuccess ||
+          cudaMalloc(&res.col_indices_buf, nnz * sizeof(int)) != cudaSuccess)
       {
-        return ffi::Error::Internal("cudaMalloc for values buffer failed");
+        return ffi::Error::Internal("cudaMalloc for MPI matrix buffers failed");
       }
-      cudaMemcpy(res.values_buf, values_data, nnz * sizeof(T), cudaMemcpyDeviceToDevice);
+      cudaMemcpyAsync(res.values_buf, values_data, nnz * sizeof(T), cudaMemcpyDeviceToDevice, stream);
+      cudaMemcpyAsync(res.row_ptrs_buf, row_ptrs_data, (n_local + 1) * sizeof(int), cudaMemcpyDeviceToDevice, stream);
+      cudaMemcpy2DAsync(res.col_indices_buf, sizeof(int), col_indices_data, sizeof(int64_t),
+                        sizeof(int), nnz, cudaMemcpyDeviceToDevice, stream);
+      cudaStreamSynchronize(stream);
 
+      // Contiguous row partition (owning rank per global row), required for AMGX
+      // to build the multi-ring halo (classical AMG uses 2 rings).
+      int nranks_host = 1;
+      MPI_Comm_size(*mpi_comm, &nranks_host);
+      std::vector<int> counts(nranks_host);
+      int n_local_send = n_local;
+      if (MPI_Allgather(&n_local_send, 1, MPI_INT, counts.data(), 1, MPI_INT,
+                        *mpi_comm) != MPI_SUCCESS)
+        return ffi::Error::Internal("MPI_Allgather of local sizes failed");
+      std::vector<int> partition_vector(nglobal_host);
+      for (int r = 0, off = 0; r < nranks_host; ++r)
+        for (int i = 0; i < counts[r] && off < nglobal_host; ++i)
+          partition_vector[off++] = r;
+
+      // 32-bit index upload path; the 64-bit AMGX_matrix_upload_all_global
+      // produces a diverging AMG hierarchy at >= 4 ranks.
       int nrings = 1;
       AMGX_SAFE_CALL(AMGX_config_get_default_number_of_rings(res.cfg, &nrings));
-
-      AMGX_SAFE_CALL(AMGX_matrix_upload_all_global(
+      AMGX_SAFE_CALL(AMGX_matrix_upload_all_global_32(
           res.A, nglobal_host, n_local, nnz, 1, 1,
-          row_ptrs_data, col_indices_data, static_cast<T *>(res.values_buf), nullptr,
-          nrings, nrings, nullptr));
+          static_cast<int *>(res.row_ptrs_buf),
+          static_cast<int *>(res.col_indices_buf),
+          static_cast<T *>(res.values_buf), nullptr,
+          nrings, nrings, partition_vector.data()));
 
       AMGX_SAFE_CALL(AMGX_vector_create(&res.x_vec, res.rsrc, Mode));
       AMGX_SAFE_CALL(AMGX_vector_create(&res.b_vec, res.rsrc, Mode));

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -27,6 +27,23 @@ namespace ffi = xla::ffi;
 namespace
 {
 
+  // Reused cuSPARSE handle for the single-GPU transpose: created once and reused
+  // (stream rebound per call), avoiding a create/destroy on every backward pass.
+  // Left to be reclaimed at process exit (a single handle, independent of AmgX).
+  inline cusparseHandle_t GetCusparseHandle()
+  {
+    static cusparseHandle_t handle = []()
+    {
+      cusparseHandle_t h = nullptr;
+      if (cusparseCreate(&h) != CUSPARSE_STATUS_SUCCESS)
+      {
+        h = nullptr;
+      }
+      return h;
+    }();
+    return handle;
+  }
+
   template <typename T>
   inline const char *CsrTransposeDevice(cudaStream_t stream,
                                         int n_rows,
@@ -38,14 +55,13 @@ namespace
                                         int *col_indices_t,
                                         T *values_t)
   {
-    cusparseHandle_t handle = nullptr;
-    if (cusparseCreate(&handle) != CUSPARSE_STATUS_SUCCESS)
+    cusparseHandle_t handle = GetCusparseHandle();
+    if (handle == nullptr)
     {
       return "cusparseCreate failed";
     }
     if (cusparseSetStream(handle, stream) != CUSPARSE_STATUS_SUCCESS)
     {
-      cusparseDestroy(handle);
       return "cusparseSetStream failed";
     }
 
@@ -69,14 +85,12 @@ namespace
         &buffer_size);
     if (status != CUSPARSE_STATUS_SUCCESS)
     {
-      cusparseDestroy(handle);
       return "cusparseCsr2cscEx2_bufferSize failed";
     }
 
     void *workspace = nullptr;
     if (buffer_size > 0 && cudaMalloc(&workspace, buffer_size) != cudaSuccess)
     {
-      cusparseDestroy(handle);
       return "cudaMalloc failed for cusparse transpose workspace";
     }
 
@@ -98,7 +112,6 @@ namespace
         workspace);
 
     cudaFree(workspace);
-    cusparseDestroy(handle);
 
     if (status != CUSPARSE_STATUS_SUCCESS)
     {

--- a/jaxamg/_amgx_utils.h
+++ b/jaxamg/_amgx_utils.h
@@ -448,10 +448,11 @@ namespace
   };
 
 #ifdef JAXAMG_WITH_MPI
-  // Singleton for global MPI AmgX resource management. Shares one
-  // AMGX_resources_handle across all MPI cache entries so multiple
-  // matrix/solver pairs can coexist on the same communicator.
-  // Owns the founding config handle (same reason as GlobalResources).
+  // Singleton for global MPI AmgX resource management. Keeps one
+  // AMGX_resources_handle per communicator: solves on the same communicator
+  // share it, distinct communicators each get their own (one handle reused
+  // across communicators would run AmgX's collectives on the wrong one). Owns
+  // the founding config handle per communicator (as GlobalResources does).
   class GlobalMPIResources {
   public:
       static GlobalMPIResources& Get() {
@@ -462,31 +463,37 @@ namespace
       AMGX_resources_handle GetHandle(AMGX_config_handle cfg,
                                        MPI_Comm *comm, int ndevs, int *devs) {
           std::lock_guard<std::mutex> lock(mutex_);
-          if (!handle_) {
-              AMGX_SAFE_CALL_VOID(AMGX_resources_create(&handle_, cfg, comm, ndevs, devs));
-              cfg_ = cfg;
+          // Key on the communicator's identity (the same pointer Python passes as
+          // comm_ptr), so each communicator gets its own resources handle.
+          uint64_t key = reinterpret_cast<uint64_t>(comm);
+          auto it = handles_.find(key);
+          if (it != handles_.end()) {
+              return it->second.handle;
           }
-          return handle_;
+          AMGX_resources_handle handle = nullptr;
+          AMGX_SAFE_CALL_VOID(AMGX_resources_create(&handle, cfg, comm, ndevs, devs));
+          handles_[key] = {handle, cfg};
+          return handle;
       }
 
       void Destroy() {
           std::lock_guard<std::mutex> lock(mutex_);
-          if (handle_) {
-              AMGX_SAFE_CALL_VOID(AMGX_resources_destroy(handle_));
-              handle_ = nullptr;
+          for (auto &kv : handles_) {
+              if (kv.second.handle) AMGX_SAFE_CALL_VOID(AMGX_resources_destroy(kv.second.handle));
+              if (kv.second.cfg) AMGX_SAFE_CALL_VOID(AMGX_config_destroy(kv.second.cfg));
           }
-          if (cfg_) {
-              AMGX_SAFE_CALL_VOID(AMGX_config_destroy(cfg_));
-              cfg_ = nullptr;
-          }
+          handles_.clear();
       }
 
   private:
-      GlobalMPIResources() : handle_(nullptr), cfg_(nullptr) {}
+      struct Entry {
+          AMGX_resources_handle handle = nullptr;
+          AMGX_config_handle cfg = nullptr;
+      };
+      GlobalMPIResources() {}
       ~GlobalMPIResources() { Destroy(); }
 
-      AMGX_resources_handle handle_;
-      AMGX_config_handle cfg_;
+      std::unordered_map<uint64_t, Entry> handles_;
       std::mutex mutex_;
   };
 #endif // JAXAMG_WITH_MPI

--- a/jaxamg/_amgx_utils.h
+++ b/jaxamg/_amgx_utils.h
@@ -213,7 +213,7 @@ namespace
     int nnz;
     int mode; // AMGX_Mode (dFFI vs dDDI)
     bool transpose_solve;
-    size_t structure_hash; // FNV-1a of row_ptrs content
+    size_t structure_hash; // FNV-1a of row_ptrs + col_indices content
     std::string config;
 
     bool operator==(const CacheKey &other) const
@@ -227,11 +227,14 @@ namespace
     }
   };
 
-  // FNV-1a hash of byte sequences.
-  inline size_t fnv1a_hash(const void *data, size_t len)
+  // FNV-1a hash of byte sequences. Pass `seed` (the running hash) to continue an
+  // existing digest so several buffers -- e.g. row_ptrs then col_indices -- fold
+  // into a single structure hash.
+  inline size_t fnv1a_hash(const void *data, size_t len,
+                           size_t seed = 14695981039346656037ULL)
   {
     const uint8_t *bytes = static_cast<const uint8_t *>(data);
-    size_t hash = 14695981039346656037ULL;
+    size_t hash = seed;
     for (size_t i = 0; i < len; ++i)
     {
       hash ^= bytes[i];
@@ -243,9 +246,9 @@ namespace
   struct MPICacheKey
   {
     // No device pointers: JAX eager calls get new addresses each time, causing
-    // cache thrashing. Value-based keys + structure_hash (FNV-1a of row_ptrs
-    // content) ensure stable hits and correct structural identity for
-    // AMGX_matrix_replace_coefficients on the cache-hit path.
+    // cache thrashing. Value-based keys + structure_hash (FNV-1a of row_ptrs +
+    // col_indices content) ensure stable hits and correct structural identity
+    // for AMGX_matrix_replace_coefficients on the cache-hit path.
     int n_local;
     int n_global;
     int nnz;

--- a/jaxamg/_amgx_utils.h
+++ b/jaxamg/_amgx_utils.h
@@ -342,6 +342,8 @@ namespace
     AMGX_vector_handle x_vec = nullptr;
     AMGX_vector_handle b_vec = nullptr;
     void *values_buf = nullptr;            // MPI replace_coefficients buffer (null for non-MPI)
+    void *row_ptrs_buf = nullptr;          // MPI: cache-owned copy of local row_ptrs (see cold path)
+    void *col_indices_buf = nullptr;       // MPI: cache-owned int32 copy of local global col_indices
     void *transpose_row_ptrs = nullptr;    // transpose_solve mode only
     void *transpose_col_indices = nullptr; // transpose_solve mode only
     void *transpose_values = nullptr;      // transpose_solve mode only
@@ -415,6 +417,8 @@ namespace
       // owned by Global{MPI}Resources and destroyed in its Destroy().
       // Non-founding configs are tiny and cleaned up at process exit.
       if (res.values_buf) cudaFree(res.values_buf);
+      if (res.row_ptrs_buf) cudaFree(res.row_ptrs_buf);
+      if (res.col_indices_buf) cudaFree(res.col_indices_buf);
       if (res.transpose_row_ptrs) cudaFree(res.transpose_row_ptrs);
       if (res.transpose_col_indices) cudaFree(res.transpose_col_indices);
       if (res.transpose_values) cudaFree(res.transpose_values);

--- a/jaxamg/_amgx_utils.h
+++ b/jaxamg/_amgx_utils.h
@@ -227,18 +227,36 @@ namespace
     }
   };
 
-  // FNV-1a hash of byte sequences. Pass `seed` (the running hash) to continue an
-  // existing digest so several buffers -- e.g. row_ptrs then col_indices -- fold
-  // into a single structure hash.
+  // Word-wise FNV-1a-style hash: four lanes break the multiply dependency chain
+  // so hashing the structure (row_ptrs + col_indices, hundreds of MB at n~1e7)
+  // isn't a bottleneck on repeated solves. Not canonical FNV-1a but a
+  // deterministic, content-sensitive digest, which is all the cache key needs.
+  // Pass `seed` to chain buffers into one digest; inputs are >=4-byte aligned.
   inline size_t fnv1a_hash(const void *data, size_t len,
                            size_t seed = 14695981039346656037ULL)
   {
+    constexpr size_t PRIME = 1099511628211ULL;
     const uint8_t *bytes = static_cast<const uint8_t *>(data);
-    size_t hash = seed;
-    for (size_t i = 0; i < len; ++i)
+    const uint32_t *words = static_cast<const uint32_t *>(data);
+    const size_t nwords = len / 4;
+    size_t h0 = seed, h1 = seed ^ 0x9e3779b97f4a7c15ULL,
+           h2 = seed + 1ULL, h3 = seed ^ 0xff51afd7ed558ccdULL;
+    size_t i = 0;
+    for (; i + 4 <= nwords; i += 4)
     {
-      hash ^= bytes[i];
-      hash *= 1099511628211ULL;
+      h0 = (h0 ^ words[i]) * PRIME;
+      h1 = (h1 ^ words[i + 1]) * PRIME;
+      h2 = (h2 ^ words[i + 2]) * PRIME;
+      h3 = (h3 ^ words[i + 3]) * PRIME;
+    }
+    size_t hash = (h0 * PRIME) ^ (h1 * PRIME) ^ (h2 * PRIME) ^ (h3 * PRIME);
+    for (; i < nwords; ++i)
+    {
+      hash = (hash ^ words[i]) * PRIME;
+    }
+    for (size_t b = nwords * 4; b < len; ++b)
+    {
+      hash = (hash ^ bytes[b]) * PRIME;
     }
     return hash;
   }

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -78,6 +78,7 @@ def cache_mpi_metadata(
     nglobal: int,
     partition_info: tuple[int, int],
     A: MatrixOrOperator,
+    is_symmetric: bool = False,
 ) -> dict[str, Any]:
     """
     Pre-compute and cache MPI metadata for JIT-compatible solver usage.
@@ -100,6 +101,10 @@ def cache_mpi_metadata(
         nglobal: Global matrix size (total rows across all ranks)
         partition_info: tuple (row_start, row_end) indicating which rows this rank owns
         A: Matrix or operator to compute max nnz for buffer sizing
+        is_symmetric: If True, the backward pass never transposes, so the
+            transpose output size (`nnz_out`) is left unset (``None``). Should
+            match the `is_symmetric` passed to `with_cache`; the default (False)
+            computes it, which is always safe.
 
     Returns:
         A dictionary containing MPI metadata.
@@ -114,6 +119,8 @@ def cache_mpi_metadata(
         - `nglobal`: Global matrix size
         - `config_str`: Prepared configuration string
         - `max_nnz`: Maximum nnz across all ranks
+        - `nnz_out`: This rank's local nnz(A^T) for the transpose output, or
+          `None` when `is_symmetric` is True
     """
     from mpi4py import MPI
 
@@ -136,10 +143,12 @@ def cache_mpi_metadata(
     # Prepare config string
     config_str = amgx_config.prepare_config(config)
 
-    # Compute max_nnz across all ranks
-    # For sparse matrices (BCSR), get nnz from data array
+    # Compute max_nnz across all ranks, and capture this rank's global column
+    # indices (needed for nnz_out, the transpose output sizing).
+    # For sparse matrices (BCSR), get nnz/indices from the arrays directly.
     if hasattr(A, "data"):
         local_nnz = len(A.data)
+        local_col_indices = np.asarray(A.indices)
     elif callable(A):
         # For distributed operators, we need to use global size for proper materialization
         # The operator shape is (n_local, n_global): takes global vector, returns local portion
@@ -159,6 +168,7 @@ def cache_mpi_metadata(
         )
 
         local_nnz = len(A_materialized.data)
+        local_col_indices = np.asarray(A_materialized.indices)
     else:
         raise TypeError(
             f"Matrix A must be BCSR, BCOO, SciPy sparse, dense array, or callable. "
@@ -168,6 +178,16 @@ def cache_mpi_metadata(
     all_nnz = comm.allgather(local_nnz)
     max_nnz = max(all_nnz)
 
+    # This rank's local nnz(A^T) for the transpose output buffers (backward pass
+    # of non-symmetric solves). Symmetric solves never transpose, so skip it.
+    if is_symmetric:
+        nnz_out = None
+    else:
+        from .mpi_utils import local_transpose_nnz
+
+        recvcounts_tuple = tuple(int(s) for s in all_sizes)
+        nnz_out = local_transpose_nnz(local_col_indices, recvcounts_tuple, comm)
+
     cache_dict = {
         "recvcounts_tuple": tuple(recvcounts.tolist()),
         "displs_tuple": tuple(displs.tolist()),
@@ -176,6 +196,7 @@ def cache_mpi_metadata(
         "nglobal": nglobal,
         "config_str": config_str,
         "max_nnz": max_nnz,
+        "nnz_out": nnz_out,
     }
 
     return cache_dict

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -121,6 +121,8 @@ def cache_mpi_metadata(
         - `max_nnz`: Maximum nnz across all ranks
         - `nnz_out`: This rank's local nnz(A^T) for the transpose output, or
           `None` when `is_symmetric` is True
+        - `halo_plan`: Backward-pass halo-exchange plan for the gradient w.r.t.
+          A (fetches only referenced remote solution entries)
     """
     rank = comm.Get_rank()
     row_start, row_end = partition_info
@@ -133,7 +135,7 @@ def cache_mpi_metadata(
         jnp.int32
     )
 
-    from .mpi_utils import local_transpose_nnz, register_comm
+    from .mpi_utils import build_halo_plan, local_transpose_nnz, register_comm
 
     # Register the communicator so the cached solver's backward pass can recover
     # it for its collectives; comm_ptr is its address.
@@ -179,13 +181,21 @@ def cache_mpi_metadata(
     all_nnz = comm.allgather(local_nnz)
     max_nnz = max(all_nnz)
 
+    recvcounts_tuple = tuple(int(s) for s in all_sizes)
+
     # This rank's local nnz(A^T) for the transpose output buffers (backward pass
     # of non-symmetric solves). Symmetric solves never transpose, so skip it.
     if is_symmetric:
         nnz_out = None
     else:
-        recvcounts_tuple = tuple(int(s) for s in all_sizes)
         nnz_out = local_transpose_nnz(local_col_indices, recvcounts_tuple, comm)
+
+    # Backward-pass halo plan: fetches only the remote solution entries this
+    # rank's rows reference for the gradient w.r.t. A, instead of gathering the
+    # full global solution. Needed for both symmetric and non-symmetric matrices.
+    halo_plan = build_halo_plan(
+        local_col_indices, recvcounts_tuple, partition_info, comm
+    )
 
     cache_dict = {
         "recvcounts_tuple": tuple(recvcounts.tolist()),
@@ -196,6 +206,7 @@ def cache_mpi_metadata(
         "config_str": config_str,
         "max_nnz": max_nnz,
         "nnz_out": nnz_out,
+        "halo_plan": halo_plan,
     }
 
     return cache_dict

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -122,8 +122,6 @@ def cache_mpi_metadata(
         - `nnz_out`: This rank's local nnz(A^T) for the transpose output, or
           `None` when `is_symmetric` is True
     """
-    from mpi4py import MPI
-
     rank = comm.Get_rank()
     row_start, row_end = partition_info
     n_local = row_end - row_start
@@ -135,8 +133,11 @@ def cache_mpi_metadata(
         jnp.int32
     )
 
-    # Get MPI communicator pointer and local rank
-    comm_ptr = MPI._addressof(comm)
+    from .mpi_utils import local_transpose_nnz, register_comm
+
+    # Register the communicator so the cached solver's backward pass can recover
+    # it for its collectives; comm_ptr is its address.
+    comm_ptr = register_comm(comm)
     gpu_count = jax.device_count()
     lrank = rank % gpu_count
 
@@ -183,8 +184,6 @@ def cache_mpi_metadata(
     if is_symmetric:
         nnz_out = None
     else:
-        from .mpi_utils import local_transpose_nnz
-
         recvcounts_tuple = tuple(int(s) for s in all_sizes)
         nnz_out = local_transpose_nnz(local_col_indices, recvcounts_tuple, comm)
 

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -19,6 +19,8 @@ from .mpi_utils import (
     _mpi4jax_allgatherv,
     _mpi4jax_alltoallv_transpose,
     local_transpose_nnz,
+    register_comm,
+    resolve_comm,
 )
 from .utils import *
 
@@ -266,9 +268,9 @@ def _get_solver_primitive_mpi(
                  patterns; required for non-symmetric matrices.
     """
 
-    from mpi4py import MPI
-
-    comm = MPI.COMM_WORLD
+    # Backward-pass collectives run on the user's communicator (recovered from
+    # comm_ptr), which may be a subcommunicator -- not MPI.COMM_WORLD.
+    comm = resolve_comm(comm_ptr)
 
     def allgather(
         sendbuf: ArrayLike,
@@ -512,9 +514,9 @@ def solve(
             (x, info), _ = solver(A_csr, b, recvcounts, displs)
         elif comm is not None:
             # Compute metadata dynamically
-            try:
-                from mpi4py import MPI
-            except ImportError:
+            import importlib.util
+
+            if importlib.util.find_spec("mpi4py") is None:
                 raise ImportError(
                     "mpi4py is required for MPI mode. Install it with: pip install mpi4py"
                 )
@@ -522,8 +524,9 @@ def solve(
             # Get MPI rank and compute local GPU assignment
             rank = comm.Get_rank()
             lrank = rank % jax.device_count()
-            # Get MPI communicator pointer
-            comm_ptr = MPI._addressof(comm)
+            # Register the communicator and get its address (so the backward pass
+            # can recover it for its collectives).
+            comm_ptr = register_comm(comm)
 
             # Gather partition sizes from all ranks for gradient allgather operation
             n_local = A_csr.shape[0]

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -86,6 +86,7 @@ def _amgx_solve_impl(
     config_str: str = "",
     transpose_solve: bool = False,
     return_stats: bool = False,
+    reuse_setup: bool = False,
 ) -> tuple[jax.Array, jax.Array]:
     """Low-level FFI call to AmgX solver (non-differentiable)."""
 
@@ -115,6 +116,7 @@ def _amgx_solve_impl(
         config=config_str,
         transpose_solve=np.int32(transpose_solve),
         return_stats=np.int32(return_stats),
+        reuse_setup=np.int32(reuse_setup),
     )
 
     return cast(tuple, results)
@@ -131,6 +133,7 @@ def _amgx_solve_mpi_impl(
     config_str: str = "",
     transpose_solve: bool = False,
     return_stats: bool = False,
+    reuse_setup: bool = False,
 ) -> tuple[jax.Array, jax.Array]:
     """Low-level FFI call to AmgX MPI solver (non-differentiable)."""
 
@@ -163,6 +166,7 @@ def _amgx_solve_mpi_impl(
         config=config_str,
         transpose_solve=np.int32(transpose_solve),
         return_stats=np.int32(return_stats),
+        reuse_setup=np.int32(reuse_setup),
     )
 
     return cast(tuple, results)
@@ -170,11 +174,16 @@ def _amgx_solve_mpi_impl(
 
 @functools.lru_cache(maxsize=32)
 def _get_solver_primitive(
-    config_str: str, is_symmetric: bool = False, return_stats: bool = False
+    config_str: str,
+    is_symmetric: bool = False,
+    return_stats: bool = False,
+    reuse_setup: bool = False,
 ) -> Callable:
     """
     Returns a JAX custom_vjp primitive for AmgX solve with a specific configuration.
     Cached to avoid recompilation for identical configurations.
+
+    reuse_setup: Skip warm AMGX resetup and keep the cached hierarchy.
     """
 
     @jax.custom_vjp
@@ -186,6 +195,7 @@ def _get_solver_primitive(
             b,
             config_str=config_str,
             return_stats=return_stats,
+            reuse_setup=reuse_setup,
         )
         return x, info
 
@@ -203,7 +213,12 @@ def _get_solver_primitive(
         A, x = residuals
 
         # Solve A^T λ = g_x
-        solver = _get_solver_primitive(config_str, is_symmetric, return_stats=False)
+        solver = _get_solver_primitive(
+            config_str,
+            is_symmetric,
+            return_stats=False,
+            reuse_setup=reuse_setup,
+        )
 
         # Check if matrix is symmetric
         if is_symmetric:
@@ -218,6 +233,7 @@ def _get_solver_primitive(
                     g_x,
                     config_str=config_str,
                     transpose_solve=True,
+                    reuse_setup=reuse_setup,
                 )
             except Exception:
                 A_T = jsp.BCSR.from_bcoo(A.to_bcoo().transpose())
@@ -251,6 +267,7 @@ def _get_solver_primitive_mpi(
     nnz_out: int | None = None,
     n_ghost: int = 0,
     return_stats: bool = False,
+    reuse_setup: bool = False,
 ) -> Callable:
     """
     Create cached JAX custom_vjp primitive for MPI AmgX solve.
@@ -309,6 +326,7 @@ def _get_solver_primitive_mpi(
             lrank_arr,
             config_str=config_str,
             return_stats=return_stats,
+            reuse_setup=reuse_setup,
         )
 
         return x, info
@@ -407,6 +425,7 @@ def solve(
     nglobal: int | None = None,
     partition_info: tuple[int, int] | None = None,
     save_stats_file: str | os.PathLike | None = None,
+    reuse_setup: bool = False,
     **kwargs: Any,
 ) -> tuple[jax.Array, dict]:
     """Solve `Ax=b` using the AmgX backend. See [Examples](examples.md) for usage.
@@ -419,6 +438,7 @@ def solve(
         nglobal: Global matrix row count for MPI mode. Required when `comm` is provided and MPI metadata is not pre-attached to `A`.
         partition_info: `(row_start, row_end)` owned by this rank in MPI mode.  Required when `comm` is provided and MPI metadata is not pre-attached to `A`.
         save_stats_file: Optional file path to save detailed AmgX solver statistics.  If None, no file is created.
+        reuse_setup: For repeated solves with the same sparsity pattern, skip warm `AMGX_solver_resetup` and keep the cached hierarchy. This is cheaper per solve but may require more iterations if matrix coefficients change significantly.
         **kwargs: Additional AmgX config parameters. These override values in `config` when both are provided.
 
     Returns:
@@ -493,6 +513,7 @@ def solve(
                 nnz_out=nnz_out,
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
+                reuse_setup=reuse_setup,
             )
 
             x, info = solver(
@@ -553,6 +574,7 @@ def solve(
                 nnz_out=nnz_out,
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
+                reuse_setup=reuse_setup,
             )
             x, info = solver(
                 A_csr,
@@ -570,6 +592,7 @@ def solve(
             config_str,
             is_symmetric=is_symmetric,
             return_stats=1 if save_stats_file else 0,
+            reuse_setup=reuse_setup,
         )
 
         x, info = solver(A_csr, b)

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -18,6 +18,7 @@ from .mpi_utils import (
     _amgx_allgather_impl,
     _mpi4jax_allgatherv,
     _mpi4jax_alltoallv_transpose,
+    local_transpose_nnz,
 )
 from .utils import *
 
@@ -245,6 +246,7 @@ def _get_solver_primitive_mpi(
     is_symmetric: bool = False,
     recvcounts_tuple: tuple[int, ...] | None = None,
     max_nnz: int | None = None,
+    nnz_out: int | None = None,
     return_stats: bool = False,
 ) -> Callable:
     """
@@ -257,8 +259,11 @@ def _get_solver_primitive_mpi(
     - MPI4JAX_USE_CUDA_MPI=0: Use CPU staging (copies GPU<->CPU for MPI)
 
     Args:
-        max_nnz: Maximum nnz across all ranks for transpose buffer sizing.
-                 Must be provided when using non-symmetric matrices (required for backward pass).
+        max_nnz: Maximum local nnz of A across ranks, for the transpose send
+                 buffers. Required for non-symmetric matrices (backward pass).
+        nnz_out: This rank's local nnz of A^T, for the transpose output buffers.
+                 Differs from the local nnz of A for structurally nonsymmetric
+                 patterns; required for non-symmetric matrices.
     """
 
     from mpi4py import MPI
@@ -346,10 +351,12 @@ def _get_solver_primitive_mpi(
                     "recvcounts_tuple is required for distributed transpose. "
                     "This should be provided automatically when using MPI mode."
                 )
-            if max_nnz is None:
+            if max_nnz is None or nnz_out is None:
                 raise ValueError(
-                    "max_nnz is required for distributed transpose of non-symmetric matrices. "
-                    "Ensure max_nnz is computed when creating the solver (via cache_mpi_metadata or dynamic computation)."
+                    "max_nnz and nnz_out are required for the distributed "
+                    "transpose of non-symmetric matrices. Ensure both are computed "
+                    "when creating the solver (via cache_mpi_metadata or dynamic "
+                    "computation)."
                 )
             # Order the transpose after the forward solve (it otherwise reads
             # only A); without this XLA may interleave their MPI collectives in
@@ -358,7 +365,7 @@ def _get_solver_primitive_mpi(
                 (A.data, A.indices, A.indptr, x)
             )
             at_data, at_indices, at_indptr = _mpi4jax_alltoallv_transpose(
-                a_data, a_indices, a_indptr, recvcounts_tuple, comm, max_nnz
+                a_data, a_indices, a_indptr, recvcounts_tuple, comm, max_nnz, nnz_out
             )
 
             # Reconstruct BCSR for A^T
@@ -487,6 +494,7 @@ def solve(
             # Use pre-cached MPI metadata
             recvcounts_tuple = mpi_cache["recvcounts_tuple"]
             max_nnz = mpi_cache["max_nnz"]  # Always present in cache
+            nnz_out = mpi_cache["nnz_out"]  # None when cached as symmetric
             solver = _get_solver_primitive_mpi(
                 mpi_cache["config_str"],
                 mpi_cache["nglobal"],
@@ -495,6 +503,7 @@ def solve(
                 is_symmetric=is_symmetric,
                 recvcounts_tuple=recvcounts_tuple,
                 max_nnz=max_nnz,
+                nnz_out=nnz_out,
                 return_stats=1 if save_stats_file else 0,
             )
             recvcounts = jnp.array(recvcounts_tuple, dtype=jnp.int32)
@@ -528,8 +537,10 @@ def solve(
             displs = jnp.array(displs_val)
             recvcounts_tuple = tuple(recvcounts_val.tolist())
 
-            # Compute max nnz across all ranks for buffer sizing
+            # max nnz across ranks (transpose send buffers) + this rank's local
+            # nnz(A^T) (its output buffers).
             max_nnz = max(comm.allgather(len(A_csr.data)))
+            nnz_out = local_transpose_nnz(A_csr.indices, recvcounts_tuple, comm)
 
             solver = _get_solver_primitive_mpi(
                 config_str,
@@ -539,6 +550,7 @@ def solve(
                 is_symmetric=is_symmetric,
                 recvcounts_tuple=recvcounts_tuple,
                 max_nnz=max_nnz,
+                nnz_out=nnz_out,
                 return_stats=1 if save_stats_file else 0,
             )
             (x, info), _ = solver(A_csr, b, recvcounts, displs)

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -15,9 +15,9 @@ from jax.typing import ArrayLike
 from . import config as amgx_config
 from ._ext import _amgx
 from .mpi_utils import (
-    _amgx_allgather_impl,
-    _mpi4jax_allgatherv,
     _mpi4jax_alltoallv_transpose,
+    _mpi4jax_halo_gather,
+    build_halo_plan,
     local_transpose_nnz,
     register_comm,
     resolve_comm,
@@ -249,13 +249,14 @@ def _get_solver_primitive_mpi(
     recvcounts_tuple: tuple[int, ...] | None = None,
     max_nnz: int | None = None,
     nnz_out: int | None = None,
+    n_ghost: int = 0,
     return_stats: bool = False,
 ) -> Callable:
     """
     Create cached JAX custom_vjp primitive for MPI AmgX solve.
     Supports automatic differentiation in distributed setting.
 
-    Uses mpi4jax for MPI communication (allgather, transpose).
+    Uses mpi4jax for MPI communication (transpose, backward halo exchange).
     GPU vs CPU MPI is controlled by MPI4JAX_USE_CUDA_MPI environment variable:
     - MPI4JAX_USE_CUDA_MPI=1: Use GPU-aware MPI (requires CUDA-aware MPI library)
     - MPI4JAX_USE_CUDA_MPI=0: Use CPU staging (copies GPU<->CPU for MPI)
@@ -272,24 +273,19 @@ def _get_solver_primitive_mpi(
     # comm_ptr), which may be a subcommunicator -- not MPI.COMM_WORLD.
     comm = resolve_comm(comm_ptr)
 
-    def allgather(
-        sendbuf: ArrayLike,
-        recvcounts: ArrayLike,
-        displs: ArrayLike,
-        comm_ptr_arr: ArrayLike,
-    ) -> jax.Array:
-        # Use mpi4jax for MPI communication
-        if recvcounts_tuple is not None:
-            return _mpi4jax_allgatherv(sendbuf, recvcounts_tuple, comm)
-        # Fallback to FFI-based allgather if recvcounts_tuple not available
-        return _amgx_allgather_impl(
-            sendbuf, recvcounts, displs, comm_ptr_arr, nglobal=nglobal
-        )
-
+    # The backward pass's gradient w.r.t. A needs the solution at the columns
+    # this rank's rows reference. The halo plan (col_to_combined, send_ids,
+    # recv_ghost_slot) is pattern-specific, so it flows as custom_vjp operands
+    # rather than being baked into this memoized factory; only the static ghost
+    # count n_ghost is captured here.
     @jax.custom_vjp
     def solve(
-        A: jsp.BCSR, b: jax.Array, recvcounts: jax.Array, displs: jax.Array
-    ) -> tuple[tuple[jax.Array, jax.Array], jax.Array]:
+        A: jsp.BCSR,
+        b: jax.Array,
+        col_to_combined: jax.Array,
+        send_ids: jax.Array,
+        recv_ghost_slot: jax.Array,
+    ) -> tuple[jax.Array, jax.Array]:
         nglobal_arr = jnp.array([nglobal], dtype=jnp.int32)
 
         # Split 64-bit comm_ptr into two int32 values for FFI
@@ -315,50 +311,36 @@ def _get_solver_primitive_mpi(
             return_stats=return_stats,
         )
 
-        return (x, info), comm_ptr_arr
+        return x, info
 
-    def fwd(
-        A: jsp.BCSR, b: jax.Array, recvcounts: jax.Array, displs: jax.Array
-    ) -> tuple[
-        tuple[tuple[jax.Array, jax.Array], jax.Array],
-        tuple[jsp.BCSR, jax.Array, jax.Array, jax.Array, jax.Array],
-    ]:
-        out = solve(A, b, recvcounts, displs)
-        (x, info), comm_ptr_arr = out
+    def fwd(A, b, col_to_combined, send_ids, recv_ghost_slot):
+        out = solve(A, b, col_to_combined, send_ids, recv_ghost_slot)
+        x, info = out
         return out, (
             A,
             x,
-            recvcounts,
-            displs,
-            comm_ptr_arr,
+            col_to_combined,
+            send_ids,
+            recv_ghost_slot,
         )
 
-    def bwd(
-        residuals: tuple[jsp.BCSR, jax.Array, jax.Array, jax.Array, jax.Array],
-        g: tuple[tuple[jax.Array, jax.Array], jax.Array],
-    ) -> tuple[jsp.BCSR, jax.Array, None, None]:
-        (g_x, _), _ = g
-        A, x, recvcounts, displs, comm_ptr_arr = residuals
+    def bwd(residuals, g):
+        g_x, _ = g
+        A, x, col_to_combined, send_ids, recv_ghost_slot = residuals
 
         # Backward solve: A^T @ adj_b = g_x
-
-        # Check if matrix is symmetric
         if is_symmetric:
-            # Skip distributed transpose
-            (adj_b, _), _ = solve(A, g_x, recvcounts, displs)
+            # Symmetric: skip the distributed transpose.
+            adj_b, _ = solve(A, g_x, col_to_combined, send_ids, recv_ghost_slot)
         else:
-            # Use mpi4jax for distributed transpose (JIT-compatible, GPU-direct when MPI4JAX_USE_CUDA_MPI=1)
-            if recvcounts_tuple is None:
+            # Distributed transpose via mpi4jax (JIT-compatible, GPU-direct when
+            # MPI4JAX_USE_CUDA_MPI=1).
+            if recvcounts_tuple is None or max_nnz is None or nnz_out is None:
                 raise ValueError(
-                    "recvcounts_tuple is required for distributed transpose. "
-                    "This should be provided automatically when using MPI mode."
-                )
-            if max_nnz is None or nnz_out is None:
-                raise ValueError(
-                    "max_nnz and nnz_out are required for the distributed "
-                    "transpose of non-symmetric matrices. Ensure both are computed "
-                    "when creating the solver (via cache_mpi_metadata or dynamic "
-                    "computation)."
+                    "recvcounts_tuple, max_nnz, and nnz_out are required for the "
+                    "distributed transpose of non-symmetric matrices. Ensure they "
+                    "are computed when creating the solver (via cache_mpi_metadata "
+                    "or dynamic computation)."
                 )
             # Order the transpose after the forward solve (it otherwise reads
             # only A); without this XLA may interleave their MPI collectives in
@@ -373,15 +355,17 @@ def _get_solver_primitive_mpi(
             # Reconstruct BCSR for A^T
             A_T = jsp.BCSR((at_data, at_indices, at_indptr), shape=A.shape)
 
-            (adj_b, _), _ = solve(A_T, g_x, recvcounts, displs)
+            adj_b, _ = solve(A_T, g_x, col_to_combined, send_ids, recv_ghost_slot)
 
-        # Gather x across all ranks for gradient computation; order it after the
-        # backward solve (same as the transpose above) so all ranks issue MPI
+        # Gradient w.r.t. A: ∂L/∂A_ij = -adj_b[i] * x[j]. Fetch only the solution
+        # entries this rank's rows reference via the halo exchange, ordered after
+        # the backward solve (same as the transpose above) so all ranks issue MPI
         # collectives in a consistent order.
         x_bar, _ = jax.lax.optimization_barrier((x, adj_b))
-        x_global = allgather(x_bar, recvcounts, displs, comm_ptr_arr)
+        x_combined = _mpi4jax_halo_gather(
+            x_bar, send_ids, recv_ghost_slot, n_ghost, comm
+        )
 
-        # Compute ∂L/∂A: ∂L/∂A_ij = -adj_b[i] * x[j]
         n_local = A.shape[0]
         row_lengths = A.indptr[1:] - A.indptr[:-1]
         row_indices = jnp.repeat(
@@ -389,10 +373,10 @@ def _get_solver_primitive_mpi(
             row_lengths,
             total_repeat_length=len(A.data),
         )
-        grad_values = -adj_b[row_indices] * x_global[A.indices.astype(jnp.int32)]
+        grad_values = -adj_b[row_indices] * x_combined[col_to_combined]
         grad_A = jsp.BCSR((grad_values, A.indices, A.indptr), shape=A.shape)
 
-        return grad_A, adj_b, None, None
+        return grad_A, adj_b, None, None, None
 
     solve.defvjp(fwd, bwd)
     return solve
@@ -497,6 +481,7 @@ def solve(
             recvcounts_tuple = mpi_cache["recvcounts_tuple"]
             max_nnz = mpi_cache["max_nnz"]  # Always present in cache
             nnz_out = mpi_cache["nnz_out"]  # None when cached as symmetric
+            halo_plan = mpi_cache["halo_plan"]
             solver = _get_solver_primitive_mpi(
                 mpi_cache["config_str"],
                 mpi_cache["nglobal"],
@@ -506,12 +491,17 @@ def solve(
                 recvcounts_tuple=recvcounts_tuple,
                 max_nnz=max_nnz,
                 nnz_out=nnz_out,
+                n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
             )
-            recvcounts = jnp.array(recvcounts_tuple, dtype=jnp.int32)
-            displs = jnp.array(mpi_cache["displs_tuple"], dtype=jnp.int32)
 
-            (x, info), _ = solver(A_csr, b, recvcounts, displs)
+            x, info = solver(
+                A_csr,
+                b,
+                jnp.asarray(halo_plan.col_to_combined),
+                jnp.asarray(halo_plan.send_ids_2d),
+                jnp.asarray(halo_plan.recv_ghost_slot_2d),
+            )
         elif comm is not None:
             # Compute metadata dynamically
             import importlib.util
@@ -528,22 +518,29 @@ def solve(
             # can recover it for its collectives).
             comm_ptr = register_comm(comm)
 
-            # Gather partition sizes from all ranks for gradient allgather operation
+            # Gather partition sizes from all ranks (row partition + displacements)
             n_local = A_csr.shape[0]
             all_sizes_list = comm.allgather(n_local)
             recvcounts_val = np.array(all_sizes_list, dtype=np.int32)
             displs_val = np.cumsum(np.concatenate(([0], recvcounts_val[:-1]))).astype(
                 np.int32
             )
-
-            recvcounts = jnp.array(recvcounts_val)
-            displs = jnp.array(displs_val)
             recvcounts_tuple = tuple(recvcounts_val.tolist())
 
             # max nnz across ranks (transpose send buffers) + this rank's local
             # nnz(A^T) (its output buffers).
             max_nnz = max(comm.allgather(len(A_csr.data)))
             nnz_out = local_transpose_nnz(A_csr.indices, recvcounts_tuple, comm)
+
+            # Halo-exchange plan for the backward pass (fetches only the remote
+            # solution entries this rank references, instead of all-gathering).
+            row_start = int(displs_val[rank])
+            halo_plan = build_halo_plan(
+                A_csr.indices,
+                recvcounts_tuple,
+                (row_start, row_start + n_local),
+                comm,
+            )
 
             solver = _get_solver_primitive_mpi(
                 config_str,
@@ -554,9 +551,16 @@ def solve(
                 recvcounts_tuple=recvcounts_tuple,
                 max_nnz=max_nnz,
                 nnz_out=nnz_out,
+                n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
             )
-            (x, info), _ = solver(A_csr, b, recvcounts, displs)
+            x, info = solver(
+                A_csr,
+                b,
+                jnp.asarray(halo_plan.col_to_combined),
+                jnp.asarray(halo_plan.send_ids_2d),
+                jnp.asarray(halo_plan.recv_ghost_slot_2d),
+            )
 
     else:
         # Single-GPU mode: use int32 indices

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -105,6 +105,36 @@ def _mpi4jax_allgatherv(
     return jnp.concatenate(result_parts)
 
 
+def local_transpose_nnz(
+    col_indices: ArrayLike, recvcounts_tuple: tuple[int, ...], comm: "Comm"
+) -> int:
+    """This rank's local nonzero count of A^T (for transpose output sizing).
+
+    Rank r's A^T rows receive every A nonzero whose column it owns, so the local
+    nnz of A^T equals the local nnz of A only for structurally symmetric
+    patterns; in general it differs per rank, so the distributed transpose sizes
+    its output by this value rather than the input nnz. Computed once on the host
+    via an ``Alltoall`` of per-destination counts.
+
+    Args:
+        col_indices: This rank's local (global-numbered) CSR column indices.
+        recvcounts_tuple: Rows owned per rank (the row partition).
+        comm: MPI communicator.
+
+    Returns:
+        This rank's local nnz of A^T (a static Python int).
+    """
+    nranks = len(recvcounts_tuple)
+    # Half-open row-block boundaries [0, r0, r0+r1, ..., n_global].
+    row_bounds = np.cumsum(np.array([0, *recvcounts_tuple], dtype=np.int64))
+    cols = np.asarray(col_indices).astype(np.int64)
+    owner = np.clip(np.searchsorted(row_bounds, cols, side="right") - 1, 0, nranks - 1)
+    send_counts = np.bincount(owner, minlength=nranks).astype(np.int32)
+    recv_counts = np.empty(nranks, dtype=np.int32)
+    comm.Alltoall(send_counts, recv_counts)
+    return int(recv_counts.sum())
+
+
 def _mpi4jax_alltoallv_transpose(
     data: jax.Array,
     indices: jax.Array,
@@ -112,6 +142,7 @@ def _mpi4jax_alltoallv_transpose(
     recvcounts_tuple: tuple[int, ...],
     comm: "Comm",
     max_nnz: int,
+    nnz_out: int,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """
     Pure JAX implementation of distributed matrix transpose using mpi4jax.
@@ -133,7 +164,14 @@ def _mpi4jax_alltoallv_transpose(
         indptr: CSR row pointers
         recvcounts_tuple: Partition sizes (rows per rank)
         comm: MPI communicator
-        max_nnz: Maximum nnz across all ranks for buffer sizing (must be precalculated)
+        max_nnz: Max local nnz of A across ranks, for send-buffer sizing (the
+            send buffers are collective, so all ranks share this size).
+        nnz_out: This rank's local nnz of A^T, the exact output length. Under row
+            partitioning it differs from the input nnz whenever the pattern is
+            structurally nonsymmetric, so it must be provided (see
+            :func:`local_transpose_nnz`). Any slots beyond the actual received
+            count are padded with in-range explicit zeros (a no-op when the count
+            is exact).
     """
     import mpi4jax
 
@@ -252,10 +290,15 @@ def _mpi4jax_alltoallv_transpose(
         -1,  # Invalid positions (will be ignored)
     )
 
-    # Initialize output arrays with size = nnz (same as input for shape compatibility)
-    recv_data_flat = jnp.zeros(nnz, dtype=data.dtype)
-    recv_rows_flat = jnp.zeros(nnz, dtype=jnp.int32)
-    recv_cols_flat = jnp.zeros(nnz, dtype=jnp.int32)
+    # Size the output by nnz_out (this rank's local nnz of A^T), not the input
+    # nnz: they differ per rank for structurally nonsymmetric patterns, and using
+    # the input nnz would drop or strand received entries. real_count is the
+    # runtime count and equals nnz_out, so the scatter fills [0, nnz_out) exactly.
+    real_count = jnp.sum(recv_counts).astype(jnp.int32)
+
+    recv_data_flat = jnp.zeros(nnz_out, dtype=data.dtype)
+    recv_rows_flat = jnp.zeros(nnz_out, dtype=jnp.int32)
+    recv_cols_flat = jnp.zeros(nnz_out, dtype=jnp.int32)
 
     # Scatter valid elements to their positions
     # Use segment_sum pattern: only positions >= 0 are valid
@@ -278,6 +321,14 @@ def _mpi4jax_alltoallv_transpose(
     recv_rows_flat = recv_rows_flat.at[valid_positions].add(masked_rows)
     recv_cols_flat = recv_cols_flat.at[valid_positions].add(masked_cols)
 
+    # Defensive: if nnz_out exceeds the received count, pad the tail slots with an
+    # on-rank explicit zero at (A^T row 0, column my_row_start) -- harmless to
+    # AmgX and a no-op when nnz_out is exact (as from local_transpose_nnz). The
+    # pre-transpose fields map recv_cols -> local row, recv_rows -> global column.
+    pad_mask = jnp.arange(nnz_out, dtype=jnp.int32) >= real_count
+    recv_cols_flat = jnp.where(pad_mask, my_row_start, recv_cols_flat)
+    recv_rows_flat = jnp.where(pad_mask, my_row_start, recv_rows_flat)
+
     # For A^T: recv_cols becomes local row (was column in A), recv_rows becomes col (was row in A)
     at_rows_local = recv_cols_flat - my_row_start  # Local row index in A^T
     at_cols = recv_rows_flat  # Column index in A^T (global row in A)
@@ -297,17 +348,17 @@ def _mpi4jax_alltoallv_transpose(
     c_sorted = at_cols[sort_idx]
     v_sorted = recv_data_flat[sort_idx]
 
-    # Build indptr from row counts
+    # Build indptr from row counts (which sum to nnz_out).
     row_counts_at = jnp.bincount(r_sorted, length=n_local).astype(jnp.int32)
 
     out_indptr = jnp.zeros(n_local + 1, dtype=indptr.dtype)
     out_indptr = out_indptr.at[1:].set(jnp.cumsum(row_counts_at).astype(jnp.int32))
 
-    # Output data and indices (already sorted). For square matrices with
-    # fixed sparsity, transpose preserves nnz, so no padding/truncation needed.
+    # Output data and indices (already sorted); length is nnz_out, this rank's
+    # local nnz(A^T).
     out_data = v_sorted
     out_indices = c_sorted
-    out_indptr = out_indptr.at[-1].set(nnz)
+    out_indptr = out_indptr.at[-1].set(nnz_out)
 
     # Convert output indices to int64
     with temp_enable_x64():

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -105,6 +105,30 @@ def _mpi4jax_allgatherv(
     return jnp.concatenate(result_parts)
 
 
+# mpi4py communicators are unhashable, so the differentiable MPI primitive is
+# keyed on the communicator's integer address. This registry maps that address
+# back to the live communicator so the backward pass can run its collectives on
+# the user's communicator (possibly a subcommunicator), not MPI.COMM_WORLD.
+_COMM_BY_PTR: dict[int, "Comm"] = {}
+
+
+def register_comm(comm: "Comm") -> int:
+    """Record `comm` by its address and return that address (see _COMM_BY_PTR)."""
+    from mpi4py import MPI
+
+    ptr = MPI._addressof(comm)
+    _COMM_BY_PTR[ptr] = comm
+    return ptr
+
+
+def resolve_comm(comm_ptr: int) -> "Comm":
+    """Recover the communicator registered under `comm_ptr` (see register_comm),
+    falling back to MPI.COMM_WORLD if it was never registered."""
+    from mpi4py import MPI
+
+    return _COMM_BY_PTR.get(comm_ptr, MPI.COMM_WORLD)
+
+
 def local_transpose_nnz(
     col_indices: ArrayLike, recvcounts_tuple: tuple[int, ...], comm: "Comm"
 ) -> int:

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -1,7 +1,7 @@
 """MPI utilities for distributed AmgX solving."""
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 import jax
 import jax.experimental.sparse as jsp
@@ -157,6 +157,142 @@ def local_transpose_nnz(
     recv_counts = np.empty(nranks, dtype=np.int32)
     comm.Alltoall(send_counts, recv_counts)
     return int(recv_counts.sum())
+
+
+class HaloPlan(NamedTuple):
+    """Static communication plan for the backward pass halo exchange.
+
+    The gradient ``dL/dA_ij = -adj_b[i] * x[j]`` needs ``x[j]`` only for the
+    global columns ``j`` this rank's local rows reference. Those split into
+    locally owned columns (already in ``x_local``) and a small set of remote
+    "ghost" columns owned by other ranks. This plan, built once from the fixed
+    sparsity pattern, fetches only the ghost values instead of all-gathering the
+    entire global solution.
+
+    Fields (all static, captured at setup):
+        n_local: Rows owned by this rank.
+        n_ghost: Distinct remote columns this rank references.
+        max_per_rank: Padded per-rank chunk size for the ``alltoall`` (a global
+            max, so every rank uses the same buffer size).
+        col_to_combined: For each local nonzero, its index into the combined
+            ``[x_local | x_ghost]`` vector (length nnz).
+        send_ids_2d: Local ``x`` indices to send to each rank, padded
+            ``(nranks, max_per_rank)``.
+        recv_ghost_slot_2d: Ghost slot each received value fills, padded
+            ``(nranks, max_per_rank)`` with ``n_ghost`` as an ignored sentinel.
+    """
+
+    n_local: int
+    n_ghost: int
+    max_per_rank: int
+    col_to_combined: np.ndarray
+    send_ids_2d: np.ndarray
+    recv_ghost_slot_2d: np.ndarray
+
+
+def build_halo_plan(
+    local_col_indices: ArrayLike,
+    recvcounts_tuple: tuple[int, ...],
+    partition_info: tuple[int, int],
+    comm: "Comm",
+) -> HaloPlan:
+    """Build the backward-pass halo-exchange plan (see :class:`HaloPlan`).
+
+    Determines which remote solution entries this rank needs for its local
+    gradient and the reciprocal entries it must supply to other ranks, via two
+    small host-side collectives (``Alltoall`` of counts, ``Alltoallv`` of the
+    requested global indices). The sparsity pattern is fixed, so this runs once.
+    """
+    from mpi4py import MPI
+
+    nranks = len(recvcounts_tuple)
+    row_start, row_end = partition_info
+    n_local = row_end - row_start
+    row_bounds = np.cumsum(np.array([0, *recvcounts_tuple], dtype=np.int64))
+
+    cols = np.asarray(local_col_indices).astype(np.int64)
+    uniq = np.unique(cols)
+    is_remote = (uniq < row_start) | (uniq >= row_end)
+    ghost_global_ids = uniq[is_remote]  # sorted (np.unique is sorted)
+    n_ghost = int(ghost_global_ids.size)
+
+    # Owner rank of each ghost column, and how many ghosts this rank needs from
+    # each owner (recv_counts). The reciprocal send_counts come from an Alltoall.
+    ghost_owner = np.clip(
+        np.searchsorted(row_bounds, ghost_global_ids, side="right") - 1, 0, nranks - 1
+    ).astype(np.int32)
+    recv_counts = np.bincount(ghost_owner, minlength=nranks).astype(np.int32)
+    send_counts = np.empty(nranks, dtype=np.int32)
+    comm.Alltoall(recv_counts, send_counts)
+
+    recv_displs = np.insert(np.cumsum(recv_counts[:-1]), 0, 0).astype(np.int32)
+    send_displs = np.insert(np.cumsum(send_counts[:-1]), 0, 0).astype(np.int32)
+
+    # Group this rank's requests by owner (stable keeps ghost order within owner),
+    # then tell each owner which global ids we want and learn which ids others
+    # want from us.
+    order = np.argsort(ghost_owner, kind="stable")
+    ghost_ids_by_owner = ghost_global_ids[order].astype(np.int64)
+    ghost_slot_by_owner = order.astype(np.int32)
+
+    requested_ids = np.empty(int(send_counts.sum()), dtype=np.int64)
+    comm.Alltoallv(
+        [ghost_ids_by_owner, recv_counts, recv_displs, MPI.INT64_T],
+        [requested_ids, send_counts, send_displs, MPI.INT64_T],
+    )
+    send_local_ids = (requested_ids - row_start).astype(np.int32)
+
+    # alltoall needs one shared chunk size across all ranks.
+    max_per_rank = int(
+        comm.allreduce(int(max(send_counts.max(), recv_counts.max())), op=MPI.MAX)
+    )
+    max_per_rank = max(max_per_rank, 1)
+
+    send_ids_2d = np.zeros((nranks, max_per_rank), dtype=np.int32)
+    recv_ghost_slot_2d = np.full((nranks, max_per_rank), n_ghost, dtype=np.int32)
+    for p in range(nranks):
+        sc = int(send_counts[p])
+        if sc:
+            send_ids_2d[p, :sc] = send_local_ids[send_displs[p] : send_displs[p] + sc]
+        rc = int(recv_counts[p])
+        if rc:
+            recv_ghost_slot_2d[p, :rc] = ghost_slot_by_owner[
+                recv_displs[p] : recv_displs[p] + rc
+            ]
+
+    # Map each local nonzero to its slot in the combined [x_local | x_ghost].
+    local_mask = (cols >= row_start) & (cols < row_end)
+    ghost_pos = np.clip(np.searchsorted(ghost_global_ids, cols), 0, max(n_ghost - 1, 0))
+    col_to_combined = np.where(
+        local_mask, cols - row_start, n_local + ghost_pos
+    ).astype(np.int32)
+
+    return HaloPlan(
+        n_local, n_ghost, max_per_rank, col_to_combined, send_ids_2d, recv_ghost_slot_2d
+    )
+
+
+def _mpi4jax_halo_gather(
+    x_local: jax.Array,
+    send_ids: jax.Array,
+    recv_ghost_slot: jax.Array,
+    n_ghost: int,
+    comm: "Comm",
+) -> jax.Array:
+    """Assemble ``[x_local | x_ghost]`` by exchanging only the needed remote
+    solution entries (see :class:`HaloPlan` for the plan arrays). ``send_ids``
+    and ``recv_ghost_slot`` are the padded ``(nranks, max_per_rank)`` plan
+    arrays; ``n_ghost`` is a static ghost count. JIT-compatible, GPU-direct."""
+    import mpi4jax
+
+    send_buf = x_local[send_ids]  # (nranks, max_per_rank); padded slots gather x[0]
+    recv_buf = mpi4jax.alltoall(send_buf, comm=comm)
+
+    # Scatter valid received values into ghost slots; padded slots hit the
+    # sentinel index n_ghost, which is sliced off.
+    x_ghost = jnp.zeros(n_ghost + 1, dtype=x_local.dtype)
+    x_ghost = x_ghost.at[recv_ghost_slot.reshape(-1)].set(recv_buf.reshape(-1))
+    return jnp.concatenate([x_local, x_ghost[:n_ghost]])
 
 
 def _mpi4jax_alltoallv_transpose(

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -551,3 +551,100 @@ def test_partition_operator(mpi_context):
     )
 
     jax.config.update("jax_enable_x64", False)
+
+
+@pytest.mark.mpi(min_size=3)
+def test_mpi_subcommunicator(mpi_context):
+    """The differentiable solve must run its backward collectives on the user's
+    communicator, not MPI.COMM_WORLD.
+
+    The solve runs on a subcommunicator that is a proper subset of COMM_WORLD
+    (the last rank stays idle and only rejoins at the fixture's COMM_WORLD
+    barrier). If the backward pass used COMM_WORLD it would deadlock waiting on
+    the idle rank; with the fix it uses the subcommunicator and completes, and
+    the gradient (summed over the subcommunicator) matches finite difference.
+    """
+    from mpi4py import MPI
+
+    comm, rank, nranks = mpi_context
+    jax.config.update("jax_enable_x64", True)
+
+    color = 0 if rank < nranks - 1 else MPI.UNDEFINED
+    sub = comm.Split(color, key=rank)
+    try:
+        if sub != MPI.COMM_NULL:
+            sub_rank, sub_size = sub.Get_rank(), sub.Get_size()
+            n_global = 4 * sub_size
+            b_local, _, _ = partition_vector(
+                jnp.ones(n_global, jnp.float64), sub_rank, sub_size
+            )
+
+            def loss(theta):
+                A, rs, re = tridiagonal_matrix_distributed(
+                    n_global, sub_rank, sub_size, diagonal_value=theta
+                )
+                x, _ = jaxamg.solve(
+                    A,
+                    b_local,
+                    comm=sub,
+                    nglobal=n_global,
+                    partition_info=(rs, re),
+                    solver="CG",
+                )
+                return jnp.sum(x**2)
+
+            theta = 5.0
+            g_total = sub.allreduce(float(jax.grad(loss)(theta)), op=MPI.SUM)
+
+            def total_loss(t):
+                return sub.allreduce(float(loss(t)), op=MPI.SUM)
+
+            eps = 1e-5
+            g_fd = (total_loss(theta + eps) - total_loss(theta - eps)) / (2 * eps)
+            np.testing.assert_allclose(g_total, g_fd, rtol=1e-4, atol=1e-8)
+    finally:
+        if sub != MPI.COMM_NULL:
+            sub.Free()
+        jax.config.update("jax_enable_x64", False)
+
+
+@pytest.mark.mpi(min_size=3)
+def test_mpi_multiple_communicators(mpi_context):
+    """A process may perform AmgX solves on more than one communicator in the
+    same run, and each must receive its own AmgX resources (keyed per
+    communicator) rather than sharing the first communicator's. A COMM_WORLD
+    solve is followed by a proper-subset subcommunicator solve (the last rank
+    idle), with no finalize in between; both must succeed.
+    """
+    from mpi4py import MPI
+
+    comm, rank, nranks = mpi_context
+    config = {
+        "solver": "PCG",
+        "preconditioner": {"solver": "MULTICOLOR_DILU", "max_iters": 100},
+    }
+
+    def dist_solve(c, c_rank, c_size):
+        n = 4 * c_size
+        A, rs, re = tridiagonal_matrix_distributed(n, c_rank, c_size, 4.0)
+        b, _, _ = partition_vector(jnp.ones(n), c_rank, c_size)
+        _, info = jaxamg.solve(
+            A, b, comm=c, nglobal=n, partition_info=(rs, re), config=config
+        )
+        return info
+
+    # 1. Solve on COMM_WORLD -- creates the world communicator's resources.
+    info_world = dist_solve(comm, rank, nranks)
+    assert info_world["status"] == jaxamg.AMGXStatus.SUCCESS
+
+    # 2. Solve on a proper-subset subcommunicator (last rank idle) -- must get its
+    #    own resources rather than reusing the COMM_WORLD ones.
+    color = 0 if rank < nranks - 1 else MPI.UNDEFINED
+    sub = comm.Split(color, key=rank)
+    try:
+        if sub != MPI.COMM_NULL:
+            info_sub = dist_solve(sub, sub.Get_rank(), sub.Get_size())
+            assert info_sub["status"] == jaxamg.AMGXStatus.SUCCESS
+    finally:
+        if sub != MPI.COMM_NULL:
+            sub.Free()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -95,7 +95,7 @@ def test_mpi_autodiff_jit(mpi_context, enable_x64):
         n_global, rank, nranks, 4.0
     )
     mpi_cache = jaxamg.cache_mpi_metadata(
-        config, comm, n_global, (row_start, row_end), dummy_A
+        config, comm, n_global, (row_start, row_end), dummy_A, is_symmetric=True
     )
 
     def loss_fn(diag_val):
@@ -233,7 +233,10 @@ def test_mpi_transpose(mpi_context):
     comm, rank, nranks = mpi_context
     from mpi4py import MPI
 
-    from jaxamg.mpi_utils import _mpi4jax_alltoallv_transpose
+    from jaxamg.mpi_utils import (
+        _mpi4jax_alltoallv_transpose,
+        local_transpose_nnz,
+    )
 
     grid_size = 4
     n_global = grid_size**2
@@ -266,12 +269,21 @@ def test_mpi_transpose(mpi_context):
     row_counts_global = comm.allgather(n_local)
     recvcounts_tuple = tuple(row_counts_global)
 
-    # Calculate max_nnz across ranks
+    # Calculate max_nnz across ranks (send buffers) and this rank's local
+    # nnz(A^T) (output). For this structurally symmetric graph the latter equals
+    # the local nnz of A, so both transpose directions use the same value.
     max_nnz = comm.allreduce(nnz_local, op=MPI.MAX)
+    nnz_out = local_transpose_nnz(A_local.indices, recvcounts_tuple, comm)
 
     # 3. Compute A^T
     data_T, indices_T, indptr_T = _mpi4jax_alltoallv_transpose(
-        new_data, A_local.indices, A_local.indptr, recvcounts_tuple, comm, max_nnz
+        new_data,
+        A_local.indices,
+        A_local.indptr,
+        recvcounts_tuple,
+        comm,
+        max_nnz,
+        nnz_out,
     )
 
     # Verify A^T is different from A (sanity check)
@@ -279,7 +291,7 @@ def test_mpi_transpose(mpi_context):
 
     # 4. Compute (A^T)^T -> should be A
     data_TT, indices_TT, indptr_TT = _mpi4jax_alltoallv_transpose(
-        data_T, indices_T, indptr_T, recvcounts_tuple, comm, max_nnz
+        data_T, indices_T, indptr_T, recvcounts_tuple, comm, max_nnz, nnz_out
     )
 
     # 5. Verify (A^T)^T == A
@@ -291,7 +303,7 @@ def test_mpi_transpose(mpi_context):
     @jax.jit
     def transpose_jit_fn(data, indices, indptr):
         return _mpi4jax_alltoallv_transpose(
-            data, indices, indptr, recvcounts_tuple, comm, max_nnz
+            data, indices, indptr, recvcounts_tuple, comm, max_nnz, nnz_out
         )
 
     # Run JIT-compiled transpose
@@ -303,6 +315,141 @@ def test_mpi_transpose(mpi_context):
     np.testing.assert_array_equal(indptr_T_jit, indptr_T)
     np.testing.assert_array_equal(indices_T_jit, indices_T)
     np.testing.assert_allclose(data_T_jit, data_T)
+
+
+@pytest.mark.mpi(min_size=2)
+def test_mpi_transpose_nonsymmetric_nnz(mpi_context):
+    """Distributed transpose of a structurally nonsymmetric matrix whose row
+    ownership gives different local nnz for A and A^T.
+
+    A has a dense first column plus a diagonal, so global column 0 is nonzero in
+    every row. The rank owning global row 0 therefore holds a dense A^T row (n
+    entries) while its A rows hold ~2 -- exactly the unequal-count case an
+    nnz(A)-sized output would truncate (dropping the off-diagonal transpose
+    entries). Sizing the output by local nnz(A^T) must recover the full A^T.
+    """
+    comm, rank, nranks = mpi_context
+    import scipy.sparse as sp
+    from mpi4py import MPI
+
+    from jaxamg.mpi_utils import _mpi4jax_alltoallv_transpose, local_transpose_nnz
+
+    n = 4 * nranks
+    rows, cols, vals = [], [], []
+    for i in range(n):
+        rows.append(i)  # dense first column: A[i, 0] != 0 for every row i
+        cols.append(0)
+        vals.append(2.0 + i)
+        if i > 0:  # diagonal (i == 0 already covered by the column-0 entry)
+            rows.append(i)
+            cols.append(i)
+            vals.append(3.0 + i)
+    A = sp.csr_matrix((vals, (rows, cols)), shape=(n, n), dtype=np.float32)
+    A.sort_indices()
+
+    A_local, row_start, row_end = partition_csr_matrix(A, rank, nranks)
+    n_local = row_end - row_start
+    recvcounts_tuple = tuple(comm.allgather(n_local))
+    max_nnz = comm.allreduce(int(A_local.data.shape[0]), op=MPI.MAX)
+    nnz_out = local_transpose_nnz(A_local.indices, recvcounts_tuple, comm)
+
+    data_T, indices_T, indptr_T = _mpi4jax_alltoallv_transpose(
+        A_local.data,
+        A_local.indices,
+        A_local.indptr,
+        recvcounts_tuple,
+        comm,
+        max_nnz,
+        nnz_out,
+    )
+    data_T = np.asarray(data_T)
+    indices_T = np.asarray(indices_T)
+    indptr_T = np.asarray(indptr_T)
+
+    # Ground truth: this rank's rows of the true global transpose.
+    at_true = A.T.tocsr()[row_start:row_end].toarray()
+
+    got = np.zeros((n_local, n), dtype=np.float64)
+    for r in range(n_local):
+        for k in range(int(indptr_T[r]), int(indptr_T[r + 1])):
+            got[r, int(indices_T[k])] += data_T[k]
+
+    np.testing.assert_allclose(got, at_true, atol=1e-6)
+
+    # The scenario must actually exercise unequal local counts on some rank
+    # (otherwise it would not distinguish the fix from the old nnz(A) sizing).
+    grew = comm.allreduce(int(nnz_out != int(A_local.data.shape[0])), op=MPI.SUM)
+    assert grew > 0, "test matrix should give unequal local nnz across transpose"
+
+
+@pytest.mark.mpi(min_size=2)
+def test_mpi_autodiff_nonsymmetric(mpi_context):
+    """End-to-end distributed reverse-mode AD through a structurally nonsymmetric
+    matrix (is_symmetric=False), driving the distributed-transpose backward path
+    with unequal local nnz between A and A^T.
+
+    A has a dense first column plus a diagonal (diagonally dominant), so global
+    column 0 is nonzero in every row and local nnz(A^T) != nnz(A). The
+    distributed VJP returns each rank's contribution to the gradient of the total
+    loss L(theta) = sum_r sum(x_local_r ** 2) (the collective backward solve
+    combines all ranks' cotangents), so the summed gradient is checked against a
+    central finite difference of L.
+    """
+    import jax.experimental.sparse as jsp
+    from mpi4py import MPI
+
+    comm, rank, nranks = mpi_context
+    jax.config.update("jax_enable_x64", True)
+    try:
+        n_global = 4 * nranks
+        row_start, row_end, n_local = get_partition_info(n_global, rank, nranks)
+        b_local, _, _ = partition_vector(
+            jnp.ones(n_global, dtype=jnp.float64), rank, nranks
+        )
+
+        # Static pattern for this rank's rows: dense first column + diagonal.
+        loc_indices, is_diag, ptr, k = [], [], [0], 0
+        for gi in range(row_start, row_end):
+            if gi == 0:  # global row 0: diagonal only (it sits in column 0)
+                loc_indices.append(0)
+                is_diag.append(1.0)
+                k += 1
+            else:  # (i, 0) off-diagonal and (i, i) diagonal
+                loc_indices.extend([0, gi])
+                is_diag.extend([0.0, 1.0])
+                k += 2
+            ptr.append(k)
+        indices = jnp.asarray(loc_indices, dtype=jnp.int32)
+        indptr = jnp.asarray(ptr, dtype=jnp.int32)
+        diag_mask = jnp.asarray(is_diag, dtype=jnp.float64)
+
+        def loss_fn(theta):
+            data = jnp.where(diag_mask > 0, 4.0 + theta, -1.0)
+            A_local = jsp.BCSR((data, indices, indptr), shape=(n_local, n_global))
+            x_local, _ = jaxamg.solve(
+                A_local,
+                b_local,
+                comm=comm,
+                nglobal=n_global,
+                partition_info=(row_start, row_end),
+                solver="GMRES",
+                preconditioner="JACOBI_L1",
+                max_iters=200,
+                tolerance=1e-12,
+            )
+            return jnp.sum(x_local**2)
+
+        theta = 5.0
+        g_total = comm.allreduce(float(jax.grad(loss_fn)(theta)), op=MPI.SUM)
+
+        def total_loss(t):
+            return comm.allreduce(float(loss_fn(t)), op=MPI.SUM)
+
+        eps = 1e-5
+        g_fd = (total_loss(theta + eps) - total_loss(theta - eps)) / (2 * eps)
+        np.testing.assert_allclose(g_total, g_fd, rtol=1e-4, atol=1e-8)
+    finally:
+        jax.config.update("jax_enable_x64", False)
 
 
 @pytest.mark.mpi(min_size=2)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -648,3 +648,116 @@ def test_mpi_multiple_communicators(mpi_context):
     finally:
         if sub != MPI.COMM_NULL:
             sub.Free()
+
+
+@pytest.mark.mpi(min_size=2)
+def test_mpi_amg_preconditioner(mpi_context):
+    """Distributed solve with the classical-AMG preconditioner.
+
+    Covers the distributed classical-AMG upload path (an explicit contiguous
+    partition vector plus the 32-bit global-index upload,
+    ``AMGX_matrix_upload_all_global_32``) that a correct multi-rank classical-AMG
+    hierarchy requires. The other MPI tests use DILU/Jacobi/plain-CG, which do not
+    build the AMG halo this path sets up, so this is the only coverage of it.
+    A single AMG solve, so it does not depend on any AmgX-internal repeated-solve
+    behavior.
+    """
+    comm, rank, nranks = mpi_context
+
+    grid_size = 16
+    n = grid_size**2
+
+    A_local, row_start, row_end = poisson_matrix_distributed(
+        grid_size, grid_size, rank, nranks
+    )
+    b_global = rhs_linear(n)
+    b_local, _, _ = partition_vector(b_global, rank, nranks)
+
+    x_local, info = jaxamg.solve(
+        A_local,
+        b_local,
+        comm=comm,
+        nglobal=n,
+        partition_info=(row_start, row_end),
+        solver="PCG",
+        preconditioner={"solver": "AMG"},
+        tolerance=1e-8,
+        max_iters=200,
+    )
+    x = gather_vector(x_local, comm, root=0)
+
+    assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+    if rank == 0:
+        A_global = poisson_matrix(grid_size)
+        # float32 AMG: residual plateaus near single precision, so 1e-4.
+        np.testing.assert_allclose(A_global @ x, b_global, atol=1e-4)
+
+
+@pytest.mark.mpi(min_size=2)
+def test_mpi_repeated_solve_warm_cache(mpi_context):
+    """Repeated distributed solves of the same sparsity pattern reuse the cached
+    per-communicator matrix structure and solver (the warm path:
+    ``AMGX_matrix_replace_coefficients`` + ``AMGX_solver_resetup`` over cache-owned
+    structure buffers). Two invariants:
+
+    1. Solving the identical system three times returns the same correct solution
+       every time (the warm path must be deterministic; no cross-solve drift).
+    2. Solving a value-scaled system with the same pattern (a cache hit) must
+       install the new coefficients, so 2A x = b gives x scaled by 1/2 -- not a
+       silent reuse of the previous matrix.
+
+    Uses a non-AMG preconditioner and a small matrix, so it exercises the JAX
+    warm-path logic without depending on any AmgX-internal behavior.
+    """
+    import jax.experimental.sparse as jsp
+
+    comm, rank, nranks = mpi_context
+
+    grid_size = 16
+    n = grid_size**2
+    A_local, row_start, row_end = poisson_matrix_distributed(
+        grid_size, grid_size, rank, nranks
+    )
+    b_global = rhs_linear(n)
+    b_local, _, _ = partition_vector(b_global, rank, nranks)
+
+    solve_kwargs = dict(
+        comm=comm,
+        nglobal=n,
+        partition_info=(row_start, row_end),
+        solver="PCG",
+        preconditioner={"solver": "MULTICOLOR_DILU", "max_iters": 50},
+        tolerance=1e-8,
+        max_iters=300,
+    )
+
+    # (1) Identical system solved three times -> warm-path (cache-hit) reuse must
+    #     be correct and deterministic across repeats.
+    solutions = []
+    for _ in range(3):
+        x_local, info = jaxamg.solve(A_local, b_local, **solve_kwargs)
+        assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+        solutions.append(gather_vector(x_local, comm, root=0))
+
+    # (2) Same pattern, scaled values (still a cache hit) -> replace_coefficients
+    #     must install the new values, so the solution scales by 1/2.
+    A_scaled = jsp.BCSR(
+        (A_local.data * 2.0, A_local.indices, A_local.indptr), shape=A_local.shape
+    )
+    x_local, info = jaxamg.solve(A_scaled, b_local, **solve_kwargs)
+    assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+    x_scaled = gather_vector(x_local, comm, root=0)
+
+    if rank == 0:
+        A_global = poisson_matrix(grid_size)
+        # float32 residuals plateau near single precision, so 1e-4.
+        for x in solutions:
+            np.testing.assert_allclose(A_global @ x, b_global, atol=1e-4)
+        # No warm-path drift: repeats agree far tighter than any real drift
+        # (the corruption this guards against changes the solution by O(1)).
+        np.testing.assert_allclose(solutions[1], solutions[0], atol=1e-5)
+        np.testing.assert_allclose(solutions[2], solutions[0], atol=1e-5)
+        # New coefficients really took effect: (2A) x = b  =>  A x = b / 2, and
+        # x = x0 / 2 rather than a silent reuse of the first matrix.
+        np.testing.assert_allclose(A_global @ x_scaled, 0.5 * b_global, atol=1e-4)
+        np.testing.assert_allclose(x_scaled, 0.5 * solutions[0], atol=1e-4)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -8,6 +8,7 @@ import pytest
 import scipy.sparse.linalg as spla
 
 import jaxamg
+import jaxamg.jaxamg as jaxamg_module
 from jaxamg import config as amgx_config
 from jaxamg.jaxamg import _amgx_solve_impl
 from jaxamg.matrices import (
@@ -274,6 +275,53 @@ class TestSolver:
 
         assert info_backend[2] == info_explicit[2] == jaxamg.AMGXStatus.SUCCESS
         np.testing.assert_allclose(lam_backend, lam_explicit)
+
+    def test_reuse_setup_forwards_to_adjoint_solve(self, monkeypatch):
+        """The VJP must use the same reuse_setup mode as the forward solve."""
+        calls = []
+
+        def fake_amgx_solve(
+            row_ptrs,
+            col_indices,
+            values,
+            b,
+            config_str="",
+            transpose_solve=False,
+            return_stats=False,
+            reuse_setup=False,
+        ):
+            calls.append(
+                {
+                    "transpose_solve": bool(transpose_solve),
+                    "reuse_setup": bool(reuse_setup),
+                }
+            )
+            return b, jnp.array([0, 0, 0], dtype=b.dtype)
+
+        monkeypatch.setattr(jaxamg_module, "_amgx_solve_impl", fake_amgx_solve)
+        jaxamg_module._get_solver_primitive.cache_clear()
+
+        try:
+            A = poisson_matrix(2, skew=0.7)
+            b = rhs_ones(A.shape[0])
+            solver = jaxamg_module._get_solver_primitive(
+                "test-config", reuse_setup=True
+            )
+
+            def loss(rhs):
+                x, _ = solver(A, rhs)
+                return jnp.sum(x)
+
+            grad_b = jax.grad(loss)(b)
+
+            assert grad_b.shape == b.shape
+            assert calls[0] == {"transpose_solve": False, "reuse_setup": True}
+            assert any(
+                call == {"transpose_solve": True, "reuse_setup": True}
+                for call in calls[1:]
+            )
+        finally:
+            jaxamg_module._get_solver_primitive.cache_clear()
 
     def test_save_stats_file(self, tmp_path):
         """Test that jaxamg.solve generates a stats file correctly."""

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -364,3 +364,53 @@ class TestSolver:
 
         with pytest.raises(ValueError, match="does not support batched BCSR matrices"):
             jaxamg.solve(A_batched, b)
+
+    def test_cache_distinguishes_sparsity_pattern(self):
+        """Reusing the solver cache must respect col_indices, not just row_ptrs.
+
+        Two SPD matrices with identical row pointers and nnz but different column
+        indices are solved back-to-back in one process. The process-global C++
+        solver cache must treat them as distinct structures; if it keys only on
+        the row pointers, the second solve reuses the first matrix's graph (a
+        values-only ``AMGX_matrix_replace_coefficients``) and returns a wrong
+        solution.
+        """
+        import scipy.sparse as sp
+
+        def cycle_laplacian(n, step, alpha):
+            # alpha*I + graph Laplacian of the 2-regular graph i <-> (i +/- step).
+            # Exactly 3 nonzeros per row, so row_ptrs are independent of `step`;
+            # only the column indices (the pattern) change with `step`.
+            rows, cols, vals = [], [], []
+            for i in range(n):
+                nbrs = sorted({(i - step) % n, (i + step) % n})
+                assert len(nbrs) == 2 and i not in nbrs
+                for j in (i, *nbrs):
+                    rows.append(i)
+                    cols.append(j)
+                    vals.append((alpha + 2.0) if j == i else -1.0)
+            A = sp.csr_matrix((vals, (rows, cols)), shape=(n, n), dtype=np.float32)
+            A.sort_indices()
+            return A
+
+        n = 64
+        A1 = cycle_laplacian(n, step=1, alpha=1.0)
+        A2 = cycle_laplacian(n, step=2, alpha=3.0)
+
+        # Same row pointers and nnz, different columns: only the pattern differs.
+        np.testing.assert_array_equal(A1.indptr, A2.indptr)
+        assert A1.nnz == A2.nnz
+        assert not np.array_equal(A1.indices, A2.indices)
+
+        rng = np.random.default_rng(0)
+        b = jnp.asarray(rng.standard_normal(n).astype(np.float32))
+        cfg = {"solver": "CG", "tolerance": 1e-10, "max_iters": 1000}
+
+        # Clean cache so A1 populates it and A2 must not silently reuse it.
+        jaxamg.clear_solver_cache()
+        x1, _ = jaxamg.solve(A1, b, config=cfg)
+        x2, _ = jaxamg.solve(A2, b, config=cfg)
+
+        # Each solution must satisfy its own system.
+        np.testing.assert_allclose(A1 @ np.asarray(x1), np.asarray(b), atol=1e-4)
+        np.testing.assert_allclose(A2 @ np.asarray(x2), np.asarray(b), atol=1e-4)


### PR DESCRIPTION
This PR improves JAX-AMG's MPI path for repeated solves and distributed autodiff, with various other improvements and fixes.

- Fixes solver cache keys to include the full sparsity pattern, preventing incorrect reuse across matrices with matching row pointers but different column indices.
- Fixes distributed classical AMG setup by passing an explicit partition vector and using the 32-bit global upload path.
- Fixes MPI reverse-mode AD for nonsymmetric matrices by sizing distributed transpose outputs correctly and replacing full solution all-gather with sparse halo exchange.
- Ensures MPI backward collectives use the user-provided communicator, including subcommunicators.
- Adds `reuse_setup` support for cached AmgX solves, including the adjoint solve path.
- Adds MPI and single-GPU tests covering repeated warm solves, AMG preconditioner setup, nonsymmetric transpose/autodiff, communicator handling, and `reuse_setup` VJP behavior.