### PR TITLE
Efficiency improvements and demo cleanup

### DIFF
--- a/demo/mpi_nonsymmetric_matrix_autodiff.py
+++ b/demo/mpi_nonsymmetric_matrix_autodiff.py
@@ -2,7 +2,7 @@
 Demo: MPI-distributed automatic differentiation of torso3 (a structurally non-symmetric system).
 
 Usage:
-    mpirun -n 2 python demo/mpi_nonsysmmetric_matrix_autodiff.py
+    mpirun -n 2 python demo/mpi_nonsymmetric_matrix_autodiff.py
 """
 
 import time

--- a/demo/mpi_poisson_problem.py
+++ b/demo/mpi_poisson_problem.py
@@ -81,8 +81,6 @@ def main():
     solve_time = time.time() - t_start
 
     comm.Barrier()
-    for r in range(nranks):
-        comm.Barrier()
 
     if rank == 0:
         print(f"  Info: {info}")

--- a/demo/mpi_poisson_problem_auto_partition.py
+++ b/demo/mpi_poisson_problem_auto_partition.py
@@ -19,7 +19,6 @@ from jaxamg.matrices import poisson_matrix, rhs_linear
 from jaxamg.mpi_utils import (
     gather_vector,
     partition_csr_matrix,
-    partition_vector,
     validate_partition,
 )
 
@@ -69,9 +68,6 @@ def main():
 
     validate_partition(A_local, n, row_start, row_end)
 
-    b_global = rhs_linear(n)
-    b_local, _, _ = partition_vector(b_global, rank, nranks)
-
     comm.Barrier()
     if rank == 0:
         print("\nSolving distributed system...")
@@ -96,8 +92,6 @@ def main():
     solve_time = time.time() - t_start
 
     comm.Barrier()
-    for r in range(nranks):
-        comm.Barrier()
 
     if rank == 0:
         print(f"  Info: {info}")

--- a/demo/mpi_solver_cache_benchmark.py
+++ b/demo/mpi_solver_cache_benchmark.py
@@ -9,7 +9,6 @@ Usage:
     mpirun -n 4 python demo/mpi_solver_cache_benchmark.py
 """
 
-import copy
 import time
 
 import jax
@@ -92,76 +91,54 @@ def run_benchmark(n_global, n_runs=5):
     baseline_times = []
     key = jax.random.PRNGKey(0)
 
-    # Build per-iteration MPI caches with distinct config file paths.
-    # The native cache key includes config string path, so this avoids resource reuse
-    # without calling clear_solver_cache() in MPI mode.
-    baseline_mpi_caches = [
-        jaxamg.cache_mpi_metadata(
-            copy.deepcopy(solver_config),
-            comm,
-            n_global,
-            partition_info,
-            A_local,
-            is_symmetric=True,
-        )
-        for _ in range(n_runs + 1)
-    ]
+    mpi_cache = jaxamg.cache_mpi_metadata(
+        solver_config, comm, n_global, partition_info, A_local, is_symmetric=True
+    )
 
     if rank == 0:
         print("\nRunning baseline...")
 
     # Warmup baseline
     key, warmup_key = jax.random.split(key)
-    step(A_local, b_local, warmup_key, baseline_mpi_caches[0]).block_until_ready()
+    step(A_local, b_local, warmup_key, mpi_cache).block_until_ready()
     comm.Barrier()
 
-    for i in range(n_runs):
+    for _ in range(n_runs):
         key, subkey = jax.random.split(key)
+        # Drop the cached AmgX resources (all ranks in lockstep) so every
+        # timed solve pays the full miss cost: resource creation, matrix
+        # upload, and solver setup. The clear itself is not timed.
+        jaxamg.clear_solver_cache()
         comm.Barrier()
         t0 = time.time()
-        x = step(A_local, b_local, subkey, baseline_mpi_caches[i + 1])
+        x = step(A_local, b_local, subkey, mpi_cache)
         x.block_until_ready()
         comm.Barrier()
         baseline_times.append((time.time() - t0) * 1000)
 
     avg_baseline = _summarize_times(comm, rank, "Baseline", baseline_times)
 
