### PR TITLE
Singular system support

### DIFF
--- a/demo/mpi_singular_poisson_stretched_grid.py
+++ b/demo/mpi_singular_poisson_stretched_grid.py
@@ -1,0 +1,118 @@
+"""
+Demo: MPI-distributed version of singular_poisson_stretched_grid.py.
+
+Usage:
+    mpirun -n 2 python demo/mpi_singular_poisson_stretched_grid.py
+"""
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from mpi4py import MPI
+
+import jaxamg
+from jaxamg import NullSpaceWarning
+from jaxamg.matrices import poisson_matrix_stretched
+from jaxamg.mpi_utils import gather_vector, partition_csr_matrix
+from jaxamg.utils import to_scipy
+
+jax.config.update("jax_enable_x64", True)
+
+nx, ny = 64, 48
+stretches = [1.00, 1.02, 1.04, 1.08, 1.10]
+cfg = {"tolerance": 1e-10, "max_iters": 200}
+
+
+def run_case(stretch, comm):
+    rank, nranks = comm.Get_rank(), comm.Get_size()
+    A_global, V = poisson_matrix_stretched(nx, ny, stretch, dtype=jnp.float64)
+    n = A_global.shape[0]
+    V_np = np.asarray(V)
+    rng = np.random.default_rng(0)
+    b = rng.standard_normal(n)
+    b -= (V_np @ b) / V_np.sum()  # compatible RHS
+    w = rng.standard_normal(n) + 0.5
+
+    A_sp = to_scipy(A_global)
+    A_local, row_start, row_end = partition_csr_matrix(A_global, rank, nranks)
+    A_T_local, _, _ = partition_csr_matrix(A_sp.T.tocsr(), rank, nranks)
+    rows = slice(row_start, row_end)
+    V_local, b_local, w_local = (jnp.asarray(v[rows]) for v in (V_np, b, w))
+    mpi = {"comm": comm, "nglobal": n, "partition_info": (row_start, row_end)}
+
+    if rank == 0:
+        pinv = np.linalg.pinv(A_sp.toarray())
+        x_ref, g_ref = pinv @ b, pinv.T @ w
+
+    def err(v_local, ref, null):
+        # plain solves are compared up to the null vector (1 forward, V adjoint)
+        v = gather_vector(v_local, comm)
+        if rank != 0:
+            return None
+        v = np.asarray(v)
+        if null is not None:
+            v = v - null * ((v - ref) @ null) / (null @ null)
+        return np.linalg.norm(v - ref) / np.linalg.norm(ref)
+
+    out = []
+    ones = np.ones(n)
+    for kwargs, kwargs_T, null_x, null_g in [
+        ({}, {}, ones, V_np),
+        (
+            {"nullspace": "constant", "transpose_nullspace": V_local},
+            {"nullspace": V_local, "transpose_nullspace": "constant"},
+            None,
+            None,
+        ),
+    ]:
+        x, info = jaxamg.solve(A_local, b_local, **kwargs, **mpi, **cfg)
+        # adjoint system Aᵀλ = g solved by jax.grad (explicitly, to read its iteration count)
+        _, info_adj = jaxamg.solve(A_T_local, w_local, **kwargs_T, **mpi, **cfg)
+        # local loss w_local·x_local: summed over ranks it is w·x, so each
+        # rank's gradient is its slice of the global one
+        g = jax.grad(
+            lambda b_: jnp.dot(
+                w_local, jaxamg.solve(A_local, b_, **kwargs, **mpi, **cfg)[0]
+            )
+        )(b_local)
+        ex = err(x, x_ref if rank == 0 else None, null_x)
+        eg = err(g, g_ref if rank == 0 else None, null_g)
+        if rank == 0:
+            out.append(
+                f"{info['iterations']:4d} {ex:8.1e}   {info_adj['iterations']:4d} {eg:8.1e}"
+            )
+    return out
+
+
+def main():
+    warnings.simplefilter("ignore", NullSpaceWarning)
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    devices = jax.devices()
+    jax.config.update("jax_default_device", devices[rank % len(devices)])
+    if rank == 0:
+        print(
+            f"{nx}x{ny} cells, {comm.Get_size()} ranks, float64, {cfg} (iterations and relative error)\n"
+        )
+        print(
+            f"{'':8s}{'------- plain solve -------':^30s}   {'----- with nullspace -----':^30s}"
+        )
+        print(
+            f"{'':8s}{'forward':^15s}{'adjoint':^15s}   {'forward':^15s}{'adjoint':^15s}"
+        )
+        print(
+            f"{'stretch':8s}{'iters':>5s}{'error':>9s}   {'iters':>5s}{'error':>9s}   "
+            f"{'iters':>5s}{'error':>9s}   {'iters':>5s}{'error':>9s}"
+        )
+    for stretch in stretches:
+        rows = run_case(stretch, comm)
+        if rank == 0:
+            print(f"{stretch:<8.2f}{rows[0]}   {rows[1]}")
+    comm.Barrier()
+    jaxamg.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/singular_poisson_stretched_grid.py
+++ b/demo/singular_poisson_stretched_grid.py
@@ -1,0 +1,88 @@
+"""
+Demo: differentiating a singular Poisson solve on a stretched grid.
+
+Volume-normalized finite-volume Poisson operator A = D⁻¹L (periodic/Neumann):
+singular, and nonsymmetric on a stretched grid (A·1 = 0 but Aᵀ·V = 0).
+Compares a plain solve with `nullspace="constant", transpose_nullspace=V`.
+"""
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import jaxamg
+from jaxamg import NullSpaceWarning
+from jaxamg.matrices import poisson_matrix_stretched
+from jaxamg.utils import to_scipy
+
+jax.config.update("jax_enable_x64", True)
+
+nx, ny = 64, 48
+stretches = [1.00, 1.02, 1.04, 1.08, 1.10]
+cfg = {"tolerance": 1e-10, "max_iters": 200}
+
+
+def run_case(stretch):
+    A, V = poisson_matrix_stretched(nx, ny, stretch, dtype=jnp.float64)
+    n = A.shape[0]
+    V_np = np.asarray(V)
+    rng = np.random.default_rng(0)
+    b = rng.standard_normal(n)
+    b -= (V_np @ b) / V_np.sum()  # compatible RHS
+    w = rng.standard_normal(n) + 0.5
+    b, w = jnp.asarray(b), jnp.asarray(w)
+
+    A_dense = to_scipy(A).toarray()
+    A_T = to_scipy(A).T.tocsr()
+    pinv = np.linalg.pinv(A_dense)
+    x_ref, g_ref = pinv @ np.asarray(b), pinv.T @ np.asarray(w)
+
+    def err(v, ref, null):
+        # plain solves are compared up to the null vector (1 forward, V adjoint)
+        v = np.asarray(v)
+        if null is not None:
+            v = v - null * ((v - ref) @ null) / (null @ null)
+        return np.linalg.norm(v - ref) / np.linalg.norm(ref)
+
+    rows = []
+    ones = np.ones(n)
+    for kwargs, kwargs_T, null_x, null_g in [
+        ({}, {}, ones, V_np),
+        (
+            {"nullspace": "constant", "transpose_nullspace": V},
+            {"nullspace": V, "transpose_nullspace": "constant"},
+            None,
+            None,
+        ),
+    ]:
+        x, info = jaxamg.solve(A, b, **kwargs, **cfg)
+        # adjoint system Aᵀλ = g solved by jax.grad (explicitly, to read its iteration count)
+        _, info_adj = jaxamg.solve(A_T, w, **kwargs_T, **cfg)
+        g = jax.grad(lambda b_: jnp.dot(w, jaxamg.solve(A, b_, **kwargs, **cfg)[0]))(b)
+        rows.append(
+            f"{info['iterations']:4d} {err(x, x_ref, null_x):8.1e}   "
+            f"{info_adj['iterations']:4d} {err(g, g_ref, null_g):8.1e}"
+        )
+    return rows
+
+
+def main():
+    warnings.simplefilter("ignore", NullSpaceWarning)
+    print(f"{nx}x{ny} cells, float64, {cfg} (iterations and relative error)\n")
+    print(
+        f"{'':8s}{'------- plain solve -------':^30s}   {'----- with nullspace -----':^30s}"
+    )
+    print(f"{'':8s}{'forward':^15s}{'adjoint':^15s}   {'forward':^15s}{'adjoint':^15s}")
+    print(
+        f"{'stretch':8s}{'iters':>5s}{'error':>9s}   {'iters':>5s}{'error':>9s}   "
+        f"{'iters':>5s}{'error':>9s}   {'iters':>5s}{'error':>9s}"
+    )
+    for stretch in stretches:
+        plain, ns = run_case(stretch)
+        print(f"{stretch:<8.2f}{plain}   {ns}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,14 @@ This page documents the public API of JAX-AMG.
         show_source: false
         heading_level: 3
 
+## Warnings
+
+::: jaxamg.NullSpaceWarning
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
 ## Caching
 
 ::: jaxamg.with_cache

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -52,6 +52,12 @@ When to use each option:
     - This allows the backward pass to skip transpose-related work for symmetric systems.
     - Set it only when the matrix is truly symmetric and remains symmetric.
     - You can set it directly in `with_cache(...)`.
+    - It also lets `transpose_nullspace` default to `nullspace`.
+
+- `nullspace=...` / `transpose_nullspace=...`
+    - Defaults for the arguments of the same name in `jaxamg.solve(...)`; see
+      [Singular systems](examples.md#singular-systems).
+    - In MPI mode also prepare the cached config with `cache_mpi_metadata(..., singular=True)`.
 
 ## Native AmgX resource cache
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -114,6 +114,18 @@ strongly coupled system, `BLOCK_JACOBI` under `block_dim=2` inverts true
 2x2 diagonal blocks (instead of scalar diagonal entries) and can converge in
 a handful of iterations where the scalar-preconditioned solve stalls.
 
+### Singular systems
+
+When a null space is declared (`solve(..., nullspace=...)` or
+`with_cache(A, nullspace=...)`), the AMG defaults change on the coarse level:
+`coarse_solver` becomes `{"solver": "BLOCK_JACOBI", "max_iters": 10}`,
+`min_coarse_rows` becomes `8`, and `dense_lu_num_rows` is dropped.
+`DENSE_LU_SOLVER` factorizes the coarsest matrix, which is singular for these
+systems, and the V-cycle diverges; Jacobi sweeps do not. Explicit
+`coarse_solver` / `min_coarse_rows` settings are kept, and `DENSE_LU_SOLVER`
+with a null space emits a `NullSpaceWarning`. For cached MPI metadata pass
+`singular=True` to `cache_mpi_metadata(...)`.
+
 ### MPI config
 
 The `communicator` key can be set to `MPI` for standard CPU-based MPI or `MPI_DIRECT` for GPU-aware MPI. The default is `MPI`. To use GPU-aware MPI, ensure that your MPI installation supports it. For more details, see the [MPI Guide](mpi.md).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -390,6 +390,49 @@ If you use [Lineax](https://docs.kidger.site/lineax/), `jaxamg.make_lineax_preco
     Converged!
     ```
 
+### Singular systems
+
+For a singular matrix (e.g. a Poisson problem with periodic or Neumann boundaries), pass the null-space bases: `nullspace` (of `A`) pins the solution and keeps the adjoint solve consistent, `transpose_nullspace` (of `Aᵀ`) projects `b` onto the range of `A`. For a symmetric matrix the two coincide; for a volume-normalized finite-volume operator `A = D⁻¹L` the first is the constant vector and the second the cell volumes. See [`jaxamg.solve`](api.md#jaxamg.solve) for details.
+
+=== "Python"
+
+    ```python
+    import jax
+    import jax.numpy as jnp
+    import numpy as np
+    import jaxamg
+    from jaxamg.matrices import poisson_matrix_stretched
+
+    jax.config.update("jax_enable_x64", True)
+
+    # Volume-normalized Poisson operator on a stretched grid: A·1 = 0, Aᵀ·V = 0
+    A, V = poisson_matrix_stretched(64, 48, stretch=1.06, dtype=jnp.float64)
+    n = A.shape[0]
+    rng = np.random.default_rng(0)
+    b = rng.standard_normal(n)
+    b -= (np.asarray(V) @ b) / np.asarray(V).sum()  # compatible RHS
+    w = jnp.asarray(rng.standard_normal(n))
+    b = jnp.asarray(b)
+
+    def loss(b):
+        x, _ = jaxamg.solve(A, b, nullspace="constant", transpose_nullspace=V, tolerance=1e-10)
+        return jnp.dot(w, x)
+
+    x, info = jaxamg.solve(A, b, nullspace="constant", transpose_nullspace=V, tolerance=1e-10)
+    g = jax.jit(jax.grad(loss))(b)
+
+    g_ref = np.linalg.pinv(np.asarray(A.todense())).T @ np.asarray(w)
+    print(f"Iterations: {info['iterations']}, mean(x): {float(x.mean()):.1e}")
+    print(f"Gradient error: {np.linalg.norm(g - g_ref) / np.linalg.norm(g_ref):.1e}")
+    ```
+
+=== "Result"
+
+    ```text
+    Iterations: 13, mean(x): 0.0e+00
+    Gradient error: 1.2e-10
+    ```
+
 ### Optimization with color caching for operator
 
 For parameterized operators, compute coloring once and reuse it during optimization.

--- a/docs/mpi.md
+++ b/docs/mpi.md
@@ -133,3 +133,17 @@ config = {
 ```
 
 Non-GPU-aware MPI still works, but communication may stage through host memory and be slower.
+
+## Singular systems
+
+`nullspace` and `transpose_nullspace` (see [Singular systems](examples.md#singular-systems))
+take each rank's local rows; the projections reduce across ranks internally.
+With cached metadata, prepare it with `singular=True` and attach the bases to `A`:
+
+```python
+mpi_cache = jaxamg.cache_mpi_metadata(config, comm, n, (row_start, row_end), A_local, singular=True)
+A_local = jaxamg.with_cache(A_local, mpi=mpi_cache, nullspace="constant", transpose_nullspace=V_local)
+x_local, info = jaxamg.solve(A_local, b_local)
+```
+
+The `Aᵀ·M ≈ 0` check of `transpose_nullspace` is skipped in MPI mode.

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -10,6 +10,7 @@ from .jaxamg import (
     get_solver_cache_info,
     solve,
 )
+from .nullspace import NullSpaceWarning
 from .preconditioners import make_lineax_preconditioner, make_preconditioner
 from .sparsity import cache_coloring
 
@@ -20,6 +21,7 @@ __all__ = [
     "cache_coloring",
     "cache_mpi_metadata",
     "AMGXStatus",
+    "NullSpaceWarning",
     "make_preconditioner",
     "make_lineax_preconditioner",
     "clear_solver_cache",

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import jax
 import numpy as np
+from jax.typing import ArrayLike
 
 from . import config as amgx_config
 from .utils import *
@@ -24,9 +25,11 @@ def with_cache(
     ) = None,
     mpi: dict[str, Any] | None = None,
     is_symmetric: bool = False,
+    nullspace: ArrayLike | str | None = None,
+    transpose_nullspace: ArrayLike | str | None = None,
 ) -> MatrixOrOperator:
     """
-    Attach cached metadata (coloring, MPI info, or symmetry) to a matrix or operator.
+    Attach cached metadata (coloring, MPI info, symmetry, null spaces) to a matrix or operator.
 
     This cache allows using matrices/operators inside JIT-compiled functions
     without recomputing metadata or passing it as separate arguments. See [Caching Guide](caching.md) for more details.
@@ -37,6 +40,9 @@ def with_cache(
         mpi: Cached MPI metadata from `cache_mpi_metadata()`.
         is_symmetric: If True, indicates the matrix is symmetric, allowing
                       optimizations like skipping transpose in backward pass.
+        nullspace: Default for `jaxamg.solve`'s `nullspace` (`"constant"`, a
+                   vector, or an `(n, k)` array; local rows in MPI mode).
+        transpose_nullspace: Default for `jaxamg.solve`'s `transpose_nullspace`.
 
     Returns:
         The same matrix/operator with requested cache attached.
@@ -68,6 +74,19 @@ def with_cache(
                 f"Error: {e}"
             )
 
+    for attr, value in (
+        ("_nullspace", nullspace),
+        ("_transpose_nullspace", transpose_nullspace),
+    ):
+        if value is not None:
+            try:
+                object.__setattr__(A, attr, value)
+            except Exception as e:
+                raise TypeError(
+                    f"Cannot attach null-space info to object of type "
+                    f"{type(A).__name__}. Error: {e}"
+                )
+
     return A
 
 
@@ -80,6 +99,7 @@ def cache_mpi_metadata(
     is_symmetric: bool = False,
     save_stats: bool = False,
     block_dim: int = 1,
+    singular: bool = False,
 ) -> dict[str, Any]:
     """
     Pre-compute and cache MPI metadata for JIT-compatible solver usage.
@@ -111,6 +131,9 @@ def cache_mpi_metadata(
             matrix produces a complete stats file.
         block_dim: BSR block size for AmgX (see `jaxamg.solve`). Each rank's
             local partition must be divisible by it.
+        singular: Use the singular-system AMG defaults (see
+            [Solver Configuration](config.md#singular-systems)). Implied when
+            null-space bases are already attached to `A` via `with_cache`.
 
     Returns:
         A dictionary containing MPI metadata.
@@ -129,6 +152,10 @@ def cache_mpi_metadata(
         - `halo_plan`: Backward-pass halo-exchange plan for the gradient w.r.t.
           A (fetches only referenced remote solution entries)
     """
+    singular = singular or any(
+        getattr(A, attr, None) is not None
+        for attr in ("_nullspace", "_transpose_nullspace")
+    )
     rank = comm.Get_rank()
     row_start, row_end = partition_info
     n_local = row_end - row_start
@@ -155,7 +182,7 @@ def cache_mpi_metadata(
 
     # Prepare config string
     config_str = amgx_config.prepare_config(
-        config, save_stats=save_stats, mpi=True, block_dim=block_dim
+        config, save_stats=save_stats, mpi=True, block_dim=block_dim, singular=singular
     )
 
     # Compute max_nnz across all ranks, and capture this rank's global column
@@ -219,6 +246,7 @@ def cache_mpi_metadata(
         "nnz_out": nnz_out,
         "halo_plan": halo_plan,
         "block_dim": block_dim,
+        "singular": singular,
     }
 
     return cache_dict

--- a/jaxamg/config.py
+++ b/jaxamg/config.py
@@ -306,6 +306,7 @@ def prepare_config(
     save_stats: bool = False,
     mpi: bool = False,
     block_dim: int = 1,
+    singular: bool = False,
     **kwargs: Any,
 ) -> str:
     """
@@ -316,6 +317,8 @@ def prepare_config(
     ``config_version: 2`` nested JSON format. For block matrices
     (``block_dim > 1``) the AMG defaults switch from classical to
     aggregation AMG, the only AmgX AMG algorithm that supports blocks.
+    ``singular=True`` (set when a null space is declared) replaces the
+    ``DENSE_LU_SOLVER`` coarse solve by block-Jacobi sweeps.
     """
     # Clean copy of AMG defaults
     amg_defaults = deep_merge(
@@ -329,6 +332,14 @@ def prepare_config(
     # distributed block solves; single-GPU block solves keep DENSE_LU.
     if mpi and block_dim > 1:
         amg_defaults["coarse_solver"] = {"solver": "BLOCK_JACOBI", "max_iters": 50}
+        amg_defaults.pop("dense_lu_num_rows", None)
+
+    # DENSE_LU on the (singular) coarsest matrix diverges; a few Jacobi sweeps
+    # do not (many slow the transposed solve). The coarse floor keeps a
+    # k-dimensional null space from collapsing the coarsest level to zero rows.
+    if singular:
+        amg_defaults["coarse_solver"] = {"solver": "BLOCK_JACOBI", "max_iters": 10}
+        amg_defaults["min_coarse_rows"] = 8
         amg_defaults.pop("dense_lu_num_rows", None)
 
     defaults = {
@@ -371,6 +382,27 @@ def prepare_config(
     validate_config(merged_config, mpi=mpi, block_dim=block_dim)
 
     return _format_config(merged_config)
+
+
+def uses_dense_lu_coarse_solver(config_str: str) -> bool:
+    """Whether an AMG scope of a prepared config string uses ``DENSE_LU_SOLVER``
+    as its coarse solver (see `prepare_config`'s ``singular`` option)."""
+    try:
+        cfg = json.loads(config_str)
+    except (TypeError, ValueError):
+        return False
+    scope = cfg
+    if isinstance(cfg, dict) and isinstance(cfg.get("solver"), dict):
+        scope = cfg["solver"]
+    if not isinstance(scope, dict):
+        return False
+    for amg in _amg_blocks(scope):
+        entry = amg.get("coarse_solver")
+        if isinstance(entry, dict):
+            entry = entry.get("solver")
+        if _as_upper(entry) == "DENSE_LU_SOLVER":
+            return True
+    return False
 
 
 def outer_max_iters(config_str: str) -> int:

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -22,6 +22,21 @@ from .mpi_utils import (
     register_comm,
     resolve_comm,
 )
+from .nullspace import (
+    _DENSE_LU_MSG,
+    _MISSING_NULLSPACE_MSG,
+    _MISSING_TRANSPOSE_MSG,
+    NullSpaceSpec,
+    NullSpaceWarning,
+    as_nullspace_basis,
+    make_mpi_reduce_sum,
+    project_out,
+    relative_norm,
+    row_index,
+    validate_basis,
+    verify_nullspace,
+    warn_if_singular,
+)
 from .utils import *
 
 if TYPE_CHECKING:
@@ -510,6 +525,8 @@ def solve(
     partition_info: tuple[int, int] | None = None,
     save_stats_file: str | os.PathLike | None = None,
     reuse_setup: bool = False,
+    nullspace: NullSpaceSpec = None,
+    transpose_nullspace: NullSpaceSpec = None,
     **kwargs: Any,
 ) -> tuple[jax.Array, dict]:
     """Solve `Ax=b` using the AmgX backend. See [Examples](examples.md) for usage.
@@ -525,11 +542,16 @@ def solve(
         partition_info: `(row_start, row_end)` owned by this rank in MPI mode.  Required when `comm` is provided and MPI metadata is not pre-attached to `A`.
         save_stats_file: Optional file path to save detailed AmgX solver statistics.  If None, no file is created.
         reuse_setup: For repeated solves with the same sparsity pattern, skip warm `AMGX_solver_resetup` and keep the cached hierarchy. This is cheaper per solve but may require more iterations if matrix coefficients change significantly.
+        nullspace: Basis of `null(A)` for singular systems: `"constant"`, a length-`n` vector, or an `(n, k)` array (local rows in MPI mode). The solution is pinned orthogonal to it, and the transpose of that pin projects the adjoint right-hand side onto `range(Aᵀ)`, which makes the backward solve converge. Gradients w.r.t. `A` assume perturbations that preserve the declared null spaces (`dA·N = 0`, `Mᵀ·dA = 0`), as coefficient changes of a conservative discretization do. Defaults to the basis attached with `with_cache`.
+        transpose_nullspace: Basis of `null(Aᵀ)` (same formats). `b` is projected onto `range(A)` (removed fraction in `info["rhs_inconsistency"]`) and, by transposition, the adjoint solution is pinned: the forward returns `A⁺b`, `jax.grad` returns `(Aᵀ)⁺g`. Equals `nullspace` for symmetric `A` (filled in when `A` is marked symmetric); for nonsymmetric `A` it differs, e.g. `A = D⁻¹L` has `nullspace="constant"` but `transpose_nullspace=V` (cell volumes). Defaults to the basis attached with `with_cache`.
         **kwargs: Additional AmgX config parameters. These override values in `config` when both are provided.
 
     Returns:
         x: Solution vector (float32 or float64). In MPI mode, returns local portion.
-        info: Dictionary containing `iterations`, `residual`, `status`, and `residual_history` (residual norm per outer iteration, entry 0 being the initial residual; inside `jit` it has fixed length `max_iters + 1` with NaN padding past entry `iterations`).
+        info: Dictionary containing `iterations`, `residual`, `status`, and `residual_history` (residual norm per outer iteration, entry 0 being the initial residual; inside `jit` it has fixed length `max_iters + 1` with NaN padding past entry `iterations`). With `transpose_nullspace`, also `rhs_inconsistency` (`‖b − b'‖/‖b‖`).
+
+    Warns:
+        NullSpaceWarning: `A·1 = 0` without a declared `nullspace`; `nullspace` without `transpose_nullspace` (or vice versa) for a matrix not marked symmetric; a basis failing `A·N ≈ 0` / `Aᵀ·M ≈ 0` (the latter not checked in MPI mode); or a `DENSE_LU_SOLVER` coarse solve. Checks run only on concrete matrix values.
     """
 
     b = jnp.asarray(b)
@@ -555,6 +577,13 @@ def solve(
 
     # MPI cache may be pre-attached to A via `with_cache`
     mpi_cache = getattr(A, "_mpi_cache", None)
+
+    # Null-space bases: explicit arguments override ones attached via with_cache.
+    if nullspace is None:
+        nullspace = getattr(A, "_nullspace", None)
+    if transpose_nullspace is None:
+        transpose_nullspace = getattr(A, "_transpose_nullspace", None)
+    singular = nullspace is not None or transpose_nullspace is not None
 
     # Prepare configuration string/file (skip if using mpi_cache which already has config_str)
     if mpi_cache is not None:
@@ -588,8 +617,11 @@ def solve(
             save_stats=(save_stats_file is not None),
             mpi=(comm is not None),
             block_dim=block_dim,
+            singular=singular,
             **kwargs,
         )
+    if singular and amgx_config.uses_dense_lu_coarse_solver(config_str):
+        warnings.warn(_DENSE_LU_MSG, NullSpaceWarning, stacklevel=2)
 
     # Residual-history slots appended to the stats output (one per outer
     # iteration, plus the initial residual).
@@ -661,14 +693,6 @@ def solve(
                 block_dim=block_dim,
             )
 
-            x, info = solver(
-                A_csr,
-                b,
-                x0_arg,
-                jnp.asarray(halo_plan.col_to_combined),
-                jnp.asarray(halo_plan.send_ids_2d),
-                jnp.asarray(halo_plan.recv_ghost_slot_2d),
-            )
         elif comm is not None:
             # Compute metadata dynamically
             import importlib.util
@@ -747,14 +771,51 @@ def solve(
                 use_x0=use_x0,
                 block_dim=block_dim,
             )
-            x, info = solver(
-                A_csr,
-                b,
-                x0_arg,
-                jnp.asarray(halo_plan.col_to_combined),
-                jnp.asarray(halo_plan.send_ids_2d),
-                jnp.asarray(halo_plan.recv_ghost_slot_2d),
-            )
+
+        halo_args = (
+            jnp.asarray(halo_plan.col_to_combined),
+            jnp.asarray(halo_plan.send_ids_2d),
+            jnp.asarray(halo_plan.recv_ghost_slot_2d),
+        )
+        if mpi_cache is not None:
+            # AmgX runs on the cached communicator; so must everything else.
+            comm_obj = resolve_comm(mpi_cache["comm_ptr"])
+            if comm is not None and register_comm(comm) != mpi_cache["comm_ptr"]:
+                warnings.warn(
+                    "comm differs from the communicator cached on A; using the "
+                    "cached one.",
+                    stacklevel=2,
+                )
+        else:
+            assert comm is not None
+            comm_obj = comm
+        # Global reductions for the null-space projections.
+        reduce_sum = make_mpi_reduce_sum(comm_obj)
+
+        def run(b_: jax.Array, x0_: jax.Array) -> tuple[jax.Array, jax.Array]:
+            return solver(A_csr, b_, x0_, *halo_args)
+
+        n_ghost = halo_plan.n_ghost
+
+        def matvec(basis: jax.Array) -> jax.Array:
+            # Local rows of A @ basis via halo exchange (eager check only).
+            rows = row_index(A_csr)
+            columns = []
+            for j in range(basis.shape[1]):
+                combined = _mpi4jax_halo_gather(
+                    basis[:, j], halo_args[1], halo_args[2], n_ghost, comm_obj
+                )
+                columns.append(
+                    jax.ops.segment_sum(
+                        A_csr.data * combined[halo_args[0]],
+                        rows,
+                        num_segments=A_csr.shape[0],
+                    )
+                )
+            return jnp.stack(columns, axis=1)
+
+        # Aᵀ·M is not checked in MPI mode (needs a reverse halo exchange).
+        matvec_T = None
 
     else:
         # Single-GPU mode: use int32 indices
@@ -769,19 +830,75 @@ def solve(
             use_x0=use_x0,
             block_dim=block_dim,
         )
+        comm_obj = None
+        reduce_sum = None
 
-        x, info = solver(A_csr, b, x0_arg)
+        def run(b_: jax.Array, x0_: jax.Array) -> tuple[jax.Array, jax.Array]:
+            return solver(A_csr, b_, x0_)
+
+        def matvec(basis: jax.Array) -> jax.Array:
+            return A_csr @ basis
+
+        def matvec_T(basis: jax.Array) -> jax.Array:
+            return A_csr.to_bcoo().T @ basis
+
+    # Null-space projections as JAX ops around the primitive; their
+    # transposes are the adjoint projections (see nullspace.py).
+    n_local = A_csr.shape[0]
+    N = as_nullspace_basis(nullspace, n_local, target_dtype, "nullspace")
+    M = as_nullspace_basis(
+        transpose_nullspace, n_local, target_dtype, "transpose_nullspace"
+    )
+    if N is not None:
+        validate_basis(N, "nullspace", comm_obj)
+    if M is not None:
+        validate_basis(M, "transpose_nullspace", comm_obj)
+    if M is None and N is not None:
+        if is_symmetric:
+            M = N
+        else:
+            warnings.warn(_MISSING_TRANSPOSE_MSG, NullSpaceWarning, stacklevel=2)
+    elif N is None and M is not None:
+        if is_symmetric:
+            N = M
+        else:
+            warnings.warn(_MISSING_NULLSPACE_MSG, NullSpaceWarning, stacklevel=2)
+    if N is None and M is None:
+        warn_if_singular(A_csr, comm=comm_obj, stacklevel=3)
+    else:
+        if N is not None:
+            verify_nullspace(A_csr, N, matvec, "nullspace", comm=comm_obj, stacklevel=3)
+        if M is not None and matvec_T is not None:
+            verify_nullspace(
+                A_csr, M, matvec_T, "transpose_nullspace", comm=comm_obj, stacklevel=3
+            )
+
+    rhs_inconsistency = None
+    if M is not None:
+        b_proj = project_out(b, M, reduce_sum)
+        rhs_inconsistency = relative_norm(b - b_proj, b, reduce_sum)
+        b = b_proj
+        if not use_x0:
+            x0_arg = b
+
+    x, info = run(b, x0_arg)
+
+    if N is not None:
+        x = project_out(x, N, reduce_sum)
 
     if isinstance(info, jax.core.Tracer):
         # Inside JIT (or another trace): info elements are tracers; return as-is.
         # The history keeps its fixed trace-time length (outer max_iters + 1),
         # NaN-padded past entry `iterations`.
-        return x, {
+        traced_info = {
             "iterations": info[0],
             "residual": info[1],
             "status": info[2],
             "residual_history": info[3:],
         }
+        if rhs_inconsistency is not None:
+            traced_info["rhs_inconsistency"] = rhs_inconsistency
+        return x, traced_info
 
     info_dict = {
         "iterations": int(info[0]),
@@ -791,6 +908,8 @@ def solve(
         # initial residual); trim the NaN padding outside a trace.
         "residual_history": info[3 : 4 + int(info[0])],
     }
+    if rhs_inconsistency is not None:
+        info_dict["rhs_inconsistency"] = float(rhs_inconsistency)
     if save_stats_file is not None:
         try:
             stats_str = _ensure_backend().get_stats_string()

--- a/jaxamg/matrices.py
+++ b/jaxamg/matrices.py
@@ -724,6 +724,85 @@ def convection_diffusion_matrix_2d(
     return jsp.BCSR((vals, cols, indptr), shape=(n2, n2))
 
 
+def poisson_matrix_stretched(
+    nx: int,
+    ny: int,
+    stretch: float = 1.05,
+    *,
+    normalize: bool = True,
+    periodic_x: bool = True,
+    dtype: DTypeLike | None = None,
+) -> tuple[jsp.BCSR, jax.Array]:
+    """Finite-volume Laplacian on a geometrically stretched 2D grid (singular).
+
+    Cell sizes grow by ``stretch`` per cell. Periodic in x (optional), Neumann
+    in y, so ``A·1 = 0``. With ``normalize=True`` rows are divided by the cell
+    volume (``A = D⁻¹L``), which for ``stretch != 1`` is nonsymmetric with
+    ``null(A) = span(1)`` but ``null(Aᵀ) = span(V)``; ``normalize=False``
+    returns the symmetric flux form ``L``. Sign convention ``-∇²`` (positive
+    diagonal). Cell ``(i, j)`` is row ``i * ny + j``.
+
+    Args:
+        nx: Number of cells in x.
+        ny: Number of cells in y.
+        stretch: Growth factor of the cell size per cell (1.0: uniform grid).
+        normalize: Divide each row by its cell volume (see above).
+        periodic_x: Periodic in x; otherwise Neumann in x as well.
+        dtype: Data type for matrix values and volumes (default float32).
+
+    Returns:
+        A: ``(nx*ny) × (nx*ny)`` BCSR matrix.
+        V: Cell volumes ``(nx*ny,)``, the left null vector of the normalized operator.
+    """
+    if nx < 2 or ny < 2:
+        raise ValueError("nx and ny must be at least 2")
+    if stretch <= 0:
+        raise ValueError("stretch must be positive")
+    dtype = jnp.float32 if dtype is None else dtype
+    np_dtype = np.float64 if dtype == jnp.float64 else np.float32
+
+    dx = float(stretch) ** np.arange(nx, dtype=np.float64)
+    dy = float(stretch) ** np.arange(ny, dtype=np.float64)
+    volumes = np.outer(dx, dy).ravel()
+    n = nx * ny
+
+    rows: list[np.ndarray] = []
+    cols: list[np.ndarray] = []
+    vals: list[np.ndarray] = []
+
+    def couple(p: np.ndarray, q: np.ndarray, c: np.ndarray) -> None:
+        # Flux form: L_pq = L_qp = -c, L_pp += c, L_qq += c.
+        rows.extend([p, q, p, q])
+        cols.extend([q, p, p, q])
+        vals.extend([-c, -c, c, c])
+
+    i_grid, j_grid = np.meshgrid(np.arange(nx), np.arange(ny), indexing="ij")
+
+    # x faces between (i, j) and (i+1, j)
+    i = i_grid[:-1].ravel()
+    j = j_grid[:-1].ravel()
+    couple(i * ny + j, (i + 1) * ny + j, dy[j] / (0.5 * (dx[i] + dx[i + 1])))
+    if periodic_x:
+        j = np.arange(ny)
+        couple((nx - 1) * ny + j, j, dy[j] / (0.5 * (dx[-1] + dx[0])))
+
+    # y faces between (i, j) and (i, j+1)
+    i = i_grid[:, :-1].ravel()
+    j = j_grid[:, :-1].ravel()
+    couple(i * ny + j, i * ny + j + 1, dx[i] / (0.5 * (dy[j] + dy[j + 1])))
+
+    L = sp.csr_matrix(
+        (np.concatenate(vals), (np.concatenate(rows), np.concatenate(cols))),
+        shape=(n, n),
+    )
+    L.sum_duplicates()
+    A = (sp.diags(1.0 / volumes) @ L).tocsr() if normalize else L
+    A.sort_indices()
+
+    A_bcsr = jsp.BCSR.from_scipy_sparse(A.astype(np_dtype))
+    return A_bcsr, jnp.asarray(volumes.astype(np_dtype))
+
+
 def rhs_ones(n: int, dtype: DTypeLike | None = None) -> jax.Array:
     """Create a constant RHS vector of ones.
 

--- a/jaxamg/nullspace.py
+++ b/jaxamg/nullspace.py
@@ -1,0 +1,294 @@
+"""Null-space handling for singular systems.
+
+Orthogonal projections around the solver primitive, as JAX ops::
+
+    forward :  b' = b - M(MᵀM)⁻¹Mᵀb     x = solve(A, b')     x' = x - N(NᵀN)⁻¹Nᵀx
+    backward:  g' = g - N(NᵀN)⁻¹Nᵀg     λ = solve(Aᵀ, g')    b̄ = λ - M(MᵀM)⁻¹Mᵀλ
+
+``N`` spans ``null(A)``, ``M`` spans ``null(Aᵀ)``. The backward line is JAX's
+transpose of the forward line, so the forward returns ``A⁺b`` and ``jax.grad``
+returns ``(Aᵀ)⁺g``. For nonsymmetric ``A`` the two null spaces differ (e.g.
+``A = D⁻¹L``: ``null(A) = span(1)``, ``null(Aᵀ) = span(V)``).
+"""
+
+import warnings
+import weakref
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import jax
+import jax.experimental.sparse as jsp
+import jax.numpy as jnp
+import numpy as np
+from jax.typing import ArrayLike, DTypeLike
+
+if TYPE_CHECKING:
+    from mpi4py.MPI import Comm
+
+__all__ = ["NullSpaceWarning"]
+
+NullSpaceSpec = ArrayLike | str | None
+
+
+class NullSpaceWarning(UserWarning):
+    """Null-space issue in `jaxamg.solve`: a singular matrix without a declared
+    `nullspace`, a missing `nullspace`/`transpose_nullspace`, a basis that is
+    not a null space, or a `DENSE_LU_SOLVER` coarse solve on a singular system."""
+
+
+_SINGULAR_MSG = (
+    "A·1 = 0: the system is singular. Pass nullspace='constant' (and "
+    "transpose_nullspace for nonsymmetric A); otherwise adjoint solves may "
+    "stall on an inconsistent right-hand side."
+)
+
+_MISSING_TRANSPOSE_MSG = (
+    "nullspace given without transpose_nullspace for a matrix not marked "
+    "symmetric: b is not projected onto range(A) and the gradient w.r.t. b is "
+    "defined only up to a component in null(Aᵀ). Pass transpose_nullspace, or "
+    "mark A symmetric with with_cache(A, is_symmetric=True)."
+)
+
+_MISSING_NULLSPACE_MSG = (
+    "transpose_nullspace given without nullspace for a matrix not marked "
+    "symmetric: the solution is not pinned (its null(A) component is whatever "
+    "the solver returns) and the adjoint right-hand side is not projected. "
+    "Pass nullspace, or mark A symmetric with with_cache(A, is_symmetric=True)."
+)
+
+_DENSE_LU_MSG = (
+    "DENSE_LU_SOLVER coarse solve with a declared null space can diverge. Use "
+    "coarse smoother sweeps (the default when a null space is declared); for "
+    "cached MPI metadata pass singular=True to cache_mpi_metadata()."
+)
+
+
+def _detect_rtol(dtype: DTypeLike) -> float:
+    return 100.0 * float(jnp.finfo(dtype).eps)
+
+
+def _verify_rtol(dtype: DTypeLike) -> float:
+    return float(np.sqrt(jnp.finfo(dtype).eps))
+
+
+def _is_traced(*arrays: Any) -> bool:
+    return any(isinstance(a, jax.core.Tracer) for a in arrays)
+
+
+class _Memo:
+    """Verdicts keyed by array identity; entries vanish with the arrays."""
+
+    def __init__(self) -> None:
+        self._data: dict[tuple[int, ...], Any] = {}
+
+    def get(self, *arrays: Any) -> Any:
+        return self._data.get(tuple(id(a) for a in arrays))
+
+    def put(self, value: Any, *arrays: Any) -> None:
+        key = tuple(id(a) for a in arrays)
+        try:
+            for a in arrays:
+                weakref.finalize(a, self._data.pop, key, None)
+        except TypeError:
+            return  # not weak-referenceable: do not memoize
+        self._data[key] = value
+
+
+_singular_memo = _Memo()
+_verified_memo = _Memo()
+
+
+def _all_ranks(flag: bool, comm: "Comm | None") -> bool:
+    """Collective AND, so memo hits cannot desynchronize the checks below."""
+    if comm is None:
+        return flag
+    from mpi4py import MPI
+
+    return bool(comm.allreduce(flag, op=MPI.LAND))
+
+
+def _global_max(value: float, comm: "Comm | None") -> float:
+    if comm is None:
+        return value
+    from mpi4py import MPI
+
+    return comm.allreduce(value, op=MPI.MAX)
+
+
+def as_nullspace_basis(
+    spec: NullSpaceSpec, n: int, dtype: DTypeLike, name: str
+) -> jax.Array | None:
+    """Normalize ``"constant"`` / vector / ``(n, k)`` array to ``(n, k)`` (or None)."""
+    if spec is None:
+        return None
+    if isinstance(spec, str):
+        if spec.lower() != "constant":
+            raise ValueError(
+                f"{name} must be 'constant', an array, or None; got {spec!r}"
+            )
+        # numpy-backed so it stays concrete when solve() is traced
+        return jnp.asarray(np.ones((n, 1), dtype=dtype))
+    basis = jnp.asarray(spec)
+    if basis.ndim == 1:
+        basis = basis[:, None]
+    if basis.ndim != 2 or basis.shape[0] != n or not 0 < basis.shape[1] <= n:
+        raise ValueError(
+            f"{name} must be a vector of length {n} or an ({n}, k) array with "
+            f"k ≤ {n}; got shape {basis.shape}"
+        )
+    if basis.dtype != dtype:
+        basis = basis.astype(dtype)
+    return basis
+
+
+def validate_basis(basis: jax.Array, name: str, comm: "Comm | None" = None) -> None:
+    """Raise unless the (concrete) basis is finite with independent columns.
+    Uses the ``k × k`` Gram matrix, reduced across ranks in MPI mode."""
+    if _is_traced(basis):
+        return
+    with jax.ensure_compile_time_eval():
+        gram = np.asarray(basis.T @ basis, dtype=np.float64)
+    if comm is not None:
+        from mpi4py import MPI
+
+        gram = comm.allreduce(gram, op=MPI.SUM)
+    if not np.isfinite(gram).all():
+        raise ValueError(f"{name} contains non-finite values")
+    ev = np.linalg.eigvalsh(gram)
+    if ev[-1] <= 0 or ev[0] <= 1e3 * float(jnp.finfo(basis.dtype).eps) * ev[-1]:
+        raise ValueError(f"{name} has zero or linearly dependent columns")
+
+
+def project_out(
+    v: jax.Array,
+    basis: jax.Array,
+    reduce_sum: Callable[[jax.Array], jax.Array] | None = None,
+) -> jax.Array:
+    """``v - B(BᵀB)⁻¹Bᵀv``. ``reduce_sum`` (MPI) reduces the stacked
+    ``[Bᵀv, vec(BᵀB)]`` in one collective."""
+    k = basis.shape[1]
+    stats = jnp.concatenate([basis.T @ v, (basis.T @ basis).reshape(-1)])
+    if reduce_sum is not None:
+        stats = reduce_sum(stats)
+    coeffs = stats[:k]
+    gram = stats[k:].reshape(k, k)
+    if k == 1:
+        return v - basis[:, 0] * (coeffs[0] / gram[0, 0])
+    return v - basis @ jnp.linalg.solve(gram, coeffs)
+
+
+def relative_norm(
+    d: jax.Array,
+    v: jax.Array,
+    reduce_sum: Callable[[jax.Array], jax.Array] | None = None,
+) -> jax.Array:
+    """``‖d‖/‖v‖`` (0 when ``v = 0``), reduced across ranks in MPI mode."""
+    stats = jnp.stack([jnp.sum(d * d), jnp.sum(v * v)])
+    if reduce_sum is not None:
+        stats = reduce_sum(stats)
+    nonzero = stats[1] > 0
+    denom = jnp.where(nonzero, stats[1], 1.0)
+    return jnp.where(nonzero, jnp.sqrt(stats[0] / denom), 0.0)
+
+
+def make_mpi_reduce_sum(comm: "Comm") -> Callable[[jax.Array], jax.Array]:
+    """Sum all-reduce whose VJP is also a sum all-reduce.
+
+    The reduced value is used in every rank's rows, so its cotangent is the sum
+    of the per-rank contributions; mpi4jax's own transpose rule (identity)
+    would only project out each rank's local component in the backward pass.
+    """
+    import mpi4jax
+    from mpi4py import MPI
+
+    def allreduce(x: jax.Array) -> jax.Array:
+        return mpi4jax.allreduce(x, op=MPI.SUM, comm=comm)
+
+    @jax.custom_vjp
+    def reduce_sum(x: jax.Array) -> jax.Array:
+        return allreduce(x)
+
+    def fwd(x: jax.Array) -> tuple[jax.Array, None]:
+        return allreduce(x), None
+
+    def bwd(_: None, g: jax.Array) -> tuple[jax.Array]:
+        return (allreduce(g),)
+
+    reduce_sum.defvjp(fwd, bwd)
+    return reduce_sum
+
+
+def row_index(A: jsp.BCSR) -> jax.Array:
+    """Row index of every stored entry."""
+    n = A.shape[0]
+    row_lengths = A.indptr[1:] - A.indptr[:-1]
+    return jnp.repeat(
+        jnp.arange(n, dtype=jnp.int32), row_lengths, total_repeat_length=len(A.data)
+    )
+
+
+def _row_sums(A: jsp.BCSR) -> tuple[jax.Array, jax.Array]:
+    """Row sums (``A·1``) and row absolute sums."""
+    rows = row_index(A)
+    n = A.shape[0]
+    return (
+        jax.ops.segment_sum(A.data, rows, num_segments=n),
+        jax.ops.segment_sum(jnp.abs(A.data), rows, num_segments=n),
+    )
+
+
+def warn_if_singular(
+    A: jsp.BCSR, comm: "Comm | None" = None, stacklevel: int = 2
+) -> None:
+    """Warn when ``A·1 = 0`` to round-off. Skipped for traced values; in MPI
+    mode every rank must call it. Memoized per matrix buffer."""
+    if _is_traced(A.data, A.indptr) or A.shape[0] == 0:
+        return
+    singular = _singular_memo.get(A.data)
+    if not _all_ranks(singular is not None, comm):
+        # Under a jit trace every op is staged; evaluate the check eagerly.
+        with jax.ensure_compile_time_eval():
+            rowsum, absrow = _row_sums(A)
+            num = float(jnp.max(jnp.abs(rowsum)))
+            den = float(jnp.max(absrow))
+        num = _global_max(num, comm)
+        den = _global_max(den, comm)
+        singular = den > 0 and num <= _detect_rtol(A.data.dtype) * den
+        _singular_memo.put(singular, A.data)
+    if singular:
+        warnings.warn(_SINGULAR_MSG, NullSpaceWarning, stacklevel=stacklevel)
+
+
+def verify_nullspace(
+    A: jsp.BCSR,
+    basis: jax.Array,
+    matvec: Callable[[jax.Array], jax.Array],
+    name: str,
+    comm: "Comm | None" = None,
+    stacklevel: int = 2,
+) -> None:
+    """Warn unless ``max|matvec(B)| ≤ sqrt(eps)·‖A‖∞·max|B|``. Skipped for
+    traced values; ``matvec`` must be collective in MPI mode. Memoized per
+    (matrix buffer, basis)."""
+    if _is_traced(A.data, A.indptr, basis) or A.shape[0] == 0:
+        return
+    ratio = _verified_memo.get(A.data, basis)
+    if not _all_ranks(ratio is not None, comm):
+        with jax.ensure_compile_time_eval():
+            _, absrow = _row_sums(A)
+            a_norm = float(jnp.max(absrow))
+            b_norm = float(jnp.max(jnp.abs(basis)))
+            residual = float(jnp.max(jnp.abs(matvec(basis))))
+        scale = _global_max(a_norm, comm) * _global_max(b_norm, comm)
+        residual = _global_max(residual, comm)
+        ratio = residual / scale if scale > 0 else 0.0
+        _verified_memo.put(ratio, A.data, basis)
+    tol = _verify_rtol(A.data.dtype)
+    if ratio > tol:
+        target = "Aᵀ" if name == "transpose_nullspace" else "A"
+        warnings.warn(
+            f"{name} does not appear to span the null space of {target}: "
+            f"relative residual {ratio:.2e} (expected ≤ {tol:.1e}).",
+            NullSpaceWarning,
+            stacklevel=stacklevel,
+        )

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -950,3 +950,78 @@ def test_mpi_block_gradients(mpi_context):
     np.testing.assert_allclose(
         np.asarray(g_b), g_b_ref, atol=1e-3 * np.max(np.abs(g_b_ref))
     )
+
+
+@pytest.mark.mpi(min_size=2)
+def test_mpi_nullspace(mpi_context):
+    """Singular nonsymmetric matrix (volume-normalized finite-volume Poisson on
+    a stretched grid) in MPI mode: `nullspace`/`transpose_nullspace` with
+    global reductions, eager and jitted (cached metadata + bases attached to A).
+    """
+    comm, rank, nranks = mpi_context
+    jax.config.update("jax_enable_x64", True)
+    try:
+        from jaxamg.matrices import poisson_matrix_stretched
+        from jaxamg.utils import to_scipy
+
+        A_global, V_global = poisson_matrix_stretched(24, 16, 1.08, dtype=jnp.float64)
+        n = A_global.shape[0]
+        V_np = np.asarray(V_global)
+        rng = np.random.default_rng(0)
+        b_global = rng.standard_normal(n)
+        b_global -= (V_np @ b_global) / V_np.sum()  # Σ V_i b_i = 0
+        w_global = rng.standard_normal(n) + 0.5  # Σ w ≠ 0
+
+        A_local, row_start, row_end = partition_csr_matrix(A_global, rank, nranks)
+        rows = slice(row_start, row_end)
+        V_local = jnp.asarray(V_np[rows])
+        b_local = jnp.asarray(b_global[rows])
+        w_local = jnp.asarray(w_global[rows])
+        cfg = {"tolerance": 1e-10, "max_iters": 300}
+
+        def solve_local(b_):
+            return jaxamg.solve(
+                A_local,
+                b_,
+                comm=comm,
+                nglobal=n,
+                partition_info=(row_start, row_end),
+                nullspace="constant",
+                transpose_nullspace=V_local,
+                **cfg,
+            )
+
+        x_local, info = solve_local(b_local)
+        assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+        assert info["rhs_inconsistency"] < 1e-12
+        # Local loss w_local·x_local: summed over ranks it is the global w·x,
+        # so each rank's gradient is its slice of the global one.
+        g_local = jax.grad(lambda b_: jnp.dot(w_local, solve_local(b_)[0]))(b_local)
+
+        # Jitted path: cached MPI metadata and null-space bases attached to A.
+        mpi_cache = jaxamg.cache_mpi_metadata(
+            cfg, comm, n, (row_start, row_end), A_local, singular=True
+        )
+        A_cached = jaxamg.with_cache(
+            A_local, mpi=mpi_cache, nullspace="constant", transpose_nullspace=V_local
+        )
+        g_jit = jax.jit(
+            jax.grad(lambda b_: jnp.dot(w_local, jaxamg.solve(A_cached, b_)[0]))
+        )(b_local)
+
+        x = gather_vector(x_local, comm)
+        g = gather_vector(g_local, comm)
+        g2 = gather_vector(g_jit, comm)
+        if rank == 0:
+            A_dense = to_scipy(A_global).toarray().astype(np.float64)
+            x = np.asarray(x)
+            assert abs(x.mean()) < 1e-10 * np.linalg.norm(x)
+            assert np.linalg.norm(A_dense @ x - b_global) < 1e-7 * np.linalg.norm(
+                b_global
+            )
+            g_ref = np.linalg.pinv(A_dense).T @ w_global
+            atol = 1e-8 * np.linalg.norm(g_ref)
+            np.testing.assert_allclose(np.asarray(g), g_ref, rtol=1e-6, atol=atol)
+            np.testing.assert_allclose(np.asarray(g2), g_ref, rtol=1e-6, atol=atol)
+    finally:
+        jax.config.update("jax_enable_x64", False)

--- a/tests/test_nullspace.py
+++ b/tests/test_nullspace.py
@@ -1,0 +1,375 @@
+"""Null-space handling of singular systems (`nullspace` / `transpose_nullspace`)."""
+
+import json
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import jaxamg
+from jaxamg import NullSpaceWarning
+from jaxamg import config as amgx_config
+from jaxamg.matrices import poisson_matrix_stretched, tridiagonal_matrix
+from jaxamg.nullspace import (
+    as_nullspace_basis,
+    project_out,
+    relative_norm,
+    validate_basis,
+)
+from jaxamg.utils import to_scipy
+
+# PBICGSTAB + classical AMG (the defaults), tightened for float64 gradient checks.
+cfg = {"tolerance": 1e-10, "max_iters": 300}
+
+
+@pytest.fixture
+def x64():
+    jax.config.update("jax_enable_x64", True)
+    yield
+    jax.config.update("jax_enable_x64", False)
+
+
+def dense(A) -> np.ndarray:
+    return to_scipy(A).toarray().astype(np.float64)
+
+
+def stretched(nx=32, ny=24, stretch=1.08, **kwargs):
+    A, V = poisson_matrix_stretched(nx, ny, stretch, dtype=jnp.float64, **kwargs)
+    return A, np.asarray(V)
+
+
+def consistent_rhs(V: np.ndarray, seed: int = 0) -> np.ndarray:
+    """Random b with Σ V_i b_i = 0."""
+    rng = np.random.default_rng(seed)
+    b = rng.standard_normal(V.shape[0])
+    return b - (V @ b) / V.sum()
+
+
+def weights(n: int, seed: int = 1) -> np.ndarray:
+    """Objective weights with Σ w ≠ 0 (cotangent not in range(Aᵀ))."""
+    return np.random.default_rng(seed).standard_normal(n) + 0.5
+
+
+def remove_component(v: np.ndarray, d: np.ndarray) -> np.ndarray:
+    d = d / np.linalg.norm(d)
+    return v - d * (d @ v)
+
+
+class TestPure:
+    """No solver needed (runs on CPU)."""
+
+    def test_basis_normalization_and_rejection(self):
+        n = 5
+        assert as_nullspace_basis(None, n, jnp.float32, "nullspace") is None
+        c = as_nullspace_basis("constant", n, jnp.float32, "nullspace")
+        assert c.shape == (n, 1) and float(c.sum()) == n
+        v = as_nullspace_basis(np.arange(n, dtype=np.float64), n, jnp.float32, "x")
+        assert v.shape == (n, 1) and v.dtype == jnp.float32
+        for bad in ["bogus", np.ones(3), np.ones((n, n + 1)), np.ones((n, 2, 1))]:
+            with pytest.raises(ValueError, match="nullspace"):
+                as_nullspace_basis(bad, n, jnp.float32, "nullspace")
+
+    def test_validate_basis(self):
+        n = 6
+        ok = jnp.asarray(np.random.default_rng(0).standard_normal((n, 2)))
+        validate_basis(ok, "nullspace")
+        dup = jnp.stack([ok[:, 0], ok[:, 0]], axis=1)
+        with pytest.raises(ValueError, match="dependent"):
+            validate_basis(dup, "nullspace")
+        with pytest.raises(ValueError, match="dependent"):
+            validate_basis(jnp.zeros((n, 1)), "nullspace")
+        with pytest.raises(ValueError, match="finite"):
+            validate_basis(ok.at[0, 0].set(jnp.nan), "nullspace")
+
+    @pytest.mark.parametrize("k", [1, 3])
+    def test_project_out(self, k, x64):
+        rng = np.random.default_rng(0)
+        B = rng.standard_normal((20, k))
+        v = rng.standard_normal(20)
+        got = np.asarray(project_out(jnp.asarray(v), jnp.asarray(B)))
+        ref = v - B @ np.linalg.solve(B.T @ B, B.T @ v)
+        np.testing.assert_allclose(got, ref, rtol=1e-5, atol=1e-6)
+        assert np.abs(B.T @ got).max() < 1e-5
+
+    def test_relative_norm(self):
+        d, v = jnp.array([3.0, 4.0]), jnp.array([0.0, 10.0])
+        assert float(relative_norm(d, v)) == pytest.approx(0.5)
+        assert float(relative_norm(d, jnp.zeros(2))) == 0.0
+
+    def test_singular_config_defaults(self):
+        default = amgx_config.prepare_config({})
+        singular = amgx_config.prepare_config({}, singular=True)
+        assert amgx_config.uses_dense_lu_coarse_solver(default)
+        assert not amgx_config.uses_dense_lu_coarse_solver(singular)
+        pc = json.loads(singular)["solver"]["preconditioner"]
+        assert (
+            pc["min_coarse_rows"] == 8
+            and pc["coarse_solver"]["solver"] == "BLOCK_JACOBI"
+        )
+        # explicit settings win
+        custom = amgx_config.prepare_config(
+            {"preconditioner": {"coarse_solver": "DENSE_LU_SOLVER"}}, singular=True
+        )
+        assert amgx_config.uses_dense_lu_coarse_solver(custom)
+
+    def test_stretched_matrix_null_vectors(self, x64):
+        A, V = stretched(8, 6, 1.1)
+        A_d = dense(A)
+        scale = np.abs(A_d).max()
+        assert np.abs(A_d @ np.ones(A_d.shape[0])).max() < 1e-12 * scale
+        assert np.abs(A_d.T @ V).max() < 1e-12 * scale
+        assert np.abs(A_d.T @ np.ones(A_d.shape[0])).max() > 1e-3 * scale
+        L, _ = stretched(8, 6, 1.1, normalize=False)
+        L_d = dense(L)
+        assert np.abs(L_d - L_d.T).max() < 1e-12 * scale
+        assert np.abs(L_d @ np.ones(L_d.shape[0])).max() < 1e-12 * scale
+
+
+class TestSolve:
+    """Runs the native AmgX solver (skip logic in conftest.py)."""
+
+    pytestmark = pytest.mark.gpu
+
+    def test_forward_pins_solution_and_projects_rhs(self, x64):
+        A, V = stretched()
+        b = jnp.asarray(consistent_rhs(V))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NullSpaceWarning)
+            x, info = jaxamg.solve(
+                A, b, nullspace="constant", transpose_nullspace=V, **cfg
+            )
+        assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+        x = np.asarray(x)
+        assert abs(x.mean()) < 1e-10 * np.linalg.norm(x)
+        assert np.linalg.norm(dense(A) @ x - np.asarray(b)) < 1e-7 * np.linalg.norm(b)
+        assert info["rhs_inconsistency"] < 1e-12
+
+        # Inconsistent RHS: solved in the least-squares sense (b projected onto
+        # range(A) = V⊥), removed fraction reported.
+        b_bad = np.asarray(b) + 0.5
+        x2, info2 = jaxamg.solve(
+            A, jnp.asarray(b_bad), nullspace="constant", transpose_nullspace=V, **cfg
+        )
+        assert info2["status"] == jaxamg.AMGXStatus.SUCCESS
+        b_proj = remove_component(b_bad, V)
+        np.testing.assert_allclose(
+            info2["rhs_inconsistency"],
+            np.linalg.norm(b_bad - b_proj) / np.linalg.norm(b_bad),
+            rtol=1e-6,
+        )
+        assert info2["rhs_inconsistency"] > 0.1
+        assert np.linalg.norm(
+            dense(A) @ np.asarray(x2) - b_proj
+        ) < 1e-7 * np.linalg.norm(b_proj)
+
+    def test_gradient_matches_pseudoinverse(self, x64):
+        """jax.grad returns (Aᵀ)⁺g on the stretched grid."""
+        A, V = stretched()
+        b = jnp.asarray(consistent_rhs(V))
+        w = weights(A.shape[0])
+
+        def loss(b_):
+            x, _ = jaxamg.solve(
+                A, b_, nullspace="constant", transpose_nullspace=V, **cfg
+            )
+            return jnp.dot(jnp.asarray(w), x)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NullSpaceWarning)
+            g = jax.grad(loss)(b)
+        g_ref = np.linalg.pinv(dense(A)).T @ w
+        np.testing.assert_allclose(
+            np.asarray(g), g_ref, rtol=1e-6, atol=1e-8 * np.linalg.norm(g_ref)
+        )
+
+    def test_gradient_wrt_matrix(self, x64):
+        """d/dt of w·x with A(t) = (1+t)·A (null spaces preserved):
+        x = A⁺b/(1+t), so the derivative is -w·A⁺b/(1+t)²."""
+        A, V = stretched()
+        b = jnp.asarray(consistent_rhs(V))
+        w = jnp.asarray(weights(A.shape[0]))
+
+        def loss(t):
+            A_t = jax.experimental.sparse.BCSR(
+                (A.data * (1.0 + t), A.indices, A.indptr), shape=A.shape
+            )
+            x, _ = jaxamg.solve(
+                A_t, b, nullspace="constant", transpose_nullspace=V, **cfg
+            )
+            return jnp.dot(w, x)
+
+        t0 = 0.2
+        g = float(jax.grad(loss)(t0))
+        ref = -float(w @ (np.linalg.pinv(dense(A)) @ np.asarray(b))) / (1 + t0) ** 2
+        assert g == pytest.approx(ref, rel=1e-6)
+
+    def test_nullspace_only_on_nonsymmetric_matrix(self, x64):
+        """Only `nullspace`: warns, the adjoint still converges, gradient is
+        right up to a null(Aᵀ) component. Only `transpose_nullspace`: warns."""
+        A, V = stretched()
+        b = jnp.asarray(consistent_rhs(V))
+        w = weights(A.shape[0])
+
+        def loss(b_):
+            x, _ = jaxamg.solve(A, b_, nullspace="constant", **cfg)
+            return jnp.dot(jnp.asarray(w), x)
+
+        with pytest.warns(NullSpaceWarning, match="without transpose_nullspace"):
+            g = jax.grad(loss)(b)
+        g_ref = np.linalg.pinv(dense(A)).T @ w
+        np.testing.assert_allclose(
+            remove_component(np.asarray(g), V),
+            remove_component(g_ref, V),
+            rtol=1e-6,
+            atol=1e-8 * np.linalg.norm(g_ref),
+        )
+        with pytest.warns(NullSpaceWarning, match="without nullspace"):
+            jaxamg.solve(A, b, transpose_nullspace=V, max_iters=5)
+
+    def test_symmetric_matrix_defaults_transpose_nullspace(self, x64):
+        """Symmetric flux form marked symmetric: `transpose_nullspace` defaults
+        to `nullspace`, no warnings, exact gradient."""
+        L, _ = stretched(normalize=False)
+        L = jaxamg.with_cache(L, is_symmetric=True)
+        n = L.shape[0]
+        b = np.random.default_rng(0).standard_normal(n)
+        b = jnp.asarray(b - b.mean())
+        w = weights(n)
+
+        def loss(b_):
+            x, _ = jaxamg.solve(L, b_, nullspace="constant", **cfg)
+            return jnp.dot(jnp.asarray(w), x)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NullSpaceWarning)
+            x, info = jaxamg.solve(L, b, nullspace="constant", **cfg)
+            g = jax.grad(loss)(b)
+        assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+        assert "rhs_inconsistency" in info
+        assert abs(float(jnp.mean(x))) < 1e-10 * float(jnp.linalg.norm(x))
+        g_ref = np.linalg.pinv(dense(L)).T @ w
+        np.testing.assert_allclose(
+            np.asarray(g), g_ref, rtol=1e-6, atol=1e-8 * np.linalg.norm(g_ref)
+        )
+
+    def test_singular_matrix_warning(self):
+        """A·1 = 0 without a declared null space warns (also at trace time for
+        a closed-over matrix); a nonsingular matrix does not."""
+        A, V = poisson_matrix_stretched(12, 10, 1.05)  # float32
+        b = jnp.asarray(consistent_rhs(np.asarray(V)), dtype=jnp.float32)
+        with pytest.warns(NullSpaceWarning, match="singular"):
+            jaxamg.solve(A, b, max_iters=5)
+        with pytest.warns(NullSpaceWarning, match="singular"):  # memoized verdict
+            jaxamg.solve(A, b, max_iters=5)
+        with pytest.warns(NullSpaceWarning, match="singular"):
+            jax.jit(lambda b_: jaxamg.solve(A, b_, max_iters=5)[0])(b)
+
+        A2 = tridiagonal_matrix(32)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NullSpaceWarning)
+            jaxamg.solve(A2, jnp.ones(32), solver="CG")
+            jax.jit(lambda b_: jaxamg.solve(A2, b_, solver="CG")[0])(jnp.ones(32))
+
+    def test_nullspace_verification_warning(self, x64):
+        A, V = stretched()
+        b = jnp.asarray(consistent_rhs(V))
+        # The constant vector spans null(A) but not null(Aᵀ) (that is V)...
+        with pytest.warns(
+            NullSpaceWarning, match="transpose_nullspace does not appear"
+        ):
+            jaxamg.solve(
+                A, b, nullspace="constant", transpose_nullspace="constant", max_iters=5
+            )
+        # ...and V spans null(Aᵀ) but not null(A).
+        with pytest.warns(
+            NullSpaceWarning,
+            match="nullspace does not appear to span the null space of A:",
+        ):
+            jaxamg.solve(A, b, nullspace=V, transpose_nullspace=V, max_iters=5)
+        with pytest.raises(ValueError, match="dependent"):
+            jaxamg.solve(A, b, nullspace=np.zeros(A.shape[0]), max_iters=5)
+        # explicit DENSE_LU coarse solve with a null space warns
+        with pytest.warns(NullSpaceWarning, match="DENSE_LU"):
+            jaxamg.solve(
+                A,
+                b,
+                nullspace="constant",
+                transpose_nullspace=V,
+                config={"preconditioner": {"coarse_solver": "DENSE_LU_SOLVER"}},
+                max_iters=5,
+            )
+
+    def test_jit_matches_eager(self, x64):
+        A, V = stretched()
+        b = jnp.asarray(consistent_rhs(V))
+        w = jnp.asarray(weights(A.shape[0]))
+
+        def loss(b_, V_):
+            x, _ = jaxamg.solve(
+                A, b_, nullspace="constant", transpose_nullspace=V_, **cfg
+            )
+            return jnp.dot(w, x)
+
+        v_eager, g_eager = jax.value_and_grad(loss)(b, jnp.asarray(V))
+        v_jit, g_jit = jax.jit(jax.value_and_grad(loss))(b, jnp.asarray(V))
+        np.testing.assert_allclose(v_jit, v_eager, rtol=1e-10)
+        np.testing.assert_allclose(g_jit, g_eager, rtol=1e-8)
+        info = jax.jit(
+            lambda b_: jaxamg.solve(
+                A, b_, nullspace="constant", transpose_nullspace=V, **cfg
+            )[1]
+        )(b)
+        assert float(info["rhs_inconsistency"]) < 1e-12
+
+    def test_multidimensional_nullspace(self, x64):
+        """Two disconnected grids: a 2-D null space."""
+        A1, V1 = stretched(12, 10, 1.06)
+        A2, V2 = stretched(10, 8, 1.10)
+        n1, n2 = A1.shape[0], A2.shape[0]
+        n = n1 + n2
+        A = sp.block_diag([to_scipy(A1), to_scipy(A2)], format="csr")
+        N = np.zeros((n, 2))
+        N[:n1, 0] = 1.0
+        N[n1:, 1] = 1.0
+        M = np.zeros((n, 2))
+        M[:n1, 0] = V1
+        M[n1:, 1] = V2
+        b = jnp.asarray(np.concatenate([consistent_rhs(V1, 0), consistent_rhs(V2, 1)]))
+        w = weights(n)
+
+        def loss(b_):
+            x, _ = jaxamg.solve(A, b_, nullspace=N, transpose_nullspace=M, **cfg)
+            return jnp.dot(jnp.asarray(w), x)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NullSpaceWarning)
+            x, info = jaxamg.solve(A, b, nullspace=N, transpose_nullspace=M, **cfg)
+            g = jax.grad(loss)(b)
+        assert info["status"] == jaxamg.AMGXStatus.SUCCESS
+        x = np.asarray(x)
+        assert abs(x[:n1].mean()) < 1e-10 * np.linalg.norm(x)
+        assert abs(x[n1:].mean()) < 1e-10 * np.linalg.norm(x)
+        g_ref = np.linalg.pinv(A.toarray()).T @ w
+        np.testing.assert_allclose(
+            np.asarray(g), g_ref, rtol=1e-6, atol=1e-8 * np.linalg.norm(g_ref)
+        )
+
+    def test_with_cache_attaches_nullspaces(self, x64):
+        A, V = stretched()
+        b = jnp.asarray(consistent_rhs(V))
+        w = jnp.asarray(weights(A.shape[0]))
+        A_c = jaxamg.with_cache(A, nullspace="constant", transpose_nullspace=V)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NullSpaceWarning)
+            x, info = jaxamg.solve(A_c, b, **cfg)
+            g = jax.grad(lambda b_: jnp.dot(w, jaxamg.solve(A_c, b_, **cfg)[0]))(b)
+        assert "rhs_inconsistency" in info
+        assert abs(float(jnp.mean(x))) < 1e-10 * float(jnp.linalg.norm(x))
+        g_ref = np.linalg.pinv(dense(A)).T @ np.asarray(w)
+        np.testing.assert_allclose(
+            np.asarray(g), g_ref, rtol=1e-6, atol=1e-8 * np.linalg.norm(g_ref)
+        )


### PR DESCRIPTION
This PR adds support for singular systems in `jaxamg.solve` through the new `nullspace` and `transpose_nullspace` arguments (also settable via `with_cache`), so the forward solve returns `A⁺b` and `jax.grad` returns `(Aᵀ)⁺g`. Works under MPI.

When a null space is declared, the coarse solver defaults to Jacobi sweeps, since `DENSE_LU_SOLVER` diverges on a singular coarsest matrix. A new `NullSpaceWarning` flags an undeclared singular matrix or an invalid basis.