### PR TITLE
Lazy extension loading + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+# Lint and CPU-only tests. The native AmgX extension is loaded lazily, so the
+# package imports without CUDA/AmgX; solver tests skip themselves on non-GPU
+# backends (see the skipif markers in tests/) and MPI tests skip without
+# pytest-mpi active. The GPU and MPI test suites are run on GPU machines as
+# described in docs/development.md.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Versions pinned to match .pre-commit-config.yaml
+      - name: Install linters
+        run: pip install "ruff==0.15.0" "black==25.1.0" "mypy==1.16.1" numpy scipy jax
+      - name: ruff
+        run: ruff check jaxamg tests demo
+      - name: black
+        run: black --check jaxamg tests demo
+      - name: mypy
+        run: mypy jaxamg
+
+  test-cpu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      # Run from the repo root without installing the package: the extension
+      # loads lazily, so the pure-Python surface (sparsity tracing, coloring,
+      # config, matrices, monkeypatched preconditioners) is fully testable.
+      - name: Run CPU-only tests
+        run: python -m pytest tests/ -v -ra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      # Versions pinned to match .pre-commit-config.yaml
-      - name: Install linters
-        run: pip install "ruff==0.15.0" "black==25.1.0" "mypy==1.16.1" numpy scipy jax
+      # Tool versions come from requirements-dev.txt (kept in sync with
+      # .pre-commit-config.yaml), so local dev, pre-commit, and CI agree.
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
       - name: ruff
         run: ruff check jaxamg tests demo
       - name: black
@@ -36,8 +37,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,21 +2,22 @@
 # Install: pre-commit install
 # Run manually: pre-commit run --all-files
 
+# Tool versions are kept in sync with requirements-dev.txt and the CI lint job.
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         args: [--fix]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.1
+    rev: v2.3.0
     hooks:
       - id: mypy
         additional_dependencies: [numpy, scipy, jax]

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -14,7 +14,6 @@ import numpy as np
 from jax.typing import ArrayLike
 
 from . import config as amgx_config
