### PR TITLE
Return residual history from solve

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -65,7 +65,12 @@ settings above.
     The default above is for `jaxamg.solve(...)`, a full Krylov solve (`PBICGSTAB`) preconditioned by AMG. `jaxamg.make_preconditioner(...)` (and `make_lineax_preconditioner(...)`) instead default to a *single* AMG V-cycle (`solver="AMG"`, `max_iters=1`) used as an approximate inverse, since there the outer Krylov method owns the iteration. Override via their own `config`/`kwargs`.
 
 JAX-AMG also enables residual tracking internally (`monitor_residual=1`,
-`store_res_history=1`) so `info["residual"]` is always available.
+`store_res_history=1`) so `info["residual"]` and `info["residual_history"]`
+are always available. The history is the outer solver's convergence curve:
+entry `i` is the residual norm after outer iteration `i`, with entry 0 the
+initial residual. Outside `jit` it is trimmed to `iterations + 1` entries;
+inside `jit` it has fixed length `max_iters + 1`, NaN-padded past entry
+`iterations`.
 
 ### MPI config
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ x, info = jaxamg.solve(A, b)
 print(f"Solution: {x}")
 print(f"Iterations: {info['iterations']}")
 print(f"Residual: {info['residual']}")
+print(f"Convergence curve: {info['residual_history']}")
 ```
 
 `A` can be any sparse matrix (`jax.experimental.sparse` BCSR/BCOO, SciPy sparse), a dense array, or a matrix-free callable operator.

--- a/jaxamg/_amgx.cc
+++ b/jaxamg/_amgx.cc
@@ -144,6 +144,9 @@ PYBIND11_MODULE(_amgx, m)
 #else
   m.attr("mpi_enabled") = py::bool_(false);
 #endif
+  // Python only requests residual-history slots in the stats buffer when this
+  // flag exists; an older extension would leave those slots uninitialized.
+  m.attr("supports_residual_history") = py::bool_(true);
 
   m.def("initialize", &EnsureAmgxInitialized);
   m.def("finalize", &AmgxFinalize);

--- a/jaxamg/_amgx_solvers.h
+++ b/jaxamg/_amgx_solvers.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <fstream>
 #include <algorithm>
+#include <limits>
 #include <type_traits>
 
 #include "_amgx_utils.h"
@@ -138,6 +139,37 @@ namespace
     }
 
     return nullptr;
+  }
+
+  // Assemble the host-side stats buffer: [iterations, final_residual, status,
+  // residual_history...]. The history capacity is whatever the caller allocated
+  // beyond the first three entries (max_iters + 1 slots, or zero for callers
+  // that predate residual history); slots past iteration `iters` stay NaN so
+  // Python can tell padding from recorded residuals.
+  template <typename T>
+  inline std::vector<T> CollectSolveStats(AMGX_solver_handle solver,
+                                          size_t stats_len,
+                                          int iters,
+                                          double residual,
+                                          AMGX_SOLVE_STATUS status)
+  {
+    std::vector<T> stats_host(stats_len, std::numeric_limits<T>::quiet_NaN());
+    if (stats_len >= 3)
+    {
+      stats_host[0] = static_cast<T>(iters);
+      stats_host[1] = static_cast<T>(residual);
+      stats_host[2] = static_cast<T>(status);
+      const size_t n_hist = std::min(stats_len - 3, static_cast<size_t>(iters) + 1);
+      for (size_t i = 0; i < n_hist; ++i)
+      {
+        double r = 0.0;
+        if (AMGX_solver_get_iteration_residual(solver, static_cast<int>(i), 0, &r) == AMGX_RC_OK)
+        {
+          stats_host[3 + i] = static_cast<T>(r);
+        }
+      }
+    }
+    return stats_host;
   }
 
   /*
@@ -364,11 +396,10 @@ namespace
       residual = -1.0;
     }
 
-    T stats_host[3] = {
-        static_cast<T>(iters),
-        static_cast<T>(residual),
-        static_cast<T>(status)};
-    cudaMemcpyAsync(stats_data, stats_host, 3 * sizeof(T), cudaMemcpyHostToDevice, stream);
+    std::vector<T> stats_host = CollectSolveStats<T>(
+        res.solver, stats->element_count(), iters, residual, status);
+    cudaMemcpyAsync(stats_data, stats_host.data(), stats_host.size() * sizeof(T),
+                    cudaMemcpyHostToDevice, stream);
 
     AMGX_SAFE_CALL(AMGX_vector_download(res.x_vec, x_data));
 
@@ -605,8 +636,10 @@ namespace
       residual = -1.0;
     }
 
-    T stats_host[3] = {static_cast<T>(iters), static_cast<T>(residual), static_cast<T>(status)};
-    cudaMemcpyAsync(stats_data, stats_host, 3 * sizeof(T), cudaMemcpyHostToDevice, stream);
+    std::vector<T> stats_host = CollectSolveStats<T>(
+        res.solver, stats->element_count(), iters, residual, status);
+    cudaMemcpyAsync(stats_data, stats_host.data(), stats_host.size() * sizeof(T),
+                    cudaMemcpyHostToDevice, stream);
     AMGX_SAFE_CALL(AMGX_vector_download(res.x_vec, x_data));
 
     if (!cache_hit)

--- a/jaxamg/config.py
+++ b/jaxamg/config.py
@@ -287,3 +287,24 @@ def prepare_config(
     validate_config(merged_config, mpi=mpi)
 
     return _format_config(merged_config)
+
+
+def outer_max_iters(config_str: str) -> int:
+    """Return the outer solver scope's ``max_iters`` from a prepared config string.
+
+    Used to size the residual-history slots of the solve's stats output. The
+    scope mirrors where ``prepare_config`` injects ``store_res_history`` (which
+    is also the scope whose history AmgX exposes); AmgX's registered default of
+    100 is the fallback when the value is absent.
+    """
+    try:
+        cfg = json.loads(config_str)
+    except (TypeError, ValueError):
+        return 100
+    scope = cfg
+    if isinstance(cfg, dict) and isinstance(cfg.get("solver"), dict):
+        scope = cfg["solver"]
+    if not isinstance(scope, dict):
+        return 100
+    value = _as_int(scope.get("max_iters"), 100)
+    return value if value is not None and value > 0 else 100

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -103,6 +103,7 @@ def _amgx_solve_impl(
     transpose_solve: bool = False,
     return_stats: bool = False,
     reuse_setup: bool = False,
+    res_history_len: int = 0,
 ) -> tuple[jax.Array, jax.Array]:
     """Low-level FFI call to AmgX solver (non-differentiable)."""
 
@@ -111,7 +112,7 @@ def _amgx_solve_impl(
 
     out_spec = (
         jax.ShapeDtypeStruct(b.shape, b.dtype),
-        jax.ShapeDtypeStruct((3,), b.dtype),
+        jax.ShapeDtypeStruct((3 + res_history_len,), b.dtype),
     )
 
     call_name = _AMGX_CALL_NAME
@@ -151,6 +152,7 @@ def _amgx_solve_mpi_impl(
     transpose_solve: bool = False,
     return_stats: bool = False,
     reuse_setup: bool = False,
+    res_history_len: int = 0,
 ) -> tuple[jax.Array, jax.Array]:
     """Low-level FFI call to AmgX MPI solver (non-differentiable)."""
 
@@ -159,7 +161,7 @@ def _amgx_solve_mpi_impl(
 
     out_spec = (
         jax.ShapeDtypeStruct(b.shape, b.dtype),
-        jax.ShapeDtypeStruct((3,), b.dtype),
+        jax.ShapeDtypeStruct((3 + res_history_len,), b.dtype),
     )
 
     call_name = _AMGX_CALL_NAME_MPI
@@ -196,12 +198,14 @@ def _get_solver_primitive(
     is_symmetric: bool = False,
     return_stats: bool = False,
     reuse_setup: bool = False,
+    res_history_len: int = 0,
 ) -> Callable:
     """
     Returns a JAX custom_vjp primitive for AmgX solve with a specific configuration.
     Cached to avoid recompilation for identical configurations.
 
     reuse_setup: Skip warm AMGX resetup and keep the cached hierarchy.
+    res_history_len: Residual-history slots appended to the stats output.
     """
 
     @jax.custom_vjp
@@ -214,6 +218,7 @@ def _get_solver_primitive(
             config_str=config_str,
             return_stats=return_stats,
             reuse_setup=reuse_setup,
+            res_history_len=res_history_len,
         )
         return x, info
 
@@ -286,6 +291,7 @@ def _get_solver_primitive_mpi(
     n_ghost: int = 0,
     return_stats: bool = False,
     reuse_setup: bool = False,
+    res_history_len: int = 0,
 ) -> Callable:
     """
     Create cached JAX custom_vjp primitive for MPI AmgX solve.
@@ -345,6 +351,7 @@ def _get_solver_primitive_mpi(
             config_str=config_str,
             return_stats=return_stats,
             reuse_setup=reuse_setup,
+            res_history_len=res_history_len,
         )
 
         return x, info
@@ -461,7 +468,7 @@ def solve(
 
     Returns:
         x: Solution vector (float32 or float64). In MPI mode, returns local portion.
-        info: Dictionary containing `iterations`, `residual`, and `status`.
+        info: Dictionary containing `iterations`, `residual`, `status`, and `residual_history` (residual norm per outer iteration, entry 0 being the initial residual; inside `jit` it has fixed length `max_iters + 1` with NaN padding past entry `iterations`).
     """
 
     b = jnp.asarray(b)
@@ -474,7 +481,7 @@ def solve(
         )
 
     # Load the native extension and register FFI targets (sets HAS_MPI).
-    _ensure_backend()
+    ext = _ensure_backend()
 
     # MPI cache may be pre-attached to A via `with_cache`
     mpi_cache = getattr(A, "_mpi_cache", None)
@@ -503,6 +510,15 @@ def solve(
             mpi=(comm is not None),
             **kwargs,
         )
+
+    # Residual-history slots appended to the stats output (outer max_iters + 1
+    # entries). An older extension without support would leave them
+    # uninitialized, so only request them when the extension advertises the
+    # capability.
+    if getattr(ext, "supports_residual_history", False):
+        res_history_len = amgx_config.outer_max_iters(config_str) + 1
+    else:
+        res_history_len = 0
 
     # Detect desired precision (non-float RHS dtypes are promoted to float32)
     target_dtype = get_preferred_dtype(A, b)
@@ -552,6 +568,7 @@ def solve(
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
                 reuse_setup=reuse_setup,
+                res_history_len=res_history_len,
             )
 
             x, info = solver(
@@ -635,6 +652,7 @@ def solve(
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
                 reuse_setup=reuse_setup,
+                res_history_len=res_history_len,
             )
             x, info = solver(
                 A_csr,
@@ -653,19 +671,33 @@ def solve(
             is_symmetric=is_symmetric,
             return_stats=1 if save_stats_file else 0,
             reuse_setup=reuse_setup,
+            res_history_len=res_history_len,
         )
 
         x, info = solver(A_csr, b)
 
     if isinstance(info, jax.core.Tracer):
         # Inside JIT (or another trace): info elements are tracers; return as-is.
-        return x, {"iterations": info[0], "residual": info[1], "status": info[2]}
+        # The history keeps its fixed trace-time length (outer max_iters + 1),
+        # NaN-padded past entry `iterations`.
+        info_dict: dict[str, Any] = {
+            "iterations": info[0],
+            "residual": info[1],
+            "status": info[2],
+        }
+        if res_history_len:
+            info_dict["residual_history"] = info[3:]
+        return x, info_dict
 
     info_dict = {
         "iterations": int(info[0]),
         "residual": float(info[1]),
         "status": AMGXStatus(int(info[2])),
     }
+    if res_history_len:
+        # Entry i is the residual norm after outer iteration i (entry 0 is the
+        # initial residual); trim the NaN padding outside a trace.
+        info_dict["residual_history"] = info[3 : 4 + int(info[0])]
     if save_stats_file is not None:
         try:
             stats_str = _ensure_backend().get_stats_string()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,3 +244,32 @@ def test_prepare_config_rejects_mpi_dilu_tiny_min_coarse_rows():
 
     with pytest.raises(ValueError, match="MULTICOLOR_DILU"):
         prepare_config(config, mpi=True)
+
+
+def test_outer_max_iters():
+    """outer_max_iters reads the outer solver scope of a prepared config."""
+    from jaxamg.config import outer_max_iters
+
+    # Default config: jaxamg's default outer max_iters.
+    assert outer_max_iters(prepare_config()) == 1000
+
+    # Flat overrides land in the outer scope.
+    assert outer_max_iters(prepare_config({"max_iters": 25})) == 25
+    assert outer_max_iters(prepare_config(max_iters=7)) == 7
+
+    # Nested config: the outer solver block's max_iters wins; the
+    # preconditioner's own max_iters is ignored.
+    nested = prepare_config(
+        {
+            "solver": {
+                "solver": "FGMRES",
+                "max_iters": 40,
+                "preconditioner": {"solver": "AMG", "max_iters": 3},
+            }
+        }
+    )
+    assert outer_max_iters(nested) == 40
+
+    # Unparseable input falls back to AmgX's registered default.
+    assert outer_max_iters("") == 100
+    assert outer_max_iters("not json") == 100

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -761,3 +761,40 @@ def test_mpi_repeated_solve_warm_cache(mpi_context):
         # x = x0 / 2 rather than a silent reuse of the first matrix.
         np.testing.assert_allclose(A_global @ x_scaled, 0.5 * b_global, atol=1e-4)
         np.testing.assert_allclose(x_scaled, 0.5 * solutions[0], atol=1e-4)
+
+
+@pytest.mark.mpi(min_size=2)
+def test_mpi_residual_history(mpi_context):
+    """The residual history is the global convergence curve on every rank."""
+    comm, rank, nranks = mpi_context
+
+    grid_size = 16
+    n = grid_size**2
+    A_local, row_start, row_end = poisson_matrix_distributed(
+        grid_size, grid_size, rank, nranks
+    )
+    b_global = rhs_linear(n)
+    b_local, _, _ = partition_vector(b_global, rank, nranks)
+
+    _, info = jaxamg.solve(
+        A_local,
+        b_local,
+        comm=comm,
+        nglobal=n,
+        partition_info=(row_start, row_end),
+    )
+
+    assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+    history = np.asarray(info["residual_history"])
+    assert history.shape == (info["iterations"] + 1,)
+    assert np.isfinite(history).all()
+    np.testing.assert_allclose(history[-1], info["residual"], rtol=1e-6)
+
+    # Entry 0 is the initial GLOBAL residual norm, and the monitored norm is a
+    # global reduction, so every rank must see the identical curve.
+    np.testing.assert_allclose(
+        history[0], np.linalg.norm(np.asarray(b_global)), rtol=1e-5
+    )
+    all_hist = comm.allgather(history)
+    for other in all_hist[1:]:
+        np.testing.assert_array_equal(other, all_hist[0])

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -294,6 +294,7 @@ class TestSolver:
             transpose_solve=False,
             return_stats=False,
             reuse_setup=False,
+            res_history_len=0,
         ):
             calls.append(
                 {
@@ -301,7 +302,7 @@ class TestSolver:
                     "reuse_setup": bool(reuse_setup),
                 }
             )
-            return b, jnp.array([0, 0, 0], dtype=b.dtype)
+            return b, jnp.zeros(3 + res_history_len, dtype=b.dtype)
 
         monkeypatch.setattr(jaxamg_module, "_amgx_solve_impl", fake_amgx_solve)
         jaxamg_module._get_solver_primitive.cache_clear()
@@ -561,3 +562,66 @@ class TestSolver:
         assert scipy.sparse.isspmatrix_csr(loaded)
         assert loaded.dtype == np.float32
         np.testing.assert_allclose(loaded.toarray(), A.astype(np.float32).toarray())
+
+
+class TestResidualHistory:
+    """info["residual_history"]: the outer solver's convergence curve."""
+
+    def test_eager_history(self):
+        A = poisson_matrix(64)
+        b = rhs_ones(64 * 64)
+        _, info = jaxamg.solve(A, b)
+
+        assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+        history = np.asarray(info["residual_history"])
+
+        # Outside jit the NaN padding is trimmed: one entry per outer
+        # iteration, plus the initial residual at entry 0.
+        assert history.shape == (info["iterations"] + 1,)
+        assert np.isfinite(history).all()
+
+        # Entry 0 is the initial residual norm (x starts at zero, so ||b||).
+        np.testing.assert_allclose(history[0], np.linalg.norm(np.asarray(b)), rtol=1e-6)
+        # The last entry is the final residual already reported in info.
+        np.testing.assert_allclose(history[-1], info["residual"], rtol=1e-6)
+        # Default convergence criterion is RELATIVE_INI at 1e-6.
+        assert history[-1] / history[0] <= 1e-6
+
+    def test_jit_history_fixed_shape(self):
+        A = poisson_matrix(32)
+        b = rhs_ones(32 * 32)
+        max_iters = 50
+
+        @jax.jit
+        def run(A, b):
+            return jaxamg.solve(A, b, max_iters=max_iters)
+
+        _, info = run(A, b)
+        history = np.asarray(info["residual_history"])
+        iters = int(info["iterations"])
+
+        # Inside jit the history keeps its trace-time length (max_iters + 1),
+        # NaN-padded past the recorded entries.
+        assert history.shape == (max_iters + 1,)
+        assert np.isfinite(history[: iters + 1]).all()
+        assert np.isnan(history[iters + 1 :]).all()
+
+        # The recorded prefix matches the eager solve.
+        _, info_eager = jaxamg.solve(A, b, max_iters=max_iters)
+        np.testing.assert_allclose(
+            history[: iters + 1],
+            np.asarray(info_eager["residual_history"]),
+            rtol=1e-6,
+        )
+
+    def test_not_converged_history_is_full(self):
+        A = poisson_matrix(64)
+        b = rhs_ones(64 * 64)
+        _, info = jaxamg.solve(A, b, max_iters=3)
+
+        assert info["status"] == jaxamg.AMGXStatus.NOT_CONVERGED
+        history = np.asarray(info["residual_history"])
+        assert history.shape == (4,)
+        assert np.isfinite(history).all()
+        # Not converged, but the preconditioned solver still made progress.
+        assert history[-1] < history[0]


### PR DESCRIPTION
This PR returns the outer solver's per-iteration residual history in `info["residual_history"]`.