### PR TITLE
Add SuiteSparse matrix helper and nonsymmetric MPI autodiff demo

### DIFF
--- a/demo/mpi_autodiff.py
+++ b/demo/mpi_autodiff.py
@@ -1,5 +1,5 @@
 """
-Deo: MPI-distributed automatic differentiation.
+Demo: MPI-distributed automatic differentiation.
 
 Demonstrates that gradients computed via MPI-distributed solver match
 the single-GPU reference implementation.

--- a/demo/mpi_nonsysmmetric_matrix_autodiff.py
+++ b/demo/mpi_nonsysmmetric_matrix_autodiff.py
@@ -1,0 +1,144 @@
+"""
+Demo: MPI-distributed automatic differentiation of torso3 (a structurally non-symmetric system).
+
+Usage:
+    mpirun -n 2 python demo/mpi_nonsysmmetric_matrix_autodiff.py
+"""
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from mpi4py import MPI
+
+import jaxamg
+from jaxamg.matrices import download_suitesparse_matrix
+from jaxamg.mpi_utils import gather_vector, partition_csr_matrix
+
+
+def make_rhs(row_start, row_end, n_global):
+    local_idx = jnp.arange(row_start, row_end, dtype=np.float64)
+    full_idx = jnp.arange(n_global, dtype=np.float64)
+    rhs_func = lambda x: jnp.sin(0.001 * (x + 1.0)) + 0.25 * jnp.cos(
+        0.00013 * (x + 1.0)
+    )
+    local = rhs_func(local_idx)
+    full = rhs_func(full_idx)
+    return local / jnp.linalg.norm(full) * jnp.sqrt(n_global)
+
+
+def main():
+    jax.config.update("jax_enable_x64", True)
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    nranks = comm.Get_size()
+
+    gpus = jax.devices()
+    dev = gpus[rank % len(gpus)]
+    jax.config.update("jax_default_device", dev)
+
+    if rank == 0:
+        print("Setting up MPI automatic differentiation for torso3 matrix...")
+        print(f"MPI ranks: {nranks}")
+        print("Downloading/loading torso3 from SuiteSparse...")
+        download_suitesparse_matrix("Norris/torso3")
+
+    # Solver configuration
+    config = {
+        "config_version": 2,
+        "solver": {
+            "solver": "FGMRES",
+            "gmres_n_restart": 100,
+            "max_iters": 3000,
+            "convergence": "RELATIVE_INI",
+            "tolerance": 1e-14,
+            "norm": "L2",
+            "monitor_residual": 1,
+            "communicator": "MPI",
+            "preconditioner": {
+                "solver": "AMG",
+                "algorithm": "CLASSICAL",
+                "selector": "PMIS",
+                "interpolator": "D2",
+                "strength_threshold": 0.5,
+                "max_levels": 100,
+                "cycle": "V",
+                "presweeps": 2,
+                "postsweeps": 3,
+                "max_iters": 1,
+                "coarse_solver": "DENSE_LU_SOLVER",
+                "dense_lu_num_rows": 64,
+                "min_coarse_rows": 64,
+                "smoother": {"solver": "MULTICOLOR_DILU"},
+            },
+            "store_res_history": 1,
+        },
+    }
+
+    A_global = download_suitesparse_matrix("Norris/torso3")
+    n = A_global.shape[0]
+
+    A_local, row_start, row_end = partition_csr_matrix(A_global, rank, nranks)
+    b = make_rhs(row_start, row_end, n)
+
+    # Pre-cache MPI metadata
+    mpi_cache = jaxamg.cache_mpi_metadata(
+        config,
+        comm,
+        n,
+        (row_start, row_end),
+        A_local,
+        is_symmetric=False,
+    )
+
+    # Attach MPI cache to matrix
+    A_cached = jaxamg.with_cache(A_local, mpi=mpi_cache, is_symmetric=False)
+
+    def loss_fn(rhs):
+        x, _ = jaxamg.solve(A_cached, rhs)
+        return 0.5 * jnp.sum(x**2)
+
+    # JIT-compile the gradient computation
+    grad_fn = jax.jit(jax.grad(loss_fn))
+
+    if rank == 0:
+        print("\nComputing RHS gradient...")
+
+    comm.Barrier()
+    t0 = time.time()
+    grad_local = grad_fn(b)
+    grad_local.block_until_ready()
+    gradient_time = comm.allreduce(time.time() - t0, op=MPI.MAX)
+
+    comm.Barrier()
+    t1 = time.time()
+    x_local, info = jaxamg.solve(A_cached, b)
+    x_local.block_until_ready()
+    solve_time = comm.allreduce(time.time() - t1, op=MPI.MAX)
+
+    x_global = gather_vector(x_local, comm, root=0)
+    g_global = gather_vector(grad_local, comm, root=0)
+
+    if rank == 0:
+        print("\nValidating forward and adjoint residuals...")
+        b_global = make_rhs(0, n, n)
+        forward_residual = np.linalg.norm(
+            b_global - A_global @ x_global
+        ) / np.linalg.norm(b_global)
+        adjoint_residual = np.linalg.norm(
+            A_global.T @ g_global - x_global
+        ) / np.linalg.norm(x_global)
+
+        print(f"Forward time: {solve_time:.3f}s")
+        print(f"Forward iterations: {int(info['iterations'])}")
+        print(f"Forward residual: {forward_residual:.3e}")
+        print(f"Gradient time: {gradient_time:.3f}s")
+        print(f"Adjoint residual: {adjoint_residual:.3e}")
+
+    comm.Barrier()
+    jaxamg.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/jaxamg/matrices.py
+++ b/jaxamg/matrices.py
@@ -5,13 +5,17 @@ This module provides common sparse matrix patterns and right-hand-side
 vector generators for testing and demonstration purposes.
 """
 