-from ._ext import _amgx
 from .mpi_utils import (
     _mpi4jax_alltoallv_transpose,
     _mpi4jax_halo_gather,
@@ -33,25 +32,41 @@ _AMGX_CALL_NAME_DOUBLE = "amgx_solve_double"
 _AMGX_CALL_NAME_MPI = "amgx_solve_mpi"
 _AMGX_CALL_NAME_MPI_DOUBLE = "amgx_solve_mpi_double"
 
+# The native extension is loaded lazily on first use, so importing jaxamg
+# (for sparsity tracing, matrix helpers, config handling, or on a CPU-only
+# machine such as a CI runner) does not require the AmgX/CUDA libraries.
+_amgx: Any = None
+
 # Whether the native extension was compiled with MPI support (JAXAMG_WITH_MPI).
-# A non-MPI build omits the MPI FFI handlers entirely, so the single-GPU path
-# below must be the only thing registered at import time.
-HAS_MPI = bool(getattr(_amgx, "mpi_enabled", False))
+# A non-MPI build omits the MPI FFI handlers entirely. Set by _ensure_backend().
+HAS_MPI = False
 
-# Get the handler from C++ and register for CUDA platform
-_AMGX_HANDLER = _amgx.get_amgx_solve_handler()
-_AMGX_HANDLER_DOUBLE = _amgx.get_amgx_solve_double_handler()
 
-ffi.register_ffi_target(_AMGX_CALL_NAME, _AMGX_HANDLER, platform="CUDA")
-ffi.register_ffi_target(_AMGX_CALL_NAME_DOUBLE, _AMGX_HANDLER_DOUBLE, platform="CUDA")
+def _ensure_backend() -> Any:
+    """Load the native AmgX extension and register its FFI targets (once)."""
+    global _amgx, HAS_MPI
+    if _amgx is not None:
+        return _amgx
+    from ._ext import _amgx as ext
 
-if HAS_MPI:
-    _AMGX_HANDLER_MPI = _amgx.get_amgx_solve_mpi_handler()
-    _AMGX_HANDLER_MPI_DOUBLE = _amgx.get_amgx_solve_mpi_double_handler()
-    ffi.register_ffi_target(_AMGX_CALL_NAME_MPI, _AMGX_HANDLER_MPI, platform="CUDA")
+    HAS_MPI = bool(getattr(ext, "mpi_enabled", False))
     ffi.register_ffi_target(
-        _AMGX_CALL_NAME_MPI_DOUBLE, _AMGX_HANDLER_MPI_DOUBLE, platform="CUDA"
+        _AMGX_CALL_NAME, ext.get_amgx_solve_handler(), platform="CUDA"
     )
+    ffi.register_ffi_target(
+        _AMGX_CALL_NAME_DOUBLE, ext.get_amgx_solve_double_handler(), platform="CUDA"
+    )
+    if HAS_MPI:
+        ffi.register_ffi_target(
+            _AMGX_CALL_NAME_MPI, ext.get_amgx_solve_mpi_handler(), platform="CUDA"
+        )
+        ffi.register_ffi_target(
+            _AMGX_CALL_NAME_MPI_DOUBLE,
+            ext.get_amgx_solve_mpi_double_handler(),
+            platform="CUDA",
+        )
+    _amgx = ext
+    return ext
 
 
 class AMGXStatus(IntEnum):
@@ -91,6 +106,7 @@ def _amgx_solve_impl(
 ) -> tuple[jax.Array, jax.Array]:
     """Low-level FFI call to AmgX solver (non-differentiable)."""
 
+    _ensure_backend()
     b = jnp.asarray(b)
 
     out_spec = (
@@ -138,6 +154,7 @@ def _amgx_solve_mpi_impl(
 ) -> tuple[jax.Array, jax.Array]:
     """Low-level FFI call to AmgX MPI solver (non-differentiable)."""
 
+    _ensure_backend()
     b = jnp.asarray(b)
 
     out_spec = (
@@ -456,6 +473,9 @@ def solve(
             "Please ensure you have a CUDA-enabled GPU and JAX is installed with CUDA support."
         )
 
+    # Load the native extension and register FFI targets (sets HAS_MPI).
+    _ensure_backend()
+
     # MPI cache may be pre-attached to A via `with_cache`
     mpi_cache = getattr(A, "_mpi_cache", None)
 
@@ -648,7 +668,7 @@ def solve(
     }
     if save_stats_file is not None:
         try:
-            stats_str = _amgx.get_stats_string()
+            stats_str = _ensure_backend().get_stats_string()
         except AttributeError:
             # Older extension without stats capture; nothing to save.
             stats_str = None
@@ -664,7 +684,7 @@ def clear_solver_cache() -> None:
     Clear the internal C++ AmgX solver cache.
     This releases all cached AmgX resources (matrices, solvers, vectors).
     """
-    _amgx.clear_solver_cache()
+    _ensure_backend().clear_solver_cache()
 
 
 def get_solver_cache_info() -> dict[str, Any]:
@@ -676,7 +696,7 @@ def get_solver_cache_info() -> dict[str, Any]:
         for single-GPU and MPI caches, plus whether isolated mode
         (`JAXAMG_CACHE_SIZE=0`) is active.
     """
-    solver_info = _amgx.get_solver_cache_info()
+    solver_info = _ensure_backend().get_solver_cache_info()
 
     # Convert config strings to JSON
     solver_info["single_gpu"]["entries"] = [
@@ -698,4 +718,4 @@ def finalize() -> None:
     Normally only needed to be called manually in MPI mode to avoid shutdown-time resource warnings.
     """
     clear_solver_cache()
-    _amgx.finalize()
+    _ensure_backend().finalize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,13 @@ version = { attr = "jaxamg._version.__version__" }
 [tool.setuptools.package-data]
 jaxamg = ["py.typed", "*.pyi"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "gpu: tests that run the native AmgX solver (skipped without a GPU JAX backend)",
+    "mpi: distributed tests; run under mpirun with pytest-mpi's --only-mpi flag",
+]
+
 [tool.ruff]
 line-length = 88
 target-version = "py312"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,10 +7,11 @@
 pytest>=7.0.0
 pytest-mpi>=0.6
 
-# Code quality
-black
-mypy
-ruff
+# Code quality (pinned so local, pre-commit, and CI lint agree;
+# keep in sync with .pre-commit-config.yaml)
+black==26.5.1
+mypy==2.3.0
+ruff==0.15.22
 pre-commit
 
 # Documentation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,27 @@ def configure_jax():
     """Configure JAX for testing."""
     # Ensure JAX uses 32-bit floats by default
     jax.config.update("jax_enable_x64", False)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Centralized skip logic for the `gpu` and `mpi` markers.
+
+    - `gpu`: tests that run the native AmgX solver; skipped unless JAX has a
+      GPU backend.
+    - `mpi`: the skip behavior normally comes from the optional pytest-mpi
+      plugin; without it the MPI tests would execute in a plain pytest run
+      (no mpirun, no ranks) and fail or hang instead of skipping.
+    """
+    if jax.default_backend() != "gpu":
+        skip_gpu = pytest.mark.skip(reason="requires a GPU JAX backend")
+        for item in items:
+            if "gpu" in item.keywords:
+                item.add_marker(skip_gpu)
+
+    if not config.pluginmanager.hasplugin("pytest_mpi"):
+        skip_mpi = pytest.mark.skip(
+            reason="pytest-mpi is not active; MPI tests require mpirun + --only-mpi"
+        )
+        for item in items:
+            if "mpi" in item.keywords:
+                item.add_marker(skip_mpi)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ def linear_system():
     return A, b
 
 
+@pytest.mark.gpu
 def test_config_defaults(linear_system):
     """Test that default configuration works."""
     A, b = linear_system
@@ -25,6 +26,7 @@ def test_config_defaults(linear_system):
     assert info["status"] == jaxamg.AMGXStatus.SUCCESS
 
 
+@pytest.mark.gpu
 def test_config_flat_dict(linear_system):
     """Test simple flat dictionary configuration."""
     A, b = linear_system
@@ -34,6 +36,7 @@ def test_config_flat_dict(linear_system):
     assert info["status"] == jaxamg.AMGXStatus.SUCCESS
 
 
+@pytest.mark.gpu
 def test_config_kwargs_override(linear_system):
     """Test that kwargs override default and config values."""
     A, b = linear_system
@@ -60,6 +63,7 @@ def test_config_kwargs_override(linear_system):
     assert info["iterations"] == 2
 
 
+@pytest.mark.gpu
 def test_config_nested(linear_system):
     """Test nested dictionary configuration."""
     A, b = linear_system

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -20,6 +20,9 @@ from jaxamg.matrices import (
 )
 from jaxamg.utils import to_scipy
 
+# Every test here calls the native AmgX solver (skip logic in conftest.py).
+pytestmark = pytest.mark.gpu
+
 
 def l2_loss(A, b, config={"solver": "CG"}):
     """Compute L(b) = ||A^{-1} b||^2."""

--- a/tests/test_matrix_formats.py
+++ b/tests/test_matrix_formats.py
@@ -7,6 +7,9 @@ import jaxamg
 from jaxamg.matrices import rhs_ones, tridiagonal_matrix
 from jaxamg.utils import to_scipy
 
+# Every test here calls the native AmgX solver (skip logic in conftest.py).
+pytestmark = pytest.mark.gpu
+
 
 class TestMatrixFormats:
     """Test solver accepts various matrix formats."""

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -2,6 +2,7 @@
 
 import jax
 import numpy as np
+import pytest
 
 import jaxamg
 from jaxamg.matrices import (
@@ -11,6 +12,9 @@ from jaxamg.matrices import (
     tridiagonal_matrix,
     tridiagonal_operator,
 )
+
+# Every test here calls the native AmgX solver (skip logic in conftest.py).
+pytestmark = pytest.mark.gpu
 
 
 class TestOperator:

--- a/tests/test_preconditioners.py
+++ b/tests/test_preconditioners.py
@@ -119,6 +119,7 @@ def test_make_preconditioner_nested_config_merge(monkeypatch):
 
 
 @pytest.mark.parametrize("skew", [0.0, 1.0, 2.0])
+@pytest.mark.gpu
 def test_make_preconditioner_with_native_jax_bicgstab(skew):
     """Test that a preconditioner created by `make_preconditioner` can be used with `jax.scipy.sparse.linalg.bicgstab` to solve a skewed Poisson problem."""
 
@@ -196,6 +197,7 @@ def test_make_lineax_preconditioner_tag_override_and_validation(monkeypatch):
 
 
 @pytest.mark.parametrize("skew", [0.0, 2.0])
+@pytest.mark.gpu
 def test_make_lineax_preconditioner_with_lineax_solver(skew):
     """End-to-end: an AMG preconditioner built from a Lineax operator accelerates a
     Lineax Krylov solve of a (possibly skewed) Poisson problem."""

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -21,6 +21,9 @@ from jaxamg.matrices import (
 )
 from jaxamg.utils import to_scipy
 
+# Every test here calls the native AmgX solver (skip logic in conftest.py).
+pytestmark = pytest.mark.gpu
+
 
 class TestSolver:
     """Test basic solver functionality."""
@@ -373,28 +376,93 @@ class TestSolver:
             assert info_batched["status"][i] == jaxamg.AMGXStatus.SUCCESS
 
     def test_vmap_batched_solve(self):
-        """Test that jax.vmap works with batched matrices."""
+        """Test that jax.vmap works with batched matrices and routes each batch
+        member's data to the right lane (distinct matrices and RHS per lane)."""
         n = 8
-        A = tridiagonal_matrix(n)
-        b = rhs_ones(n)
+        A1 = tridiagonal_matrix(n, diagonal_value=2.0)
+        A2 = tridiagonal_matrix(n, diagonal_value=4.0)
+        b1 = rhs_ones(n)
+        b2 = 2.0 * rhs_ones(n)
 
         A_batched = jsp.BCSR(
             (
-                jnp.stack([A.data, A.data]),
-                jnp.stack([A.indices, A.indices]),
-                jnp.stack([A.indptr, A.indptr]),
+                jnp.stack([A1.data, A2.data]),
+                jnp.stack([A1.indices, A2.indices]),
+                jnp.stack([A1.indptr, A2.indptr]),
             ),
             shape=(2, n, n),
         )
-        b_batched = jnp.stack([b, b])
+        b_batched = jnp.stack([b1, b2])
 
         # Vmap over the 0th axis of A_batched and b_batched
         vmap_solve = jax.vmap(jaxamg.solve, in_axes=(0, 0))
 
         # This should NOT raise ValueError because inside vmap A is not batched
-        x_batched, _ = vmap_solve(A_batched, b_batched)
+        x_batched, info_batched = vmap_solve(A_batched, b_batched)
 
         assert x_batched.shape == (2, n)
+        for i, (A, b) in enumerate(((A1, b1), (A2, b2))):
+            x_expected = jnp.linalg.solve(A.todense(), b)
+            np.testing.assert_allclose(x_batched[i], x_expected, rtol=1e-4, atol=1e-5)
+            assert info_batched["status"][i] == jaxamg.AMGXStatus.SUCCESS
+
+    def test_get_solver_cache_info(self):
+        """get_solver_cache_info reports the cached solver with a parsed config."""
+        jaxamg.clear_solver_cache()
+        n = 16
+        A = tridiagonal_matrix(n)
+        b = rhs_ones(n)
+        jaxamg.solve(A, b)
+
+        info = jaxamg.get_solver_cache_info()
+        assert set(info) >= {"single_gpu", "mpi", "isolated_mode"}
+        if info["isolated_mode"]:
+            pytest.skip("JAXAMG_CACHE_SIZE=0: nothing is cached in isolated mode")
+
+        single = info["single_gpu"]
+        assert single["size"] == len(single["entries"]) == 1
+        assert single["capacity"] >= 1
+        entry = single["entries"][0]
+        assert entry["n_rows"] == n
+        assert entry["nnz"] == 3 * n - 2
+        assert entry["mode"] == "float32"
+        # The config string must round-trip to the prepared default config.
+        assert isinstance(entry["config"], dict)
+        assert entry["config"]["solver"]["solver"] == "PBICGSTAB"
+
+    def test_jitted_iterative_solve_matches_eager(self):
+        """Regression test for the missing device sync after AmgX solves.
+
+        An FFI solve inside a jitted loop feeds XLA kernels immediately; before
+        the trailing ``cudaDeviceSynchronize`` in the native handler, those
+        consumers could read the solution buffer before AmgX's download landed
+        (stale zeros/garbage under GPU contention). The jitted Richardson
+        iteration must match the identical iteration run eagerly, where
+        ``block_until_ready`` guarantees every download has completed.
+        """
+        n = 8
+        steps = 20
+        A = poisson_matrix(n)
+        b = rhs_ones(n * n)
+        apply = jaxamg.make_preconditioner(A)
+
+        @jax.jit
+        def richardson(v):
+            def body(_, x):
+                return x + apply(v - A @ x)
+
+            return jax.lax.fori_loop(0, steps, body, jnp.zeros_like(v))
+
+        x_ref = jnp.zeros_like(b)
+        for _ in range(steps):
+            z = apply(b - A @ x_ref)
+            z.block_until_ready()
+            x_ref = x_ref + z
+
+        x_jit = richardson(b)
+        np.testing.assert_allclose(
+            np.asarray(x_jit), np.asarray(x_ref), rtol=1e-4, atol=1e-4
+        )
 
     def test_batched_matrix_error(self):
         """Test that passing a batched matrix directly raises ValueError."""


### PR DESCRIPTION
This PR loads the native AmgX extension on first use instead of at import, so the package imports without CUDA, and adds a CI workflow with lint and CPU-only tests plus gpu/mpi markers that skip themselves.