-    # Important for small cache sizes (especially CACHE_SIZE=1):
-    # baseline intentionally churns cache keys and can stress eviction paths.
-    # Fully reset native state before running cached branch.
-    comm.Barrier()
-    jaxamg.finalize()
-    comm.Barrier()
-
-    # Recreate matrix/RHS after finalize so cached branch starts from clean state.
-    A_local, row_start, row_end = tridiagonal_matrix_distributed(
-        n_global, rank, nranks, diagonal_value=4.0
-    )
-    n_local = row_end - row_start
-    b_local = rhs_ones(n_local, dtype=A_local.data.dtype)
-    partition_info = (row_start, row_end)
-
     cached_times = []
     key = jax.random.PRNGKey(0)
 
-    # Single MPI metadata cache reused across iterations for resource cache hits.
-    cached_mpi_cache = jaxamg.cache_mpi_metadata(
-        solver_config, comm, n_global, partition_info, A_local, is_symmetric=True
-    )
+    # Start the cached branch from a miss as well: its warmup repopulates the
+    # cache, then every timed solve is a hit that reuses the AmgX resources.
+    jaxamg.clear_solver_cache()
+    comm.Barrier()
 
     if rank == 0:
         print("\nRunning cached...")
 
     # Warmup cached
     key, warmup_key = jax.random.split(key)
-    step(A_local, b_local, warmup_key, cached_mpi_cache).block_until_ready()
+    step(A_local, b_local, warmup_key, mpi_cache).block_until_ready()
     comm.Barrier()
 
     for _ in range(n_runs):
         key, subkey = jax.random.split(key)
         comm.Barrier()
         t0 = time.time()
-        x = step(A_local, b_local, subkey, cached_mpi_cache)
+        x = step(A_local, b_local, subkey, mpi_cache)
         x.block_until_ready()
         comm.Barrier()
         cached_times.append((time.time() - t0) * 1000)

--- a/demo/preconditioned_solver.py
+++ b/demo/preconditioned_solver.py
@@ -23,11 +23,10 @@ def run_jaxamg_solver(name, A, b, *, config=None, **kwargs):
         x, info = jaxamg.solve(A, b, config=config, **kwargs)
         elapsed = time.time() - t_start
         residual = jnp.linalg.norm(b - A @ x) / jnp.linalg.norm(b)
-        iterations = info.get("iterations", "?")
         print(f"{name:40s} | time={elapsed:6.3f}s residual={float(residual):.3e}")
-    except Exception:
+    except Exception as exc:
         elapsed = time.time() - t_start
-        print(f"{name:40s} | time={elapsed:6.3f}s residual=nan")
+        print(f"{name:40s} | time={elapsed:6.3f}s FAILED: {exc}")
 
 
 def run_solver(name, solver_fn, A, b, *, M=None, tol=1e-6, maxiter=200):
@@ -39,7 +38,7 @@ def run_solver(name, solver_fn, A, b, *, M=None, tol=1e-6, maxiter=200):
         print(f"{name:40s} | time={elapsed:6.3f}s residual={float(residual):.3e}")
     except Exception as exc:
         elapsed = time.time() - t_start
-        print(f"{name:40s} | time={elapsed:6.3f}s residaul=nan")
+        print(f"{name:40s} | time={elapsed:6.3f}s FAILED: {exc}")
 
 
 def run_lineax_solver(name, solver, operator, b, *, preconditioner=None):
@@ -47,15 +46,17 @@ def run_lineax_solver(name, solver, operator, b, *, preconditioner=None):
     kwargs = {}
     if preconditioner is not None:
         kwargs["options"] = {"preconditioner": preconditioner}