+import tarfile
 from collections.abc import Callable
+from pathlib import Path
 from typing import cast
+from urllib.request import urlretrieve
 
 import jax
 import jax.experimental.sparse as jsp
 import jax.numpy as jnp
 import numpy as np
+import scipy.io
 import scipy.sparse as sp
 from jax.typing import DTypeLike
 
@@ -779,3 +783,64 @@ def rhs_random(n: int, seed: int = 0, dtype: DTypeLike | None = None) -> jax.Arr
     """
     key = jax.random.PRNGKey(seed)
     return jax.random.normal(key, (n,), dtype=dtype)
+
+
+def download_suitesparse_matrix(
+    name: str,
+    group: str | None = None,
+    cache_dir: str | Path | None = None,
+    dtype: DTypeLike | None = None,
+    base_url: str = "https://sparse.tamu.edu/MM",
+) -> sp.csr_matrix:
+    """Download a SuiteSparse Matrix Collection matrix and return it as CSR.
+
+    Args:
+        name: Matrix name, or ``"group/name"``.
+        group: SuiteSparse group name. Optional if included in ``name``.
+        cache_dir: Directory for downloaded archives and extracted files.
+        dtype: Optional dtype for matrix values.
+        base_url: SuiteSparse Matrix Market archive base URL.
+
+    Returns:
+        SciPy CSR matrix.
+    """
+    if group is None:
+        if "/" not in name:
+            raise ValueError("Pass group='...' or use name='group/matrix'.")
+        group, name = name.split("/", 1)
+
+    cache_root = (
+        Path(cache_dir).expanduser()
+        if cache_dir is not None
+        else Path.home() / ".cache" / "jaxamg" / "suitesparse"
+    )
+    matrix_dir = cache_root / group / name
+    archive_path = matrix_dir / f"{name}.tar.gz"
+    matrix_path = matrix_dir / f"{name}.mtx"
+    matrix_dir.mkdir(parents=True, exist_ok=True)
+
+    if not matrix_path.exists():
+        if not archive_path.exists():
+            url = f"{base_url.rstrip('/')}/{group}/{name}.tar.gz"
+            urlretrieve(url, archive_path)
+
+        with tarfile.open(archive_path, "r:gz") as archive:
+            member = next(
+                (m for m in archive.getmembers() if Path(m.name).name == f"{name}.mtx"),
+                None,
+            )
+            if member is None:
+                raise FileNotFoundError(f"{name}.mtx not found in {archive_path}")
+            source = archive.extractfile(member)
+            if source is None:
+                raise FileNotFoundError(f"{name}.mtx could not be read from archive")
+            with matrix_path.open("wb") as target:
+                target.write(source.read())
+
+    matrix = scipy.io.mmread(matrix_path)
+    if not sp.issparse(matrix):
+        matrix = sp.coo_matrix(matrix)
+    matrix = matrix.tocsr()
+    if dtype is not None:
+        matrix = matrix.astype(dtype)
+    return matrix

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -5,6 +5,7 @@ import jax.experimental.sparse as jsp
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import scipy.io
 import scipy.sparse.linalg as spla
 
 import jaxamg
@@ -13,6 +14,7 @@ from jaxamg import config as amgx_config
 from jaxamg.jaxamg import _amgx_solve_impl
 from jaxamg.matrices import (
     convection_diffusion_matrix_2d,
+    download_suitesparse_matrix,
     poisson_matrix,
     rhs_ones,
     tridiagonal_matrix,
@@ -462,3 +464,32 @@ class TestSolver:
         # Each solution must satisfy its own system.
         np.testing.assert_allclose(A1 @ np.asarray(x1), np.asarray(b), atol=1e-4)
         np.testing.assert_allclose(A2 @ np.asarray(x2), np.asarray(b), atol=1e-4)
+
+    def test_download_suitesparse_matrix_from_cache(self, tmp_path):
+        """SuiteSparse helper should load a cached Matrix Market tarball."""
+        import tarfile
+
+        group = "TestGroup"
+        name = "toy"
+        matrix_dir = tmp_path / group / name
+        matrix_dir.mkdir(parents=True)
+
+        A = scipy.sparse.csr_matrix(
+            np.array([[2.0, 0.0, -1.0], [0.0, 3.0, 4.0]], dtype=np.float64)
+        )
+        source_dir = tmp_path / "source" / name
+        source_dir.mkdir(parents=True)
+        source_mtx = source_dir / f"{name}.mtx"
+        scipy.io.mmwrite(source_mtx, A)
+
+        archive_path = matrix_dir / f"{name}.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as archive:
+            archive.add(source_mtx, arcname=f"{name}/{name}.mtx")
+
+        loaded = download_suitesparse_matrix(
+            f"{group}/{name}", cache_dir=tmp_path, dtype=np.float32
+        )
+
+        assert scipy.sparse.isspmatrix_csr(loaded)
+        assert loaded.dtype == np.float32
+        np.testing.assert_allclose(loaded.toarray(), A.astype(np.float32).toarray())


### PR DESCRIPTION
This PR adds a small SuiteSparse Matrix Collection helper and a new MPI autodiff demo for a structurally nonsymmetric matrix.

- Add `download_suitesparse_matrix()` to load SuiteSparse Matrix Market archives into CSR format with local caching.
- Add a structurally nonsymmetric MPI autodiff demo using the SuiteSparse `torso3` matrix.