-    try:
-        solution = lx.linear_solve(operator, b, solver=solver, **kwargs)
-        elapsed = time.time() - t_start
-        x = solution.value
-        residual = jnp.linalg.norm(b - operator.mv(x)) / jnp.linalg.norm(b)
-        print(f"{name:40s} | time={elapsed:6.3f}s residual={float(residual):.3e}")
-    except Exception as exc:
-        elapsed = time.time() - t_start
-        print(f"{name:40s} | time={elapsed:6.3f}s residual=nan")
+    # throw=False reports solver failure via solution.result instead of raising.
+    solution = lx.linear_solve(operator, b, solver=solver, throw=False, **kwargs)
+    x = solution.value
+    elapsed = time.time() - t_start
+    residual = jnp.linalg.norm(b - operator.mv(x)) / jnp.linalg.norm(b)
+    status = (
+        ""
+        if solution.result == lx.RESULTS.successful
+        else f" FAILED: {solution.result}"
+    )
+    print(f"{name:40s} | time={elapsed:6.3f}s residual={float(residual):.3e}{status}")
 
 
 def main():

--- a/demo/solver_info.py
+++ b/demo/solver_info.py
@@ -11,20 +11,20 @@ def main():
     b = rhs_ones(n)
 
     # Ill-conditioned matrix
-    print(f"Sovling a ill-conditioned matrix of size {n}x{n}")
+    print(f"Solving an ill-conditioned matrix of size {n}x{n}")
     config = {"max_iters": 50, "tolerance": 1e-5}
     A = tridiagonal_matrix(n, diagonal_value=2.0)
     _, info = jaxamg.solve(A, b, config=config)
     print(info)
 
     # Well-conditioned matrix
-    print(f"\nSovling a well-conditioned matrix of size {n}x{n}")
+    print(f"\nSolving a well-conditioned matrix of size {n}x{n}")
     A = tridiagonal_matrix(n, diagonal_value=4.0)
     _, info = jaxamg.solve(A, b, config=config)
     print(info)
 
     # Well-conditioned matrix with max_iters=1
-    print(f"\nSovling a well-conditioned matrix of size {n}x{n} with 1 iteration")
+    print(f"\nSolving a well-conditioned matrix of size {n}x{n} with 1 iteration")
     config = {"max_iters": 1, "tolerance": 1e-5}
     _, info = jaxamg.solve(A, b, config=config)
     print(info)

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -44,6 +44,11 @@ namespace
     return handle;
   }
 
+  // The scratch workspace lives in the solver-cache entry (workspace_slot /
+  // workspace_size_slot) and is only (re)allocated when the required size
+  // grows: the transpose reruns on every backward solve whose values changed,
+  // and a per-call cudaMalloc/cudaFree pair is comparatively expensive
+  // (cudaFree also implicitly synchronizes the device).
   template <typename T>
   inline const char *CsrTransposeDevice(cudaStream_t stream,
                                         int n_rows,
@@ -53,7 +58,9 @@ namespace
                                         const T *values,
                                         int *row_ptrs_t,
                                         int *col_indices_t,
-                                        T *values_t)
+                                        T *values_t,
+                                        void **workspace_slot,
+                                        size_t *workspace_size_slot)
   {
     cusparseHandle_t handle = GetCusparseHandle();
     if (handle == nullptr)
@@ -88,10 +95,19 @@ namespace
       return "cusparseCsr2cscEx2_bufferSize failed";
     }
 
-    void *workspace = nullptr;
-    if (buffer_size > 0 && cudaMalloc(&workspace, buffer_size) != cudaSuccess)
+    if (buffer_size > *workspace_size_slot)
     {
-      return "cudaMalloc failed for cusparse transpose workspace";
+      if (*workspace_slot)
+      {
+        cudaFree(*workspace_slot);
+        *workspace_slot = nullptr;
+        *workspace_size_slot = 0;
+      }
+      if (cudaMalloc(workspace_slot, buffer_size) != cudaSuccess)
+      {
+        return "cudaMalloc failed for cusparse transpose workspace";
+      }
+      *workspace_size_slot = buffer_size;
     }
 
     status = cusparseCsr2cscEx2(
@@ -109,9 +125,7 @@ namespace
         CUSPARSE_ACTION_NUMERIC,
         CUSPARSE_INDEX_BASE_ZERO,
         CUSPARSE_CSR2CSC_ALG1,
-        workspace);
-
-    cudaFree(workspace);
+        *workspace_slot);
 
     if (status != CUSPARSE_STATUS_SUCCESS)
     {
@@ -215,7 +229,9 @@ namespace
             values_data,
             static_cast<int *>(res.transpose_row_ptrs),
             static_cast<int *>(res.transpose_col_indices),
-            static_cast<T *>(res.transpose_values));
+            static_cast<T *>(res.transpose_values),
+            &res.transpose_workspace,
+            &res.transpose_workspace_size);
         if (transpose_err != nullptr)
         {
           return ffi::Error::Internal(transpose_err);
@@ -286,7 +302,9 @@ namespace
             values_data,
             static_cast<int *>(res.transpose_row_ptrs),
             static_cast<int *>(res.transpose_col_indices),
-            static_cast<T *>(res.transpose_values));
+            static_cast<T *>(res.transpose_values),
+            &res.transpose_workspace,
+            &res.transpose_workspace_size);
         if (transpose_err != nullptr)
         {
           return ffi::Error::Internal(transpose_err);

--- a/jaxamg/_amgx_utils.h
+++ b/jaxamg/_amgx_utils.h
@@ -347,6 +347,8 @@ namespace
     void *transpose_row_ptrs = nullptr;    // transpose_solve mode only
     void *transpose_col_indices = nullptr; // transpose_solve mode only
     void *transpose_values = nullptr;      // transpose_solve mode only
+    void *transpose_workspace = nullptr;   // cusparse csr2csc scratch (transpose_solve only)
+    size_t transpose_workspace_size = 0;
     bool owns_resources = false;           // true if isolated (JAXAMG_CACHE_SIZE=0)
   };
 
@@ -422,6 +424,7 @@ namespace
       if (res.transpose_row_ptrs) cudaFree(res.transpose_row_ptrs);
       if (res.transpose_col_indices) cudaFree(res.transpose_col_indices);
       if (res.transpose_values) cudaFree(res.transpose_values);
+      if (res.transpose_workspace) cudaFree(res.transpose_workspace);
     }
     catch (...)
     {

--- a/jaxamg/matrices.py
+++ b/jaxamg/matrices.py
@@ -5,11 +5,13 @@ This module provides common sparse matrix patterns and right-hand-side
 vector generators for testing and demonstration purposes.
 """
 
+import shutil
 import tarfile
+import tempfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
-from urllib.request import urlretrieve
+from typing import IO, cast
+from urllib.request import urlopen
 
 import jax
 import jax.experimental.sparse as jsp
@@ -763,12 +765,31 @@ def rhs_random(n: int, seed: int = 0, dtype: DTypeLike | None = None) -> jax.Arr
     return jax.random.normal(key, (n,), dtype=dtype)
 
 
+def _stream_to_path(source: IO[bytes], dest: Path) -> None:
+    """Stream ``source`` into ``dest`` via a unique temp file + atomic rename.
+
+    An interrupted write can therefore never leave a partial file at ``dest``
+    (which would permanently poison the cache), and concurrent writers (e.g.
+    MPI ranks) each write their own temp file instead of interleaving.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=dest.parent, suffix=".part")
+    tmp_path = Path(tmp_name)
+    try:
+        with open(fd, "wb") as target:
+            shutil.copyfileobj(source, target)
+        tmp_path.replace(dest)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def download_suitesparse_matrix(
     name: str,
     group: str | None = None,
     cache_dir: str | Path | None = None,
     dtype: DTypeLike | None = None,
     base_url: str = "https://sparse.tamu.edu/MM",
+    timeout: float = 60.0,
 ) -> sp.csr_matrix:
     """Download a SuiteSparse Matrix Collection matrix and return it as CSR.
 
@@ -778,6 +799,7 @@ def download_suitesparse_matrix(
         cache_dir: Directory for downloaded archives and extracted files.
         dtype: Optional dtype for matrix values.
         base_url: SuiteSparse Matrix Market archive base URL.
+        timeout: Socket timeout in seconds for the download.
 
     Returns:
         SciPy CSR matrix.
@@ -800,7 +822,8 @@ def download_suitesparse_matrix(
     if not matrix_path.exists():
         if not archive_path.exists():
             url = f"{base_url.rstrip('/')}/{group}/{name}.tar.gz"
-            urlretrieve(url, archive_path)
+            with urlopen(url, timeout=timeout) as response:
+                _stream_to_path(response, archive_path)
 
         with tarfile.open(archive_path, "r:gz") as archive:
             member = next(
@@ -812,8 +835,8 @@ def download_suitesparse_matrix(
             source = archive.extractfile(member)
             if source is None:
                 raise FileNotFoundError(f"{name}.mtx could not be read from archive")
-            with matrix_path.open("wb") as target:
-                target.write(source.read())
+            with source:
+                _stream_to_path(source, matrix_path)
 
     matrix = scipy.io.mmread(matrix_path)
     if not sp.issparse(matrix):

--- a/jaxamg/matrices.py
+++ b/jaxamg/matrices.py
@@ -340,31 +340,26 @@ def tridiagonal_matrix_distributed(
     # Row-based partitioning
     row_start, row_end, n_local = get_partition_info(n_global, rank, nranks)
 
-    data, indices, indptr = [], [], [0]
+    # Each row's stencil in column order: (g-1, -1), (g, diag), (g+1, -1),
+    # with off-matrix neighbors masked out. Boolean masking with the concrete
+    # (n_local, 3) mask yields row-major CSR data with sorted columns.
+    global_rows = np.arange(row_start, row_end)
+    stencil_cols = global_rows[:, None] + np.array([-1, 0, 1])
+    valid = (stencil_cols >= 0) & (stencil_cols < n_global)
 
-    for local_i in range(n_local):
-        global_i = row_start + local_i
-
-        # Lower diagonal
-        if global_i > 0:
-            data.append(-1.0)
-            indices.append(global_i - 1)
-
-        # Main diagonal
-        data.append(diagonal_value)
-        indices.append(global_i)
-
-        # Upper diagonal
-        if global_i < n_global - 1:
-            data.append(-1.0)
-            indices.append(global_i + 1)
-
-        indptr.append(len(data))
+    # Values go through jnp, not NumPy: diagonal_value may be a tracer
+    # (e.g. when differentiating through the matrix build).
+    stencil_vals = jnp.broadcast_to(
+        jnp.array([-1.0, diagonal_value, -1.0], dtype=dtype), (n_local, 3)
+    )
+    data = stencil_vals[valid]
+    indices = stencil_cols[valid]
+    indptr = np.concatenate(([0], np.cumsum(valid.sum(axis=1))))
 
     # Indices are int32 by default; converted to int64 by _ensure_bcsr_properties if needed for MPI
     A_local = jsp.BCSR(
         (
-            jnp.array(data, dtype=dtype),
+            data,
             jnp.array(indices, dtype=jnp.int32),
             jnp.array(indptr, dtype=jnp.int32),
         ),
@@ -402,57 +397,42 @@ def poisson_matrix_distributed(
     # Row-based partitioning
     row_start, row_end, n_local = get_partition_info(n, rank, nranks)
 
-    rows, cols, vals = [], [], []
+    global_rows = np.arange(row_start, row_end)
+    ix = global_rows % nx
+    iy = global_rows // nx
 
-    for local_i in range(n_local):
-        global_i = row_start + local_i
-        ix = global_i % nx
-        iy = global_i // nx
-
-        # Diagonal entry
-        rows.append(local_i)
-        cols.append(global_i)
-        vals.append(4.0)
-
-        # Left neighbor
-        if ix > 0:
-            rows.append(local_i)
-            cols.append(global_i - 1)
-            vals.append(-1.0 - skew / 2.0)
-
-        # Right neighbor
-        if ix < nx - 1:
-            rows.append(local_i)
-            cols.append(global_i + 1)
-            vals.append(-1.0 + skew / 2.0)
-
-        # Bottom neighbor
-        if iy > 0:
-            rows.append(local_i)
-            cols.append(global_i - nx)
-            vals.append(-1.0 - skew / 2.0)
-
-        # Top neighbor
-        if iy < ny - 1:
-            rows.append(local_i)
-            cols.append(global_i + nx)
-            vals.append(-1.0 + skew / 2.0)
-
-    # Convert JAX dtype to NumPy dtype
-    np_dtype: type = np.float32 if dtype == jnp.float32 else np.float64
-
-    A_local_scipy = sp.csr_matrix(
-        (vals, (rows, cols)),
-        shape=(n_local, n),
-        dtype=np_dtype,
+    # Each row's 5-point stencil in column order: bottom (g-nx), left (g-1),
+    # diagonal (g), right (g+1), top (g+nx), with off-grid neighbors masked
+    # out. Boolean masking on the C-ordered (n_local, 5) arrays yields
+    # row-major CSR data with sorted columns.
+    stencil_cols = global_rows[:, None] + np.array([-nx, -1, 0, 1, nx])
+    stencil_vals = np.broadcast_to(
+        np.array(
+            [
+                -1.0 - skew / 2.0,  # bottom
+                -1.0 - skew / 2.0,  # left
+                4.0,  # diagonal
+                -1.0 + skew / 2.0,  # right
+                -1.0 + skew / 2.0,  # top
+            ]
+        ),
+        (n_local, 5),
     )
+    valid = np.stack(
+        [iy > 0, ix > 0, np.ones(n_local, dtype=bool), ix < nx - 1, iy < ny - 1],
+        axis=1,
+    )
+
+    data = stencil_vals[valid]
+    indices = stencil_cols[valid]
+    indptr = np.concatenate(([0], np.cumsum(valid.sum(axis=1))))
 
     # Indices are int32 by default; converted to int64 by _ensure_bcsr_properties if needed for MPI
     A_local = jsp.BCSR(
         (
-            jnp.array(A_local_scipy.data, dtype=dtype),
-            jnp.array(A_local_scipy.indices, dtype=jnp.int32),
-            jnp.array(A_local_scipy.indptr, dtype=jnp.int32),
+            jnp.array(data, dtype=dtype),
+            jnp.array(indices, dtype=jnp.int32),
+            jnp.array(indptr, dtype=jnp.int32),
         ),
         shape=(n_local, n),
     )

--- a/jaxamg/sparsity_tracing.py
+++ b/jaxamg/sparsity_tracing.py
@@ -819,7 +819,21 @@ def _scan(
     p = eqn.params
     body = p["jaxpr"]
     body_jaxpr, body_consts = getattr(body, "jaxpr", body), getattr(body, "consts", [])
-    nconsts, ncarry, length = p["num_consts"], p["num_carry"], p["length"]
+    if "num_consts" in p:
+        nconsts, ncarry = p["num_consts"], p["num_carry"]
+    else:
+        # jax >= 0.11: the counts moved into the ft_in FlatTree, whose unpacked
+        # (consts, carry, xs) groups hold one placeholder per eqn invar. Bail on
+        # any forwarding shape where invars are not their plain concatenation.
+        groups = p["ft_in"].unpack()
+        if any(entry is not None for group in groups for entry in group):
+            raise _BailOut("scan with forwarded ft_in entries")
+        nconsts, ncarry = len(groups[0]), len(groups[1])
+        if nconsts + ncarry + len(groups[2]) != len(eqn.invars):
+            raise _BailOut("scan ft_in inconsistent with invars")
+    if len(body_jaxpr.outvars) != len(eqn.outvars):
+        raise _BailOut("scan body outputs inconsistent with outvars")
+    length = p["length"]
     reverse = p.get("reverse", False)
     if length > 4096:
         raise _BailOut("scan too long to unroll")


### PR DESCRIPTION
This PR vectorizes the distributed matrix builders, caches the cuSPARSE transpose workspace, and makes SuiteSparse downloads atomic; it also fixes the MPI cache benchmark baseline, cleans up demo typos and redundant MPI steps, and adapts the sparsity tracer to the new scan param format in jax 0.11 (fixes the CI failure).