### PR TITLE
JAX sharding support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ include pyproject.toml
 include setup.py
 recursive-include jaxamg *.h *.cc *.pyi
 include jaxamg/py.typed
+recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Documentation: <https://jx-wang-s-group.github.io/JAX-AMG/>
 
 ## Features
 
-- **GPU-Accelerated Solvers**: Leverages NVIDIA AmgX for a broad range of GPU-accelerated sparse linear solvers, including algebraic multigrid (AMG), Krylov methods, and various variants, with flexible configuraiton options for solvers, smoothers, and preconditioners.
+- **GPU-Accelerated Solvers**: Leverages NVIDIA AmgX for a broad range of GPU-accelerated sparse linear solvers, including algebraic multigrid (AMG), Krylov methods, and various variants, with flexible configuration options for solvers, smoothers, and preconditioners.
 - **Automatic Differentiation**: Supports adjoint-based gradient computation and integrates seamlessly with JAX for end-to-end differentiable workflows.
 - **JIT Compilation**: Built as a native JAX primitive, fully compatible with Just-in-Time compilation (`jax.jit`) for efficient, low-overhead execution.
-- **MPI Support**: Enables distributed linear solves across multiple GPUs, with GPU-aware MPI support.
+- **Distributed Solving**: Supports multi-GPU MPI, GPU-aware communication, and JAX sharding.
 - **Matrix-Free Operators**: Beyond explicit matrices, `A` can be a callable operator. The library recovers the exact sparsity pattern in a single pass by tracing the operator's computation graph, then assembles the matrix the solver needs.
 
 ## Prerequisites

--- a/demo/sharded_poisson_operator_optimization.py
+++ b/demo/sharded_poisson_operator_optimization.py
@@ -1,0 +1,165 @@
+"""
+Demo: JAX-sharded optimization of a Poisson operator skew parameter.
+
+Demonstrates end-to-end JIT compilation and differentiation of a custom JAX operator
+with the sharding interface. The counterpart of demo/mpi_poisson_operator_optimization.py:
+the RHS and solution are JAX global arrays, so the loss is a global reduction and
+no MPI call is needed.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=0,1 mpirun -n 2 python demo/sharded_poisson_operator_optimization.py
+"""
+
+import os
+
+# Required for compiled multi-process losses; see docs/sharding.md.
+os.environ["XLA_FLAGS"] = (
+    os.environ.get("XLA_FLAGS", "") + " --xla_gpu_shard_autotuning=false"
+).strip()
+
+import jax
+import jax.numpy as jnp
+
+# One JAX process per MPI rank; must precede any JAX array creation.
+jax.distributed.initialize(cluster_detection_method="mpi4py")
+
+from jax.experimental import multihost_utils
+
+import jaxamg
+from jaxamg.matrices import poisson_operator, rhs_ones
+from jaxamg.mpi_utils import get_partition_info, partition_operator
+
+jax.config.update("jax_enable_x64", True)
+
+
+def main():
+    rank = jax.process_index()
+    nranks = jax.process_count()
+
+    # Problem size
+    grid_size = 16
+    n_global = grid_size * grid_size
+
+    if rank == 0:
+        print(
+            f"Setting up sharded Poisson Optimization on {grid_size}x{grid_size} grid..."
+        )
+        print(f"Processes: {nranks}")
+        print()
+
+    # Ground truth
+    true_skew = 5.0
+
+    # Generate ground truth solution using single-GPU on rank 0
+    if rank == 0:
+        b_global = rhs_ones(n_global)
+        A_true = poisson_operator(true_skew)
+
+        x_target_global, info = jaxamg.solve(
+            A_true,
+            b_global,
+            solver="PBICGSTAB",
+            preconditioner={"solver": "JACOBI_L1"},
+            tolerance=1e-8,
+        )
+    else:
+        x_target_global = jnp.zeros(n_global)
+
+    # Broadcast ground truth
+    x_target_global = multihost_utils.broadcast_one_to_all(x_target_global)
+
+    # Partition
+    row_start, row_end, n_local = get_partition_info(n_global, rank, nranks)
+    x_target_local = jnp.array(x_target_global[row_start:row_end])
+    b_local = rhs_ones(n_local)
+
+    multihost_utils.sync_global_devices("partition")
+    print(f"  Rank {rank}: {n_local} rows [{row_start}:{row_end})")
+    multihost_utils.sync_global_devices("partition")
+
+    # Configuration for solver
+    config = {
+        "solver": "PBICGSTAB",
+        "preconditioner": {"solver": "JACOBI_L1"},
+        "communicator": "MPI_DIRECT",
+        "max_iters": 50,
+        "tolerance": 1e-6,
+    }
+
+    # Create local dummy operator for caching
+    dummy_op, _, _ = partition_operator(
+        poisson_operator(skew=1.0), n_global, rank, nranks
+    )
+
+    # Cache coloring
+    coloring_cache = jaxamg.cache_coloring(dummy_op, shape=(n_local, n_global))
+
+    # Global arrays and the sharded solver (fixes the sparsity pattern)
+    b = jaxamg.make_sharded_vector(b_local, global_size=n_global)
+    x_target = jaxamg.make_sharded_vector(x_target_local, global_size=n_global)
+    A = jaxamg.make_sharded_matrix(
+        jaxamg.with_cache(dummy_op, coloring=coloring_cache), b
+    )
+    solver = jaxamg.make_sharded_solver(A, b, config=config)
+
+    if rank == 0:
+        print("\nStarting optimization...")
+
+    # Define loss function
+    def loss(skew, b, x_true):
+        op, _, _ = partition_operator(
+            poisson_operator(skew=skew), n_global, rank, nranks
+        )
+
+        x_pred, info = solver(b, A=op)
+
+        loss = jnp.sum((x_pred - x_true) ** 2) / n_global
+        return loss
+
+    # JIT loss and gradient
+    value_and_grad_fn = jax.jit(jax.value_and_grad(loss))
+
+    # Optimization Loop
+    skew_init = 0.0
+    lr = 0.1
+
+    if rank == 0:
+        print(f"{'Epoch':<6} {'Skew':<12} {'Global Loss':<15} {'Gradient':<12}")
+        print("-" * 50)
+
+    # Outer transforms over sharded arrays need the mesh in context
+    with jax.set_mesh(A.mesh):
+        for epoch in range(200):
+            # Force solver rebuild
+            if epoch % 20 == 0:
+                jaxamg.clear_solver_cache()
+
+            # Compute global loss and gradient
+            l_global, g_global = value_and_grad_fn(skew_init, b, x_target)
+            l_global = float(l_global)
+            g_global = float(g_global)
+
+            if rank == 0:
+                print(
+                    f"{epoch:<6} {skew_init:<12.4f} {l_global:<15.6f} {g_global:<12.6f}"
+                )
+
+            # Update
+            skew_init -= lr * g_global
+
+            if l_global < 1e-6:
+                if rank == 0:
+                    print("\nConverged!")
+                break
+
+    if rank == 0:
+        print(f"\nFinal skew: {skew_init:.4f}, True skew: {true_skew:.4f}")
+
+    multihost_utils.sync_global_devices("finalize")
+    jaxamg.finalize()
+    multihost_utils.sync_global_devices("shutdown")
+    jax.distributed.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/sharded_poisson_operator_optimization.py
+++ b/demo/sharded_poisson_operator_optimization.py
@@ -10,13 +10,6 @@ Usage:
     CUDA_VISIBLE_DEVICES=0,1 mpirun -n 2 python demo/sharded_poisson_operator_optimization.py
 """
 
-import os
-
-# Required for compiled multi-process losses; see docs/sharding.md.
-os.environ["XLA_FLAGS"] = (
-    os.environ.get("XLA_FLAGS", "") + " --xla_gpu_shard_autotuning=false"
-).strip()
-
 import jax
 import jax.numpy as jnp
 

--- a/demo/sharded_poisson_problem.py
+++ b/demo/sharded_poisson_problem.py
@@ -34,11 +34,9 @@ def main() -> None:
     )
     b_local = np.ones(row_end - row_start)
 
-    # Create a mesh and sharding for the distributed vector
-    mesh = jax.make_mesh((nranks,), ("rank",))
+    # Create a global sharded vector from this process's local values.
     b = jaxamg.make_sharded_vector(
         b_local,
-        mesh=mesh,
         global_size=n_global,
     )
 
@@ -46,7 +44,6 @@ def main() -> None:
     solver = jaxamg.make_sharded_solver(
         A_local,
         b,
-        mesh=mesh,
         config={
             "solver": "CG",
             "preconditioner": {"solver": "JACOBI_L1"},
@@ -61,7 +58,7 @@ def main() -> None:
         solution, _ = solver(rhs, A_data=A_data)
         return jnp.sum(solution**2)
 
-    with jax.set_mesh(mesh):
+    with jax.set_mesh(b.sharding.mesh):
         grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(solver.A_data, b)
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()

--- a/demo/sharded_poisson_problem.py
+++ b/demo/sharded_poisson_problem.py
@@ -59,8 +59,10 @@ def main() -> None:
         solution, _ = solver(rhs, A=A_data)
         return jnp.sum(solution**2)
 
+    grad_fn = jax.jit(jax.grad(loss, argnums=(0, 1)))
+
     with jax.set_mesh(b.sharding.mesh):
-        grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(A.data, b)
+        grad_A_data, grad_b = grad_fn(A.data, b)
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()
     grad_A_local = A.local_matrix(grad_A_data)

--- a/demo/sharded_poisson_problem.py
+++ b/demo/sharded_poisson_problem.py
@@ -56,7 +56,7 @@ def main() -> None:
     x.block_until_ready()
 
     def loss(A_data, rhs):
-        solution, _ = solver(rhs, A_data=A_data)
+        solution, _ = solver(rhs, A=A_data)
         return jnp.sum(solution**2)
 
     with jax.set_mesh(b.sharding.mesh):

--- a/demo/sharded_poisson_problem.py
+++ b/demo/sharded_poisson_problem.py
@@ -29,21 +29,18 @@ def main() -> None:
     grid_size = 32
     n_global = grid_size**2
 
-    # NamedSharding requires equal shard sizes
-    if n_global % nranks:
-        raise ValueError(
-            "JAX row sharding requires grid_size**2 to be divisible by the "
-            "number of ranks"
-        )
-
-    A_local, _, _ = poisson_matrix_distributed(grid_size, grid_size, rank, nranks)
-    b_local = np.ones(n_global // nranks)
+    A_local, row_start, row_end = poisson_matrix_distributed(
+        grid_size, grid_size, rank, nranks
+    )
+    b_local = np.ones(row_end - row_start)
 
     # Create a mesh and sharding for the distributed vector
     mesh = jax.make_mesh((nranks,), ("rank",))
-    sharding = jax.NamedSharding(mesh, jax.P("rank"))
-    b = jax.make_array_from_process_local_data(
-        sharding, b_local, global_shape=(n_global,)
+    b = jaxamg.make_sharded_vector(
+        b_local,
+        comm=comm,
+        mesh=mesh,
+        global_size=n_global,
     )
 
     # Create a sharded solver
@@ -72,10 +69,9 @@ def main() -> None:
     grad_b.block_until_ready()
     grad_A_local = solver.local_matrix_gradient(grad_A_data)
 
-    # Multi-host global arrays cannot be converted directly to NumPy. Inspect
-    # the one addressable shard owned by this process instead.
-    x_local = np.asarray(x.addressable_shards[0].data)
-    grad_b_local = np.asarray(grad_b.addressable_shards[0].data)
+    # Extract the unpadded portion owned by this process.
+    x_local = np.asarray(solver.local_vector(x))
+    grad_b_local = np.asarray(solver.local_vector(grad_b))
     local_status = np.asarray(info["status"].addressable_shards[0].data)
     print(
         f"rank {rank}: solution norm={np.linalg.norm(x_local):.6e}, "

--- a/demo/sharded_poisson_problem.py
+++ b/demo/sharded_poisson_problem.py
@@ -39,10 +39,11 @@ def main() -> None:
         b_local,
         global_size=n_global,
     )
+    A = jaxamg.make_sharded_matrix(A_local, b)
 
     # Create a sharded solver
     solver = jaxamg.make_sharded_solver(
-        A_local,
+        A,
         b,
         config={
             "solver": "CG",
@@ -59,10 +60,10 @@ def main() -> None:
         return jnp.sum(solution**2)
 
     with jax.set_mesh(b.sharding.mesh):
-        grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(solver.A_data, b)
+        grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(A.data, b)
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_local = A.local_matrix(grad_A_data)
 
     # Extract the unpadded portion owned by this process.
     x_local = np.asarray(solver.local_vector(x))

--- a/demo/sharded_poisson_problem.py
+++ b/demo/sharded_poisson_problem.py
@@ -1,0 +1,95 @@
+"""Hybrid JAX-sharded and MPI-distributed Poisson solve with autodiff.
+
+All GPUs on a node must remain visible to every local MPI process. JAX selects
+one distinct GPU per process through ``local_device_ids``.
+
+Single-node usage:
+    CUDA_VISIBLE_DEVICES=0,1 mpirun -n 2 python demo/sharded_poisson_problem.py
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from mpi4py import MPI
+
+# Initialize before importing JAX-AMG modules that may initialize XLA.
+jax.distributed.initialize(cluster_detection_method="mpi4py")
+
+import jaxamg
+from jaxamg.matrices import poisson_matrix_distributed
+
+
+def main() -> None:
+
+    jax.config.update("jax_logging_level", "ERROR")
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    nranks = comm.Get_size()
+    grid_size = 32
+    n_global = grid_size**2
+
+    # NamedSharding requires equal shard sizes
+    if n_global % nranks:
+        raise ValueError(
+            "JAX row sharding requires grid_size**2 to be divisible by the "
+            "number of ranks"
+        )
+
+    A_local, _, _ = poisson_matrix_distributed(grid_size, grid_size, rank, nranks)
+    b_local = np.ones(n_global // nranks)
+
+    # Create a mesh and sharding for the distributed vector
+    mesh = jax.make_mesh((nranks,), ("rank",))
+    sharding = jax.NamedSharding(mesh, jax.P("rank"))
+    b = jax.make_array_from_process_local_data(
+        sharding, b_local, global_shape=(n_global,)
+    )
+
+    # Create a sharded solver
+    solver = jaxamg.make_sharded_solver(
+        A_local,
+        b,
+        comm=comm,
+        mesh=mesh,
+        config={
+            "solver": "CG",
+            "preconditioner": {"solver": "JACOBI_L1"},
+            "communicator": "MPI_DIRECT",
+        },
+    )
+
+    x, info = solver(b)
+    x.block_until_ready()
+
+    def loss(A_data, rhs):
+        solution, _ = solver(rhs, A_data=A_data)
+        return jnp.sum(solution**2)
+
+    with jax.set_mesh(mesh):
+        grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(solver.A_data, b)
+    grad_A_data.block_until_ready()
+    grad_b.block_until_ready()
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+
+    # Multi-host global arrays cannot be converted directly to NumPy. Inspect
+    # the one addressable shard owned by this process instead.
+    x_local = np.asarray(x.addressable_shards[0].data)
+    grad_b_local = np.asarray(grad_b.addressable_shards[0].data)
+    local_status = np.asarray(info["status"].addressable_shards[0].data)
+    print(
+        f"rank {rank}: solution norm={np.linalg.norm(x_local):.6e}, "
+        f"RHS gradient norm={np.linalg.norm(grad_b_local):.6e}, "
+        f"matrix gradient norm={np.linalg.norm(grad_A_local.data):.6e}, "
+        f"status={local_status.item()}",
+        flush=True,
+    )
+
+    comm.Barrier()
+    jaxamg.finalize()
+    comm.Barrier()
+    jax.distributed.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/sharded_poisson_problem.py
+++ b/demo/sharded_poisson_problem.py
@@ -10,10 +10,11 @@ Single-node usage:
 import jax
 import jax.numpy as jnp
 import numpy as np
-from mpi4py import MPI
 
 # Initialize before importing JAX-AMG modules that may initialize XLA.
 jax.distributed.initialize(cluster_detection_method="mpi4py")
+
+from jax.experimental import multihost_utils
 
 import jaxamg
 from jaxamg.matrices import poisson_matrix_distributed
@@ -23,9 +24,8 @@ def main() -> None:
 
     jax.config.update("jax_logging_level", "ERROR")
 
-    comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()
-    nranks = comm.Get_size()
+    rank = jax.process_index()
+    nranks = jax.process_count()
     grid_size = 32
     n_global = grid_size**2
 
@@ -38,7 +38,6 @@ def main() -> None:
     mesh = jax.make_mesh((nranks,), ("rank",))
     b = jaxamg.make_sharded_vector(
         b_local,
-        comm=comm,
         mesh=mesh,
         global_size=n_global,
     )
@@ -47,7 +46,6 @@ def main() -> None:
     solver = jaxamg.make_sharded_solver(
         A_local,
         b,
-        comm=comm,
         mesh=mesh,
         config={
             "solver": "CG",
@@ -81,9 +79,9 @@ def main() -> None:
         flush=True,
     )
 
-    comm.Barrier()
+    multihost_utils.sync_global_devices("before jaxamg finalize")
     jaxamg.finalize()
-    comm.Barrier()
+    multihost_utils.sync_global_devices("before jax distributed shutdown")
     jax.distributed.shutdown()
 
 

--- a/demo/sharding_mpi_benchmark.py
+++ b/demo/sharding_mpi_benchmark.py
@@ -1,0 +1,333 @@
+"""Benchmark the MPI and JAX-sharding distributed interfaces.
+
+The benchmark uses the same nonsymmetric tridiagonal system, AmgX
+configuration, MPI communicator, and one-GPU-per-rank placement for both
+interfaces. It separates JAX compilation, the first execution after clearing
+the AmgX resource cache, and steady-state execution for a forward solve,
+``dL/db``, and ``dL/dA``, where ``L = 0.5 * ||x||**2``.
+
+Single-node usage:
+    CUDA_VISIBLE_DEVICES=0,1 \
+      OMPI_MCA_opal_cuda_support=true MPI4JAX_USE_CUDA_MPI=1 \
+      mpirun -n 2 python demo/sharding_mpi_benchmark.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any
+
+import jax
+import numpy as np
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+nranks = comm.Get_size()
+
+# Multi-process JAX must initialize before any operation that can inspect the
+# backend. A one-rank run needs no coordination service.
+if nranks > 1:
+    jax.distributed.initialize(cluster_detection_method="mpi4py")
+jax.config.update("jax_enable_x64", True)
+
+import jax.experimental.sparse as jsp
+import jax.numpy as jnp
+
+import jaxamg
+from jaxamg.matrices import tridiagonal_matrix_distributed
+from jaxamg.sharding import ShardedSolve
+
+
+@dataclass
+class Timing:
+    compile_ms: float
+    first_ms: float
+    steady_ms: list[float]
+    output: jax.Array
+
+    @property
+    def mean_ms(self) -> float:
+        return float(np.mean(self.steady_ms))
+
+
+def _global_max_time(start: float) -> float:
+    elapsed_ms = (perf_counter() - start) * 1000.0
+    return float(comm.allreduce(elapsed_ms, op=MPI.MAX))
+
+
+def _execute_once(compiled: Any, arguments: tuple[jax.Array, ...]):
+    comm.Barrier()
+    start = perf_counter()
+    output = compiled(*arguments)
+    output.block_until_ready()
+    elapsed_ms = _global_max_time(start)
+    return output, elapsed_ms
+
+
+def _benchmark_callable(
+    function: Any,
+    arguments: tuple[jax.Array, ...],
+    n_runs: int,
+) -> Timing:
+    comm.Barrier()
+    start = perf_counter()
+    compiled = function.lower(*arguments).compile()
+    compile_ms = _global_max_time(start)
+
+    # Measure the first execution from an empty AmgX resource cache. Compilation
+    # is already complete, so this isolates resource creation and execution.
+    jaxamg.clear_solver_cache()
+    first_output, first_ms = _execute_once(compiled, arguments)
+
+    # Populate the ordinary jit dispatch cache before steady-state timing. This
+    # extra invocation is intentionally untimed: mpi4jax threads a hidden token
+    # through its compiled gradient, so a directly invoked Lowered executable
+    # is valid for the cold call but cannot be reused with the same public
+    # argument list. The normal jit callable manages that token across calls.
+    function(*arguments).block_until_ready()
+
+    steady_ms = []
+    for _ in range(n_runs):
+        _, elapsed_ms = _execute_once(function, arguments)
+        steady_ms.append(elapsed_ms)
+
+    return Timing(compile_ms, first_ms, steady_ms, first_output)
+
+
+def _nonsymmetric_tridiagonal(n_global: int) -> tuple[jsp.BCSR, int, int]:
+    template, row_start, row_end = tridiagonal_matrix_distributed(
+        n_global,
+        rank,
+        nranks,
+        diagonal_value=4.0,
+        dtype=jnp.float32,
+    )
+    global_rows = np.repeat(
+        np.arange(row_start, row_end), np.diff(np.asarray(template.indptr))
+    )
+    columns = np.asarray(template.indices)
+    values = np.where(
+        columns < global_rows,
+        -0.75,
+        np.where(columns > global_rows, -1.25, 4.0),
+    ).astype(np.float32)
+    matrix = jsp.BCSR(
+        (jnp.asarray(values), template.indices, template.indptr),
+        shape=template.shape,
+    )
+    return matrix, row_start, row_end
+
+
+def _initialize_amgx(config: dict[str, Any]) -> None:
+    """Remove one-time AmgX initialization from the first measured interface."""
+    warmup_size = 4 * nranks
+    matrix, row_start, row_end = _nonsymmetric_tridiagonal(warmup_size)
+    cache = jaxamg.cache_mpi_metadata(
+        config,
+        comm,
+        warmup_size,
+        (row_start, row_end),
+        matrix,
+        is_symmetric=False,
+    )
+    matrix = jaxamg.with_cache(matrix, mpi=cache, is_symmetric=False)
+    rhs = jnp.ones(row_end - row_start, dtype=matrix.data.dtype)
+    jaxamg.solve(matrix, rhs, reuse_setup=True)[0].block_until_ready()
+    comm.Barrier()
+    jaxamg.clear_solver_cache()
+    comm.Barrier()
+
+
+def _mpi_functions(
+    A_local: jsp.BCSR,
+    mpi_cache: dict[str, Any],
+) -> dict[str, Any]:
+    def solution(matrix_data, rhs):
+        matrix = jsp.BCSR(
+            (matrix_data, A_local.indices, A_local.indptr), shape=A_local.shape
+        )
+        matrix = jaxamg.with_cache(matrix, mpi=mpi_cache, is_symmetric=False)
+        return jaxamg.solve(matrix, rhs, reuse_setup=True)[0]
+
+    def rhs_gradient(matrix_data, rhs):
+        x, pullback = jax.vjp(lambda value: solution(matrix_data, value), rhs)
+        return pullback(x)[0]
+
+    def matrix_gradient(matrix_data, rhs):
+        x, pullback = jax.vjp(lambda value: solution(value, rhs), matrix_data)
+        return pullback(x)[0]
+
+    return {
+        "forward": jax.jit(solution),
+        "dL/db": jax.jit(rhs_gradient),
+        "dL/dA": jax.jit(matrix_gradient),
+    }
+
+
+def _sharding_functions(solver: ShardedSolve) -> dict[str, Any]:
+    def solution(matrix_data, rhs):
+        return solver(rhs, A_data=matrix_data)[0]
+
+    def rhs_gradient(matrix_data, rhs):
+        x, pullback = jax.vjp(lambda value: solution(matrix_data, value), rhs)
+        return pullback(x)[0]
+
+    def matrix_gradient(matrix_data, rhs):
+        x, pullback = jax.vjp(lambda value: solution(value, rhs), matrix_data)
+        return pullback(x)[0]
+
+    return {
+        "forward": jax.jit(solution),
+        "dL/db": jax.jit(rhs_gradient),
+        "dL/dA": jax.jit(matrix_gradient),
+    }
+
+
+def _run_interface(
+    name: str,
+    functions: dict[str, Any],
+    arguments: tuple[jax.Array, jax.Array],
+    n_runs: int,
+) -> dict[str, Timing]:
+    timings = {}
+    for metric, function in functions.items():
+        if rank == 0:
+            print(f"Benchmarking {name} {metric}...", flush=True)
+        timings[metric] = _benchmark_callable(function, arguments, n_runs)
+    return timings
+
+
+def _relative_error(left: jax.Array, right: jax.Array) -> float:
+    left_np = np.asarray(left, dtype=np.float64)
+    right_np = np.asarray(right, dtype=np.float64)
+    error_sq = comm.allreduce(float(np.sum((left_np - right_np) ** 2)), op=MPI.SUM)
+    reference_sq = comm.allreduce(float(np.sum(right_np**2)), op=MPI.SUM)
+    return float(np.sqrt(error_sq / reference_sq))
+
+
+def _print_results(
+    mpi_timings: dict[str, Timing],
+    sharding_timings: dict[str, Timing],
+) -> None:
+    if rank != 0:
+        return
+
+    print("\nTimes are maximum wall-clock times across MPI ranks (milliseconds).")
+    print(
+        f"{'Interface':<10} {'Metric':<8} {'Compile':>10} {'First':>10} "
+        f"{'Steady avg':>12} {'Steady min':>12} {'Steady max':>12}"
+    )
+    print("-" * 80)
+    for name, timings in (("MPI", mpi_timings), ("Sharding", sharding_timings)):
+        for metric, timing in timings.items():
+            print(
+                f"{name:<10} {metric:<8} {timing.compile_ms:10.2f} "
+                f"{timing.first_ms:10.2f} {timing.mean_ms:12.2f} "
+                f"{min(timing.steady_ms):12.2f} {max(timing.steady_ms):12.2f}"
+            )
+
+    print("\nSteady-state sharding / MPI ratio:")
+    for metric in mpi_timings:
+        ratio = sharding_timings[metric].mean_ms / mpi_timings[metric].mean_ms
+        print(f"  {metric:<8} {ratio:.3f}x")
+
+
+def main() -> None:
+    n_global = 1000000
+    n_runs = 5
+
+    if n_global % nranks:
+        raise ValueError("n_global must be divisible by the number of MPI ranks")
+
+    jax.config.update("jax_logging_level", "ERROR")
+    config = {
+        "solver": "PBICGSTAB",
+        "preconditioner": {"solver": "JACOBI_L1"},
+        "communicator": "MPI_DIRECT",
+        "max_iters": 100,
+        "tolerance": 1e-6,
+        "monitor_residual": 0,
+        "obtain_timings": 0,
+        "print_solve_stats": 0,
+    }
+    _initialize_amgx(config)
+
+    A_local, row_start, row_end = _nonsymmetric_tridiagonal(n_global)
+    b_local_np = (
+        1.0 + 0.1 * np.sin(np.arange(row_start, row_end, dtype=np.float32) * 0.001)
+    ).astype(np.float32)
+    b_local = jnp.asarray(b_local_np)
+
+    mpi_matrix = jsp.BCSR(
+        (A_local.data, A_local.indices, A_local.indptr), shape=A_local.shape
+    )
+    mpi_cache = jaxamg.cache_mpi_metadata(
+        config,
+        comm,
+        n_global,
+        (row_start, row_end),
+        mpi_matrix,
+        is_symmetric=False,
+    )
+
+    mesh = jax.make_mesh((nranks,), ("rank",))
+    sharding = jax.NamedSharding(mesh, jax.P("rank"))
+    b_sharded = jax.make_array_from_process_local_data(
+        sharding, b_local_np, global_shape=(n_global,)
+    )
+    sharded_solver = jaxamg.make_sharded_solver(
+        A_local,
+        b_sharded,
+        comm=comm,
+        mesh=mesh,
+        config=config,
+        is_symmetric=False,
+        reuse_setup=True,
+    )
+
+    if rank == 0:
+        print(
+            f"Nonsymmetric tridiagonal system: n={n_global:,}, "
+            f"ranks/GPUs={nranks}, steady runs={n_runs}\n"
+        )
+
+    mpi_timings = _run_interface(
+        "MPI", _mpi_functions(mpi_matrix, mpi_cache), (mpi_matrix.data, b_local), n_runs
+    )
+    with jax.set_mesh(mesh):
+        sharding_timings = _run_interface(
+            "Sharding",
+            _sharding_functions(sharded_solver),
+            (sharded_solver.A_data, b_sharded),
+            n_runs,
+        )
+
+    sharded_x_local = sharding_timings["forward"].output.addressable_shards[0].data
+    sharded_db_local = sharding_timings["dL/db"].output.addressable_shards[0].data
+    sharded_dA_local = sharded_solver.local_matrix_gradient(
+        sharding_timings["dL/dA"].output
+    ).data
+    forward_error = _relative_error(sharded_x_local, mpi_timings["forward"].output)
+    rhs_gradient_error = _relative_error(sharded_db_local, mpi_timings["dL/db"].output)
+    matrix_gradient_error = _relative_error(
+        sharded_dA_local, mpi_timings["dL/dA"].output
+    )
+
+    _print_results(mpi_timings, sharding_timings)
+    if rank == 0:
+        print("\nRelative differences (sharding versus MPI):")
+        print(f"  forward  {forward_error:.3e}")
+        print(f"  dL/db    {rhs_gradient_error:.3e}")
+        print(f"  dL/dA    {matrix_gradient_error:.3e}")
+
+    comm.Barrier()
+    jaxamg.finalize()
+    comm.Barrier()
+    if nranks > 1:
+        jax.distributed.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/sharding_mpi_benchmark.py
+++ b/demo/sharding_mpi_benchmark.py
@@ -1,10 +1,11 @@
-"""Benchmark the MPI and JAX-sharding distributed interfaces.
+"""Benchmark MPI and JAX sharding on a realistic distributed PDE solve.
 
-The benchmark uses the same nonsymmetric tridiagonal system, AmgX
-configuration, MPI communicator, and one-GPU-per-rank placement for both
-interfaces. It separates JAX compilation, the first execution after clearing
-the AmgX resource cache, and steady-state execution for a forward solve,
-``dL/db``, and ``dL/dA``, where ``L = 0.5 * ||x||**2``.
+Both interfaces solve the same nonsymmetric 3D seven-point
+convection-diffusion system with an AMG-preconditioned Krylov method. Timings
+include AmgX setup/resetup rather than reusing a previously built hierarchy.
+Compilation, the first execution after clearing the AmgX resource cache, and
+steady-state execution are reported separately for a forward solve, ``dL/db``,
+and ``dL/dA``, where ``L = 0.5 * ||x||**2``.
 
 Single-node usage:
     CUDA_VISIBLE_DEVICES=0,1 \
@@ -36,7 +37,7 @@ import jax.experimental.sparse as jsp
 import jax.numpy as jnp
 
 import jaxamg
-from jaxamg.matrices import tridiagonal_matrix_distributed
+from jaxamg.mpi_utils import get_partition_info
 from jaxamg.sharding import ShardedSolve
 
 
@@ -96,34 +97,67 @@ def _benchmark_callable(
     return Timing(compile_ms, first_ms, steady_ms, first_output)
 
 
-def _nonsymmetric_tridiagonal(n_global: int) -> tuple[jsp.BCSR, int, int]:
-    template, row_start, row_end = tridiagonal_matrix_distributed(
-        n_global,
-        rank,
-        nranks,
-        diagonal_value=4.0,
-        dtype=jnp.float32,
+def _convection_diffusion_3d(grid_size: int) -> tuple[jsp.BCSR, int, int]:
+    """Build this rank's CSR rows without materializing the global matrix."""
+    n_global = grid_size**3
+    row_start, row_end, n_local = get_partition_info(n_global, rank, nranks)
+    global_rows = np.arange(row_start, row_end, dtype=np.int64)
+    plane_size = grid_size**2
+    x_coordinate = global_rows // plane_size
+    remainder = global_rows % plane_size
+    y_coordinate = remainder // grid_size
+    z_coordinate = remainder % grid_size
+
+    has_x_minus = x_coordinate > 0
+    has_x_plus = x_coordinate + 1 < grid_size
+    has_y_minus = y_coordinate > 0
+    has_y_plus = y_coordinate + 1 < grid_size
+    has_z_minus = z_coordinate > 0
+    has_z_plus = z_coordinate + 1 < grid_size
+    row_counts = (
+        1
+        + has_x_minus
+        + has_x_plus
+        + has_y_minus
+        + has_y_plus
+        + has_z_minus
+        + has_z_plus
     )
-    global_rows = np.repeat(
-        np.arange(row_start, row_end), np.diff(np.asarray(template.indptr))
-    )
-    columns = np.asarray(template.indices)
-    values = np.where(
-        columns < global_rows,
-        -0.75,
-        np.where(columns > global_rows, -1.25, 4.0),
-    ).astype(np.float32)
+    indptr = np.empty(n_local + 1, dtype=np.int64)
+    indptr[0] = 0
+    np.cumsum(row_counts, out=indptr[1:])
+    indices = np.empty(indptr[-1], dtype=np.int64)
+    values = np.empty(indptr[-1], dtype=np.float32)
+    cursor = indptr[:-1].copy()
+
+    def insert(mask: np.ndarray, offset: int, coefficient: float) -> None:
+        positions = cursor[mask]
+        indices[positions] = global_rows[mask] + offset
+        values[positions] = coefficient
+        cursor[mask] += 1
+
+    # Increasing column order within each row. The unequal x-direction
+    # coefficients add a modest convection term to the diffusion stencil.
+    insert(has_x_minus, -plane_size, -1.15)
+    insert(has_y_minus, -grid_size, -1.0)
+    insert(has_z_minus, -1, -1.0)
+    insert(np.ones(n_local, dtype=bool), 0, 6.25)
+    insert(has_z_plus, 1, -1.0)
+    insert(has_y_plus, grid_size, -1.0)
+    insert(has_x_plus, plane_size, -0.85)
+
     matrix = jsp.BCSR(
-        (jnp.asarray(values), template.indices, template.indptr),
-        shape=template.shape,
+        (jnp.asarray(values), jnp.asarray(indices), jnp.asarray(indptr)),
+        shape=(n_local, n_global),
     )
     return matrix, row_start, row_end
 
 
 def _initialize_amgx(config: dict[str, Any]) -> None:
     """Remove one-time AmgX initialization from the first measured interface."""
-    warmup_size = 4 * nranks
-    matrix, row_start, row_end = _nonsymmetric_tridiagonal(warmup_size)
+    warmup_grid_size = 4
+    warmup_size = warmup_grid_size**3
+    matrix, row_start, row_end = _convection_diffusion_3d(warmup_grid_size)
     cache = jaxamg.cache_mpi_metadata(
         config,
         comm,
@@ -134,7 +168,7 @@ def _initialize_amgx(config: dict[str, Any]) -> None:
     )
     matrix = jaxamg.with_cache(matrix, mpi=cache, is_symmetric=False)
     rhs = jnp.ones(row_end - row_start, dtype=matrix.data.dtype)
-    jaxamg.solve(matrix, rhs, reuse_setup=True)[0].block_until_ready()
+    jaxamg.solve(matrix, rhs)[0].block_until_ready()
     comm.Barrier()
     jaxamg.clear_solver_cache()
     comm.Barrier()
@@ -149,7 +183,7 @@ def _mpi_functions(
             (matrix_data, A_local.indices, A_local.indptr), shape=A_local.shape
         )
         matrix = jaxamg.with_cache(matrix, mpi=mpi_cache, is_symmetric=False)
-        return jaxamg.solve(matrix, rhs, reuse_setup=True)[0]
+        return jaxamg.solve(matrix, rhs)[0]
 
     def rhs_gradient(matrix_data, rhs):
         x, pullback = jax.vjp(lambda value: solution(matrix_data, value), rhs)
@@ -235,18 +269,16 @@ def _print_results(
 
 
 def main() -> None:
-    n_global = 1000000
-    n_runs = 5
-
-    if n_global % nranks:
-        raise ValueError("n_global must be divisible by the number of MPI ranks")
+    grid_size = 128
+    n_global = grid_size**3
+    n_runs = 3
 
     jax.config.update("jax_logging_level", "ERROR")
     config = {
         "solver": "PBICGSTAB",
-        "preconditioner": {"solver": "JACOBI_L1"},
+        "preconditioner": {"solver": "AMG"},
         "communicator": "MPI_DIRECT",
-        "max_iters": 100,
+        "max_iters": 200,
         "tolerance": 1e-6,
         "monitor_residual": 0,
         "obtain_timings": 0,
@@ -254,7 +286,7 @@ def main() -> None:
     }
     _initialize_amgx(config)
 
-    A_local, row_start, row_end = _nonsymmetric_tridiagonal(n_global)
+    A_local, row_start, row_end = _convection_diffusion_3d(grid_size)
     b_local_np = (
         1.0 + 0.1 * np.sin(np.arange(row_start, row_end, dtype=np.float32) * 0.001)
     ).astype(np.float32)
@@ -273,9 +305,8 @@ def main() -> None:
     )
 
     mesh = jax.make_mesh((nranks,), ("rank",))
-    sharding = jax.NamedSharding(mesh, jax.P("rank"))
-    b_sharded = jax.make_array_from_process_local_data(
-        sharding, b_local_np, global_shape=(n_global,)
+    b_sharded = jaxamg.make_sharded_vector(
+        b_local, comm=comm, mesh=mesh, global_size=n_global
     )
     sharded_matrix = jaxamg.make_sharded_matrix(
         A_local, b_sharded, comm=comm, mesh=mesh
@@ -285,13 +316,15 @@ def main() -> None:
         b_sharded,
         config=config,
         is_symmetric=False,
-        reuse_setup=True,
     )
 
+    global_nnz = comm.allreduce(len(A_local.data), op=MPI.SUM)
     if rank == 0:
         print(
-            f"Nonsymmetric tridiagonal system: n={n_global:,}, "
-            f"ranks/GPUs={nranks}, steady runs={n_runs}\n"
+            f"Nonsymmetric 3D convection-diffusion: grid={grid_size}^3, "
+            f"n={n_global:,}, nnz={global_nnz:,}\n"
+            f"AMG-preconditioned PBICGSTAB, ranks/GPUs={nranks}, "
+            f"steady runs={n_runs}, hierarchy reuse disabled\n"
         )
 
     mpi_timings = _run_interface(
@@ -305,8 +338,8 @@ def main() -> None:
             n_runs,
         )
 
-    sharded_x_local = sharding_timings["forward"].output.addressable_shards[0].data
-    sharded_db_local = sharding_timings["dL/db"].output.addressable_shards[0].data
+    sharded_x_local = sharded_solver.local_vector(sharding_timings["forward"].output)
+    sharded_db_local = sharded_solver.local_vector(sharding_timings["dL/db"].output)
     sharded_dA_local = sharded_matrix.local_matrix(
         sharding_timings["dL/dA"].output
     ).data

--- a/demo/sharding_mpi_benchmark.py
+++ b/demo/sharding_mpi_benchmark.py
@@ -202,7 +202,7 @@ def _mpi_functions(
 
 def _sharding_functions(solver: ShardedSolve) -> dict[str, Any]:
     def solution(matrix_data, rhs):
-        return solver(rhs, A_data=matrix_data)[0]
+        return solver(rhs, A=matrix_data)[0]
 
     def rhs_gradient(matrix_data, rhs):
         x, pullback = jax.vjp(lambda value: solution(matrix_data, value), rhs)

--- a/demo/sharding_mpi_benchmark.py
+++ b/demo/sharding_mpi_benchmark.py
@@ -277,11 +277,12 @@ def main() -> None:
     b_sharded = jax.make_array_from_process_local_data(
         sharding, b_local_np, global_shape=(n_global,)
     )
+    sharded_matrix = jaxamg.make_sharded_matrix(
+        A_local, b_sharded, comm=comm, mesh=mesh
+    )
     sharded_solver = jaxamg.make_sharded_solver(
-        A_local,
+        sharded_matrix,
         b_sharded,
-        comm=comm,
-        mesh=mesh,
         config=config,
         is_symmetric=False,
         reuse_setup=True,
@@ -300,13 +301,13 @@ def main() -> None:
         sharding_timings = _run_interface(
             "Sharding",
             _sharding_functions(sharded_solver),
-            (sharded_solver.A_data, b_sharded),
+            (sharded_matrix.data, b_sharded),
             n_runs,
         )
 
     sharded_x_local = sharding_timings["forward"].output.addressable_shards[0].data
     sharded_db_local = sharding_timings["dL/db"].output.addressable_shards[0].data
-    sharded_dA_local = sharded_solver.local_matrix_gradient(
+    sharded_dA_local = sharded_matrix.local_matrix(
         sharding_timings["dL/dA"].output
     ).data
     forward_error = _relative_error(sharded_x_local, mpi_timings["forward"].output)

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,18 @@ This page documents the public API of JAX-AMG.
 
 ## JAX Sharding
 
+::: jaxamg.ShardedMatrix
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
+::: jaxamg.make_sharded_matrix
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
 ::: jaxamg.make_sharded_vector
     options:
         show_root_heading: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,12 +44,6 @@ This page documents the public API of JAX-AMG.
         show_source: false
         heading_level: 3
 
-::: jaxamg.solve_sharded
-    options:
-        show_root_heading: true
-        show_source: false
-        heading_level: 3
-
 ## Caching
 
 ::: jaxamg.with_cache

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,20 @@ This page documents the public API of JAX-AMG.
         show_source: false
         heading_level: 3
 
+## JAX Sharding
+
+::: jaxamg.make_sharded_solver
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
+::: jaxamg.solve_sharded
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
 ## Caching
 
 ::: jaxamg.with_cache

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,12 @@ This page documents the public API of JAX-AMG.
 
 ## JAX Sharding
 
+::: jaxamg.make_sharded_vector
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
 ::: jaxamg.make_sharded_solver
     options:
         show_root_heading: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,12 @@ This page documents the public API of JAX-AMG.
         show_source: false
         heading_level: 3
 
+::: jaxamg.ShardedSolve
+    options:
+        show_root_heading: true
+        show_source: false
+        heading_level: 3
+
 ::: jaxamg.make_sharded_matrix
     options:
         show_root_heading: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,6 +55,19 @@ mpirun -n 2 python -m pytest --only-mpi tests/
   [MPI Guide](mpi.md#gpu-aware-mpi) and
   [Environment Variables Reference](environ.md) for details.
 
+### JAX sharding tests
+
+Run the sharding integration tests separately so every MPI process retains
+visibility of all participating GPUs:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+mpirun -n 2 python -m pytest --only-mpi tests/test_sharding_mpi.py
+```
+
+Selecting this test module prevents the ordinary MPI test fixture from narrowing
+each rank to one visible CUDA device and enables early `jax.distributed` setup.
+
 !!! tip
     The MPI demos under `demo/` (e.g. `mpirun -n 4 python demo/mpi_autodiff.py`)
     are a quick way to sanity-check distributed behavior end to end.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 - **GPU-Accelerated Solvers**: Leverages NVIDIA AmgX for a broad range of GPU-accelerated sparse linear solvers, including algebraic multigrid (AMG), Krylov methods, and various variants, with flexible configuration options for solvers, smoothers, and preconditioners.
 - **Automatic Differentiation**: Supports adjoint-based gradient computation and integrates seamlessly with JAX for end-to-end differentiable workflows.
 - **JIT Compilation**: Built as a native JAX primitive, fully compatible with Just-in-Time compilation (`jax.jit`) for efficient, low-overhead execution.
-- **MPI Support**: Enables distributed linear solves across multiple GPUs, with GPU-aware MPI support.
+- **Distributed Solving**: Supports multi-GPU MPI, GPU-aware communication, and JAX sharding.
 - **Matrix-Free Operators**: Beyond explicit matrices, `A` can be a callable operator. The library recovers the exact sparsity pattern in a single pass by tracing the operator's computation graph, then assembles the matrix the solver needs.
 
 ## Dependencies
@@ -68,4 +68,3 @@ If you use JAX-AMG in your work, please consider using the following citation ([
       url={https://arxiv.org/abs/2606.09001},
 }
 ```
-

--- a/docs/mpi.md
+++ b/docs/mpi.md
@@ -2,6 +2,10 @@
 
 This page explains how to run JAX-AMG in distributed mode with MPI across multiple GPUs and nodes.
 
+If your application already uses JAX sharding, see the additive
+[JAX Sharding](sharding.md) interface. It retains MPI inside AmgX rather than
+replacing the workflow documented here.
+
 ## Prerequisites
 
 Before running MPI jobs, make sure you have:

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -164,7 +164,9 @@ dynamic operand rather than a constant baked into the executable.
 When the values depend on parameters, pass this rank's operator or matrix as
 `A=`, exactly as `solve(A, b)` takes it in the MPI interface. The solver
 materializes it with the sparsity fixed at construction and differentiates
-through it:
+through it. A matrix must carry exactly that CSR structure, with concrete
+indices and row pointers; traced values with the fixed structure go through
+the packed `A.data` layout.
 
 ```python
 from jaxamg.matrices import poisson_operator

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -46,26 +46,19 @@ Launchers recognized directly by JAX may also work with an argument-free
 `jax.distributed.initialize()`. The explicit `mpi4py` method also covers MPI
 environments whose launcher variables JAX does not recognize automatically.
 
-## Required XLA Flag for Multi-Process Jobs
+## XLA Sharded Autotuning
 
-A sharded solver compiles each rank's local CSR structure and communication
-plans into that process's program as constants, so the processes compile
-programs that are not identical. XLA's cross-process *sharded autotuning*
-assumes identical programs and deadlocks during compilation as soon as such a
-program also contains an automatically partitioned collective. A loss that
-reduces the solution across ranks inside `jax.jit`, such as
-`jnp.sum(x**2)`, produces exactly that collective, so disable the autotuning:
-
-```bash
-XLA_FLAGS=--xla_gpu_shard_autotuning=false \
-  mpirun -n 2 python your_script.py
-```
-
-The flag is read when JAX initializes its backend, so set it in the environment
-or via `os.environ` before the first JAX device call. Without it, a compiled
-loss that reduces across ranks hangs in compilation rather than failing;
-uncompiled calls and `jax.jit(jax.grad(...))` are unaffected, because neither
-emits that collective.
+XLA's cross-process sharded autotuning assumes every process compiles the
+identical program. A sharded solver compiles each rank's local CSR structure
+and communication plans into that process's program, so compiling a
+multi-process loss under that autotuning deadlocks. Importing jaxamg therefore
+disables it (`--xla_gpu_shard_autotuning=false`; this only affects compile
+time). XLA reads `XLA_FLAGS` when its backend initializes, so import jaxamg
+before the first JAX device call. Otherwise set the flag in the environment
+yourself or pass `compiler_options={"xla_gpu_shard_autotuning": False}` to
+the outer `jax.jit`; `make_sharded_solver` warns when the flag was not applied
+in time. An explicit `xla_gpu_shard_autotuning` setting in `XLA_FLAGS` is left
+untouched.
 
 ## Sharded Solve
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -9,6 +9,11 @@ The interface targets `shard_map` and `NamedSharding` rather than adding a
 separate `pmap` wrapper. This keeps inputs and outputs as JAX global arrays and
 fits JAX's current explicit-sharding model.
 
+The interface is experimental. Every process issues the same collectives, but
+its compiled program carries rank-specific constants (the local CSR structure
+and communication plans), which JAX's SPMD model does not formally promise to
+support. Expect the API to evolve.
+
 ## Current Scope
 
 The initial interface supports:
@@ -22,8 +27,10 @@ The initial interface supports:
 - JIT compilation and reverse-mode differentiation with respect to matrix
   values and the RHS.
 
-The local CSR structure is fixed when the solver is created. Multiple local GPUs
-per MPI process are not supported yet.
+The local CSR structure is fixed when the solver is created. It requires JAX
+0.8 or newer, a communicator spanning every JAX process
+(no subcommunicators), and at least one row per rank. Multiple local GPUs per
+MPI process are not supported yet.
 
 ## Process and Device Setup
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -15,14 +15,14 @@ The initial interface supports:
 
 - one MPI process and one mesh-local GPU per rank;
 - a one-dimensional JAX mesh where device position `i` belongs to MPI rank `i`;
-- a uniformly row-sharded, one-dimensional right-hand side;
+- a row-sharded, one-dimensional right-hand side with equal or unequal local
+  row counts;
 - symmetric and nonsymmetric distributed matrices; and
 - JIT compilation and reverse-mode differentiation with respect to matrix
   values and the RHS.
 
 The local CSR structure is fixed when the solver is created. Multiple local GPUs
-per MPI process and uneven row partitions are not supported yet. Use
-`jaxamg.solve(..., comm=...)` when you need those MPI features.
+per MPI process are not supported yet.
 
 ## Process and Device Setup
 
@@ -55,11 +55,11 @@ import numpy as np
 import jaxamg
 
 mesh = jax.make_mesh((nranks,), ("rank",))
-sharding = jax.NamedSharding(mesh, jax.P("rank"))
-b = jax.make_array_from_process_local_data(
-    sharding,
+b = jaxamg.make_sharded_vector(
     np.asarray(b_local),
-    global_shape=(n_global,),
+    comm=comm,
+    mesh=mesh,
+    global_size=n_global,
 )
 
 solver = jaxamg.make_sharded_solver(
@@ -73,10 +73,11 @@ solver = jaxamg.make_sharded_solver(
 x, info = solver(b)
 ```
 
-`x` is a global array with the same row sharding as `b`. The values in `info`
-are also global arrays, with one entry per rank. Use `addressable_shards` for
-process-local inspection or JAX multi-host utilities when you need a complete
-host copy.
+`x` is a global array with the same row sharding as `b`. For unequal row counts,
+JAX's equal physical shards are padded to the largest local partition; the
+solver ignores the padding and returns zeros there. Use `solver.local_vector(x)`
+to access this rank's unpadded result. The values in `info` are global arrays,
+with one entry per rank.
 
 The solver exposes the packed, sharded CSR values as `solver.A_data`. Pass them
 to the solve when differentiating matrix values. Enter the mesh context for an

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -72,12 +72,11 @@ x, info = solver(b)
 
 The sharding helpers use `MPI.COMM_WORLD` and a one-dimensional mesh over all
 JAX devices by default. Pass `comm=` or `mesh=` explicitly to override them;
-the matrix and solver otherwise infer the mesh from `b`.
+the matrix otherwise infers the mesh from `b`, and the solver uses the matrix's
+communicator and mesh.
 
 `A` stores the CSR structure only on its owning rank and exposes its padded,
 globally sharded values as `A.data`; it does not replicate the global matrix.
-The original local-matrix form remains supported by
-`make_sharded_solver(A_local, b)` as a convenience.
 
 When `b_local` or the local matrix values are JAX device arrays, vector and
 matrix packing stays on device. NumPy inputs are transferred to the target GPU
@@ -103,9 +102,8 @@ RHS gradients retain the padded shape and sharding of the RHS. The scalar info
 values have shape `(nranks, nrhs)`, and residual history has shape
 `(nranks, nrhs, max_iters + 1)`.
 
-Pass `A.data` to the solve when differentiating matrix values. The
-backward-compatible `solver.A_data` attribute aliases the same array. Enter the
-mesh context for an outer transformation:
+Pass `A.data` to the solve when differentiating matrix values. Enter the mesh
+context for an outer transformation:
 
 ```python
 import jax.numpy as jnp
@@ -126,10 +124,6 @@ grad_A_local = A.local_matrix(grad_A_data)
 
 The solver is compiled internally and also composes with an enclosing
 `jax.jit`, including JIT-compiled reverse-mode differentiation.
-
-For a one-off solve, `jaxamg.solve_sharded(...)` accepts the same setup arguments
-and immediately invokes the resulting solver. Prefer `make_sharded_solver` in
-loops so metadata and compiled executables are reused.
 
 Run the complete single-node example with:
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -17,6 +17,8 @@ The initial interface supports:
 - a one-dimensional JAX mesh where device position `i` belongs to MPI rank `i`;
 - a row-sharded, one-dimensional right-hand side with equal or unequal local
   row counts;
+- scalar and block matrices, provided every rank's true row count is divisible
+  by `block_dim`;
 - symmetric and nonsymmetric distributed matrices; and
 - JIT compilation and reverse-mode differentiation with respect to matrix
   values and the RHS.
@@ -72,6 +74,11 @@ solver = jaxamg.make_sharded_solver(
 
 x, info = solver(b)
 ```
+
+For a coupled block system, pass `block_dim=k` to `make_sharded_solver`. The
+matrix and vectors retain their ordinary scalar CSR/vector representation;
+AmgX performs the internal block conversion. Unequal rank partitions remain
+supported as long as each partition ends on a block boundary.
 
 `x` is a global array with the same row sharding as `b`. For unequal row counts,
 JAX's equal physical shards are padded to the largest local partition; the

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -56,25 +56,23 @@ once and reuse it:
 import numpy as np
 import jaxamg
 
-mesh = jax.make_mesh((nranks,), ("rank",))
 b = jaxamg.make_sharded_vector(
     np.asarray(b_local),
-    mesh=mesh,
     global_size=n_global,
 )
 
 solver = jaxamg.make_sharded_solver(
     A_local,
     b,
-    mesh=mesh,
     config={"solver": "GMRES", "communicator": "MPI_DIRECT"},
 )
 
 x, info = solver(b)
 ```
 
-The sharding helpers use `MPI.COMM_WORLD` by default. Pass `comm=` explicitly
-when using an MPI subcommunicator.
+The sharding helpers use `MPI.COMM_WORLD` and a one-dimensional mesh over all
+JAX devices by default. Pass `comm=` or `mesh=` explicitly to override them;
+the solver otherwise infers the mesh from `b`.
 
 For a coupled block system, pass `block_dim=k` to `make_sharded_solver`. The
 matrix and vectors retain their ordinary scalar CSR/vector representation;

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -23,14 +23,15 @@ The initial interface supports:
 - row-sharded vectors with equal or unequal local row counts;
 - scalar and block matrices, provided every rank's true row count is divisible
   by `block_dim`;
-- symmetric and nonsymmetric distributed matrices; and
+- symmetric and nonsymmetric distributed matrices;
+- singular systems with declared null spaces; and
 - JIT compilation and reverse-mode differentiation with respect to matrix
   values and the RHS.
 
 The local CSR structure is fixed when the solver is created. It requires JAX
 0.8 or newer, a communicator spanning every JAX process
 (no subcommunicators), and at least one row per rank. Multiple local GPUs per
-MPI process and singular systems (`nullspace`) are not supported yet.
+MPI process are not supported yet.
 
 ## Process and Device Setup
 
@@ -165,6 +166,26 @@ grad_A_local = A.local_matrix(grad_A_data)
 A direct `solver(b)` call uses the cached values. Under a JAX transformation
 `A` is required, even for RHS-only differentiation, so the values stay a
 dynamic operand rather than a constant baked into the executable.
+
+## Singular Systems
+
+Attach the null-space bases (local rows) to the matrix before packing it, as
+for `solve`:
+
+```python
+A_local = jaxamg.with_cache(A_local, nullspace="constant", transpose_nullspace=V_local)
+A = jaxamg.make_sharded_matrix(A_local, b)
+solver = jaxamg.make_sharded_solver(A, b, config=config)
+```
+
+The bases are fixed at creation, like the sparsity, and applied to every solve
+(including through `A=`): the RHS is projected onto `range(A)`, the solution is
+pinned orthogonal to `null(A)`, the adjoint solve applies the transposed
+projections, and the AMG configuration switches to the singular-system
+defaults. `info["rhs_inconsistency"]` has one entry per rank. With
+`is_symmetric=True` one basis serves both roles. Every rank must declare the
+same bases (column counts included). As in `solve`, gradients with respect to
+matrix values assume perturbations that preserve the declared null spaces.
 
 ## Differentiating Operator Parameters
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -97,10 +97,11 @@ with one entry per rank.
 For multiple right-hand sides sharing the same matrix, pass rank-local values
 with shape `(n_local, nrhs)` to `make_sharded_vector`. The returned array and
 solution use `PartitionSpec("rank", None)`. AmgX solves the columns sequentially
-in a fixed cross-rank order. Matrix gradients are summed over all RHS columns;
-RHS gradients retain the padded shape and sharding of the RHS. The scalar info
-values have shape `(nranks, nrhs)`, and residual history has shape
-`(nranks, nrhs, max_iters + 1)`.
+in a fixed cross-rank order and reuses the hierarchy after the first column.
+Matrix gradients are accumulated over all RHS columns without retaining one
+full sparse gradient per column; RHS gradients retain the padded shape and
+sharding of the RHS. The scalar info values have shape `(nranks, nrhs)`, and
+residual history has shape `(nranks, nrhs, max_iters + 1)`.
 
 Pass `A.data` to the solve when differentiating matrix values. Enter the mesh
 context for an outer transformation:
@@ -112,18 +113,23 @@ def loss(A_data, rhs):
     x, _ = solver(rhs, A_data=A_data)
     return jnp.sum(x**2)
 
-compiled_solver = jax.jit(solver)
+compiled_solver = jax.jit(
+    lambda A_data, rhs: solver(rhs, A_data=A_data)
+)
 compiled_gradient = jax.jit(jax.grad(loss, argnums=(0, 1)))
 
 with jax.set_mesh(b.sharding.mesh):
-    x, info = compiled_solver(b)
+    x, info = compiled_solver(A.data, b)
     grad_A_data, grad_b = compiled_gradient(A.data, b)
 
 grad_A_local = A.local_matrix(grad_A_data)
 ```
 
-The solver is compiled internally and also composes with an enclosing
-`jax.jit`, including JIT-compiled reverse-mode differentiation.
+The solver is compiled internally, so a direct `solver(b)` call can use the
+matrix's cached values. Pass `A.data` explicitly under an enclosing JAX
+transformation, including RHS-only differentiation. This keeps the distributed
+matrix values as a dynamic operand instead of embedding a full local value
+buffer in the compiled executable.
 
 Run the complete single-node example with:
 
@@ -135,6 +141,8 @@ mpirun -n 2 python demo/sharded_poisson_problem.py
 
 `MPI4JAX_USE_CUDA_MPI` remains relevant to the existing MPI autodiff path but
 is not required for the sharding path. Matrix gradients use a sparse JAX
-all-to-all halo exchange. For a nonsymmetric matrix, the transpose structure is
-cached during solver creation and its values are updated for each adjoint solve;
-the forward and adjoint solves are both performed by AmgX.
+all-to-all halo exchange. For a nonsymmetric matrix, the transpose structure
+and a sparse value-exchange plan are cached during solver creation. Only
+off-rank transpose values are exchanged, once per backward pass, rather than
+replicating all matrix values on every GPU. The forward and adjoint solves are
+both performed by AmgX.

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -61,8 +61,9 @@ b = jaxamg.make_sharded_vector(
     global_size=n_global,
 )
 
+A = jaxamg.make_sharded_matrix(A_local, b)
 solver = jaxamg.make_sharded_solver(
-    A_local,
+    A,
     b,
     config={"solver": "GMRES", "communicator": "MPI_DIRECT"},
 )
@@ -72,7 +73,12 @@ x, info = solver(b)
 
 The sharding helpers use `MPI.COMM_WORLD` and a one-dimensional mesh over all
 JAX devices by default. Pass `comm=` or `mesh=` explicitly to override them;
-the solver otherwise infers the mesh from `b`.
+the matrix and solver otherwise infer the mesh from `b`.
+
+`A` stores the CSR structure only on its owning rank and exposes its padded,
+globally sharded values as `A.data`; it does not replicate the global matrix.
+The original local-matrix form remains supported by
+`make_sharded_solver(A_local, b)` as a convenience.
 
 For a coupled block system, pass `block_dim=k` to `make_sharded_solver`. The
 matrix and vectors retain their ordinary scalar CSR/vector representation;
@@ -93,9 +99,9 @@ RHS gradients retain the padded shape and sharding of the RHS. The scalar info
 values have shape `(nranks, nrhs)`, and residual history has shape
 `(nranks, nrhs, max_iters + 1)`.
 
-The solver exposes the packed, sharded CSR values as `solver.A_data`. Pass them
-to the solve when differentiating matrix values. Enter the mesh context for an
-outer transformation:
+Pass `A.data` to the solve when differentiating matrix values. The
+backward-compatible `solver.A_data` attribute aliases the same array. Enter the
+mesh context for an outer transformation:
 
 ```python
 import jax.numpy as jnp
@@ -107,11 +113,11 @@ def loss(A_data, rhs):
 compiled_solver = jax.jit(solver)
 compiled_gradient = jax.jit(jax.grad(loss, argnums=(0, 1)))
 
-with jax.set_mesh(mesh):
+with jax.set_mesh(b.sharding.mesh):
     x, info = compiled_solver(b)
-    grad_A_data, grad_b = compiled_gradient(solver.A_data, b)
+    grad_A_data, grad_b = compiled_gradient(A.data, b)
 
-grad_A_local = solver.local_matrix_gradient(grad_A_data)
+grad_A_local = A.local_matrix(grad_A_data)
 ```
 
 The solver is compiled internally and also composes with an enclosing

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -89,11 +89,18 @@ def loss(A_data, rhs):
     x, _ = solver(rhs, A_data=A_data)
     return jnp.sum(x**2)
 
+compiled_solver = jax.jit(solver)
+compiled_gradient = jax.jit(jax.grad(loss, argnums=(0, 1)))
+
 with jax.set_mesh(mesh):
-    grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(solver.A_data, b)
+    x, info = compiled_solver(b)
+    grad_A_data, grad_b = compiled_gradient(solver.A_data, b)
 
 grad_A_local = solver.local_matrix_gradient(grad_A_data)
 ```
+
+The solver is compiled internally and also composes with an enclosing
+`jax.jit`, including JIT-compiled reverse-mode differentiation.
 
 For a one-off solve, `jaxamg.solve_sharded(...)` accepts the same setup arguments
 and immediately invokes the resulting solver. Prefer `make_sharded_solver` in

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -15,8 +15,7 @@ The initial interface supports:
 
 - one MPI process and one mesh-local GPU per rank;
 - a one-dimensional JAX mesh where device position `i` belongs to MPI rank `i`;
-- row-sharded vector and batched right-hand sides with equal or unequal local
-  row counts;
+- row-sharded vectors with equal or unequal local row counts;
 - scalar and block matrices, provided every rank's true row count is divisible
   by `block_dim`;
 - symmetric and nonsymmetric distributed matrices; and
@@ -94,14 +93,20 @@ solver ignores the padding and returns zeros there. Use `solver.local_vector(x)`
 to access this rank's unpadded result. The values in `info` are global arrays,
 with one entry per rank.
 
-For multiple right-hand sides sharing the same matrix, pass rank-local values
-with shape `(n_local, nrhs)` to `make_sharded_vector`. The returned array and
-solution use `PartitionSpec("rank", None)`. AmgX solves the columns sequentially
-in a fixed cross-rank order and reuses the hierarchy after the first column.
-Matrix gradients are accumulated over all RHS columns without retaining one
-full sparse gradient per column; RHS gradients retain the padded shape and
-sharding of the RHS. The scalar info values have shape `(nranks, nrhs)`, and
-residual history has shape `(nranks, nrhs, max_iters + 1)`.
+For multiple right-hand sides, construct each global sharded vector separately
+and apply `jax.vmap` to the single-vector solver, just as with `jaxamg.solve`:
+
+```python
+import jax
+import jax.numpy as jnp
+
+batched_b = jnp.stack((b1, b2))
+batched_x, batched_info = jax.vmap(
+    lambda rhs: solver(rhs, A_data=A.data)
+)(batched_b)
+```
+
+The underlying AmgX solves use JAX-AMG's sequential FFI batching path.
 
 Pass `A.data` to the solve when differentiating matrix values. Enter the mesh
 context for an outer transformation:

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -15,7 +15,7 @@ The initial interface supports:
 
 - one MPI process and one mesh-local GPU per rank;
 - a one-dimensional JAX mesh where device position `i` belongs to MPI rank `i`;
-- a row-sharded, one-dimensional right-hand side with equal or unequal local
+- row-sharded vector and batched right-hand sides with equal or unequal local
   row counts;
 - scalar and block matrices, provided every rank's true row count is divisible
   by `block_dim`;
@@ -85,6 +85,14 @@ JAX's equal physical shards are padded to the largest local partition; the
 solver ignores the padding and returns zeros there. Use `solver.local_vector(x)`
 to access this rank's unpadded result. The values in `info` are global arrays,
 with one entry per rank.
+
+For multiple right-hand sides sharing the same matrix, pass rank-local values
+with shape `(n_local, nrhs)` to `make_sharded_vector`. The returned array and
+solution use `PartitionSpec("rank", None)`. AmgX solves the columns sequentially
+in a fixed cross-rank order. Matrix gradients are summed over all RHS columns;
+RHS gradients retain the padded shape and sharding of the RHS. The scalar info
+values have shape `(nranks, nrhs)`, and residual history has shape
+`(nranks, nrhs, max_iters + 1)`.
 
 The solver exposes the packed, sharded CSR values as `solver.A_data`. Pass them
 to the solve when differentiating matrix values. Enter the mesh context for an

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -29,7 +29,7 @@ The initial interface supports:
   values and the RHS.
 
 The local CSR structure is fixed when the solver is created. It requires JAX
-0.8 or newer, a communicator spanning every JAX process
+0.9 or newer, a communicator spanning every JAX process
 (no subcommunicators), and at least one row per rank. Multiple local GPUs per
 MPI process are not supported yet.
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -1,0 +1,114 @@
+# JAX Sharding
+
+JAX-AMG provides an additive sharding interface for applications that already
+use JAX global arrays. It does not replace the [MPI interface](mpi.md): AmgX
+still performs the distributed solve through MPI, while `jax.shard_map`
+preserves the global sharding of the right-hand side and solution.
+
+The interface targets `shard_map` and `NamedSharding` rather than adding a
+separate `pmap` wrapper. This keeps inputs and outputs as JAX global arrays and
+fits JAX's current explicit-sharding model.
+
+## Current Scope
+
+The initial interface supports:
+
+- one MPI process and one mesh-local GPU per rank;
+- a one-dimensional JAX mesh where device position `i` belongs to MPI rank `i`;
+- a uniformly row-sharded, one-dimensional right-hand side;
+- symmetric and nonsymmetric distributed matrices; and
+- JIT compilation and reverse-mode differentiation with respect to matrix
+  values and the RHS.
+
+The local CSR structure is fixed when the solver is created. Multiple local GPUs
+per MPI process and uneven row partitions are not supported yet. Use
+`jaxamg.solve(..., comm=...)` when you need those MPI features.
+
+## Process and Device Setup
+
+Call `jax.distributed.initialize()` before querying JAX devices. On a single
+node, keep all participating GPUs visible to every MPI process and select one
+distinct device per process. Do not remap every rank's GPU to CUDA ordinal 0;
+JAX/NCCL would then see duplicate devices. Because JAX-AMG already requires
+`mpi4py`, its cluster-detection method can derive the coordinator, process IDs,
+and local device assignment from the MPI job:
+
+```python
+import jax
+
+jax.distributed.initialize(
+    cluster_detection_method="mpi4py",
+)
+```
+
+Launchers recognized directly by JAX may also work with an argument-free
+`jax.distributed.initialize()`. The explicit `mpi4py` method also covers MPI
+environments whose launcher variables JAX does not recognize automatically.
+
+## Sharded Solve
+
+Build a global RHS from each process's local partition, then create the solver
+once and reuse it:
+
+```python
+import numpy as np
+import jaxamg
+
+mesh = jax.make_mesh((nranks,), ("rank",))
+sharding = jax.NamedSharding(mesh, jax.P("rank"))
+b = jax.make_array_from_process_local_data(
+    sharding,
+    np.asarray(b_local),
+    global_shape=(n_global,),
+)
+
+solver = jaxamg.make_sharded_solver(
+    A_local,
+    b,
+    comm=comm,
+    mesh=mesh,
+    config={"solver": "GMRES", "communicator": "MPI_DIRECT"},
+)
+
+x, info = solver(b)
+```
+
+`x` is a global array with the same row sharding as `b`. The values in `info`
+are also global arrays, with one entry per rank. Use `addressable_shards` for
+process-local inspection or JAX multi-host utilities when you need a complete
+host copy.
+
+The solver exposes the packed, sharded CSR values as `solver.A_data`. Pass them
+to the solve when differentiating matrix values. Enter the mesh context for an
+outer transformation:
+
+```python
+import jax.numpy as jnp
+
+def loss(A_data, rhs):
+    x, _ = solver(rhs, A_data=A_data)
+    return jnp.sum(x**2)
+
+with jax.set_mesh(mesh):
+    grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(solver.A_data, b)
+
+grad_A_local = solver.local_matrix_gradient(grad_A_data)
+```
+
+For a one-off solve, `jaxamg.solve_sharded(...)` accepts the same setup arguments
+and immediately invokes the resulting solver. Prefer `make_sharded_solver` in
+loops so metadata and compiled executables are reused.
+
+Run the complete single-node example with:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+OMPI_MCA_opal_cuda_support=true \
+mpirun -n 2 python demo/sharded_poisson_problem.py
+```
+
+`MPI4JAX_USE_CUDA_MPI` remains relevant to the existing MPI autodiff path but
+is not required for the sharding path. Matrix gradients use a sparse JAX
+all-to-all halo exchange. For a nonsymmetric matrix, the transpose structure is
+cached during solver creation and its values are updated for each adjoint solve;
+the forward and adjoint solves are both performed by AmgX.

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -87,6 +87,17 @@ matrix and vectors retain their ordinary scalar CSR/vector representation;
 AmgX performs the internal block conversion. Unequal rank partitions remain
 supported as long as each partition ends on a block boundary.
 
+To save detailed AmgX solver statistics, create the solver with
+`save_stats=True` and pass a file path to a direct call:
+
+```python
+solver = jaxamg.make_sharded_solver(A, b, save_stats=True)
+x, info = solver(b, save_stats_file="stats_sharded.txt")
+```
+
+As with `jaxamg.solve`, rank 0 writes the formatted file. Statistics can only
+be saved from a direct call, not from inside `jax.jit` or another transform.
+
 `x` is a global array with the same row sharding as `b`. For unequal row counts,
 JAX's equal physical shards are padded to the largest local partition; the
 solver ignores the padding and returns zeros there. Use `solver.local_vector(x)`

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -30,7 +30,7 @@ per MPI process are not supported yet.
 Call `jax.distributed.initialize()` before querying JAX devices. On a single
 node, keep all participating GPUs visible to every MPI process and select one
 distinct device per process. Do not remap every rank's GPU to CUDA ordinal 0;
-JAX/NCCL would then see duplicate devices. Because JAX-AMG already requires
+JAX/NCCL would then see duplicate devices. Because this interface uses
 `mpi4py`, its cluster-detection method can derive the coordinator, process IDs,
 and local device assignment from the MPI job:
 

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -59,7 +59,6 @@ import jaxamg
 mesh = jax.make_mesh((nranks,), ("rank",))
 b = jaxamg.make_sharded_vector(
     np.asarray(b_local),
-    comm=comm,
     mesh=mesh,
     global_size=n_global,
 )
@@ -67,13 +66,15 @@ b = jaxamg.make_sharded_vector(
 solver = jaxamg.make_sharded_solver(
     A_local,
     b,
-    comm=comm,
     mesh=mesh,
     config={"solver": "GMRES", "communicator": "MPI_DIRECT"},
 )
 
 x, info = solver(b)
 ```
+
+The sharding helpers use `MPI.COMM_WORLD` by default. Pass `comm=` explicitly
+when using an MPI subcommunicator.
 
 For a coupled block system, pass `block_dim=k` to `make_sharded_solver`. The
 matrix and vectors retain their ordinary scalar CSR/vector representation;

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -134,25 +134,25 @@ import jax.numpy as jnp
 
 batched_b = jnp.stack((b1, b2))
 batched_x, batched_info = jax.vmap(
-    lambda rhs: solver(rhs, A_data=A.data)
+    lambda rhs: solver(rhs, A=A.data)
 )(batched_b)
 ```
 
 The underlying AmgX solves use JAX-AMG's sequential FFI batching path.
 
-Pass `A.data` to the solve when differentiating matrix values. Enter the mesh
-context for an outer transformation:
+`A=` accepts either this rank's operator or matrix (next section) or the
+packed global values `A.data`. Pass `A.data` to differentiate matrix entries;
+the gradient has the same layout. Enter the mesh context for an outer
+transformation:
 
 ```python
 import jax.numpy as jnp
 
 def loss(A_data, rhs):
-    x, _ = solver(rhs, A_data=A_data)
+    x, _ = solver(rhs, A=A_data)
     return jnp.sum(x**2)
 
-compiled_solver = jax.jit(
-    lambda A_data, rhs: solver(rhs, A_data=A_data)
-)
+compiled_solver = jax.jit(lambda A_data, rhs: solver(rhs, A=A_data))
 compiled_gradient = jax.jit(jax.grad(loss, argnums=(0, 1)))
 
 with jax.set_mesh(b.sharding.mesh):
@@ -162,10 +162,46 @@ with jax.set_mesh(b.sharding.mesh):
 grad_A_local = A.local_matrix(grad_A_data)
 ```
 
-A direct `solver(b)` call can use the matrix's cached values. Pass `A.data`
-explicitly under an enclosing JAX transformation, including RHS-only
-differentiation. This keeps the distributed matrix values as a dynamic operand
-instead of embedding a full local value buffer in the compiled executable.
+A direct `solver(b)` call uses the cached values. Under a JAX transformation
+`A` is required, even for RHS-only differentiation, so the values stay a
+dynamic operand rather than a constant baked into the executable.
+
+## Differentiating Operator Parameters
+
+When the values depend on parameters, pass this rank's operator or matrix as
+`A=`, exactly as `solve(A, b)` takes it in the MPI interface. The solver
+materializes it with the sparsity fixed at construction and differentiates
+through it:
+
+```python
+from jaxamg.matrices import poisson_operator
+from jaxamg.mpi_utils import partition_operator
+
+def local_operator(skew):
+    operator, _, _ = partition_operator(
+        poisson_operator(skew), n_global, rank, nranks
+    )
+    return operator
+
+coloring = jaxamg.cache_coloring(local_operator(0.0), shape=(n_local, n_global))
+A = jaxamg.make_sharded_matrix(
+    jaxamg.with_cache(local_operator(0.0), coloring=coloring), b
+)
+solver = jaxamg.make_sharded_solver(A, b)
+
+def loss(skew, rhs, x_target):
+    x, _ = solver(rhs, A=local_operator(skew))
+    return jnp.sum((x - x_target) ** 2) / n_global
+
+with jax.set_mesh(A.mesh):
+    value, grad_skew = jax.value_and_grad(loss)(skew, b, x_target)
+```
+
+Per rank this is the MPI interface's own materialization, so memory and
+compute per solve match `solve(..., comm=...)`. Parameters the operator closes
+over must be identical on every rank; their gradients are summed across ranks.
+A closed-over value sharded across ranks is rejected under `jax.jit` — pass
+rank-local matrix values as `A.data` instead.
 
 Compilation is entirely the caller's decision: the solver adds no `jax.jit` of
 its own. `jax.value_and_grad(loss)` runs the whole pipeline eagerly, while
@@ -189,11 +225,11 @@ OMPI_MCA_opal_cuda_support=true \
 mpirun -n 2 python demo/sharded_poisson_operator_optimization.py
 ```
 
-The second example recovers an operator parameter by gradient descent, the
-sharded counterpart of `demo/mpi_poisson_operator_optimization.py`. Because the
-loss is a reduction over global arrays, JAX emits the cross-rank collectives and
-the gradient it returns is already the complete global gradient, so no
-`comm.allreduce` of losses or gradients is needed.
+The second example is the sharded counterpart of
+`demo/mpi_poisson_operator_optimization.py`: it recovers an operator parameter
+by gradient descent through `solver(rhs, A=...)`. The loss is a reduction over
+global arrays, so its gradient is already global and no `comm.allreduce` is
+needed.
 
 Matrix gradients use a sparse all-to-all halo exchange: `jax.lax.all_to_all`
 inside a compiled program, and the MPI interface's mpi4jax exchange for

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -46,6 +46,27 @@ Launchers recognized directly by JAX may also work with an argument-free
 `jax.distributed.initialize()`. The explicit `mpi4py` method also covers MPI
 environments whose launcher variables JAX does not recognize automatically.
 
+## Required XLA Flag for Multi-Process Jobs
+
+A sharded solver compiles each rank's local CSR structure and communication
+plans into that process's program as constants, so the processes compile
+programs that are not identical. XLA's cross-process *sharded autotuning*
+assumes identical programs and deadlocks during compilation as soon as such a
+program also contains an automatically partitioned collective. A loss that
+reduces the solution across ranks inside `jax.jit`, such as
+`jnp.sum(x**2)`, produces exactly that collective, so disable the autotuning:
+
+```bash
+XLA_FLAGS=--xla_gpu_shard_autotuning=false \
+  mpirun -n 2 python your_script.py
+```
+
+The flag is read when JAX initializes its backend, so set it in the environment
+or via `os.environ` before the first JAX device call. Without it, a compiled
+loss that reduces across ranks hangs in compilation rather than failing;
+uncompiled calls and `jax.jit(jax.grad(...))` are unaffected, because neither
+emits that collective.
+
 ## Sharded Solve
 
 Build a global RHS from each process's local partition, then create the solver
@@ -141,24 +162,44 @@ with jax.set_mesh(b.sharding.mesh):
 grad_A_local = A.local_matrix(grad_A_data)
 ```
 
-The solver is compiled internally, so a direct `solver(b)` call can use the
-matrix's cached values. Pass `A.data` explicitly under an enclosing JAX
-transformation, including RHS-only differentiation. This keeps the distributed
-matrix values as a dynamic operand instead of embedding a full local value
-buffer in the compiled executable.
+A direct `solver(b)` call can use the matrix's cached values. Pass `A.data`
+explicitly under an enclosing JAX transformation, including RHS-only
+differentiation. This keeps the distributed matrix values as a dynamic operand
+instead of embedding a full local value buffer in the compiled executable.
 
-Run the complete single-node example with:
+Compilation is entirely the caller's decision: the solver adds no `jax.jit` of
+its own. `jax.value_and_grad(loss)` runs the whole pipeline eagerly, while
+`jax.jit(jax.value_and_grad(loss))` compiles it as one program. Both give the
+same results and both match the MPI interface's speed: a compiled caller runs
+the solver's `shard_map` regions inside its one program, while an untransformed
+call executes the rank-local pipeline directly on this process's shard — the
+same code path as `solve(..., comm=...)` — and reassembles the global arrays,
+instead of paying for JAX's much slower per-primitive eager `shard_map`
+execution.
+
+Run the complete single-node examples with:
 
 ```bash
 CUDA_VISIBLE_DEVICES=0,1 \
 OMPI_MCA_opal_cuda_support=true \
 mpirun -n 2 python demo/sharded_poisson_problem.py
+
+CUDA_VISIBLE_DEVICES=0,1 \
+OMPI_MCA_opal_cuda_support=true \
+mpirun -n 2 python demo/sharded_poisson_operator_optimization.py
 ```
 
-`MPI4JAX_USE_CUDA_MPI` remains relevant to the existing MPI autodiff path but
-is not required for the sharding path. Matrix gradients use a sparse JAX
-all-to-all halo exchange. For a nonsymmetric matrix, the transpose structure
-and a sparse value-exchange plan are cached during solver creation. Only
-off-rank transpose values are exchanged, once per backward pass, rather than
-replicating all matrix values on every GPU. The forward and adjoint solves are
-both performed by AmgX.
+The second example recovers an operator parameter by gradient descent, the
+sharded counterpart of `demo/mpi_poisson_operator_optimization.py`. Because the
+loss is a reduction over global arrays, JAX emits the cross-rank collectives and
+the gradient it returns is already the complete global gradient, so no
+`comm.allreduce` of losses or gradients is needed.
+
+Matrix gradients use a sparse all-to-all halo exchange: `jax.lax.all_to_all`
+inside a compiled program, and the MPI interface's mpi4jax exchange for
+untransformed calls — so `MPI4JAX_USE_CUDA_MPI` applies to eager sharded
+gradients exactly as it does to the MPI autodiff path. For a nonsymmetric
+matrix, the transpose structure and a sparse value-exchange plan are cached
+during solver creation. Only off-rank transpose values are exchanged, once per
+backward pass, rather than replicating all matrix values on every GPU. The
+forward and adjoint solves are both performed by AmgX.

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -53,11 +53,10 @@ Build a global RHS from each process's local partition, then create the solver
 once and reuse it:
 
 ```python
-import numpy as np
 import jaxamg
 
 b = jaxamg.make_sharded_vector(
-    np.asarray(b_local),
+    b_local,
     global_size=n_global,
 )
 
@@ -79,6 +78,11 @@ the matrix and solver otherwise infer the mesh from `b`.
 globally sharded values as `A.data`; it does not replicate the global matrix.
 The original local-matrix form remains supported by
 `make_sharded_solver(A_local, b)` as a convenience.
+
+When `b_local` or the local matrix values are JAX device arrays, vector and
+matrix packing stays on device. NumPy inputs are transferred to the target GPU
+once during construction. Solver setup inspects only static CSR structure on
+the host to build MPI partition, transpose, and halo metadata.
 
 For a coupled block system, pass `block_dim=k` to `make_sharded_solver`. The
 matrix and vectors retain their ordinary scalar CSR/vector representation;

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -11,7 +11,13 @@ from .jaxamg import (
     solve,
 )
 from .preconditioners import make_lineax_preconditioner, make_preconditioner
-from .sharding import make_sharded_solver, make_sharded_vector, solve_sharded
+from .sharding import (
+    ShardedMatrix,
+    make_sharded_matrix,
+    make_sharded_solver,
+    make_sharded_vector,
+    solve_sharded,
+)
 from .sparsity import cache_coloring
 
 __all__ = [
@@ -20,6 +26,8 @@ __all__ = [
     "with_cache",
     "cache_coloring",
     "cache_mpi_metadata",
+    "ShardedMatrix",
+    "make_sharded_matrix",
     "make_sharded_solver",
     "make_sharded_vector",
     "solve_sharded",

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -11,7 +11,7 @@ from .jaxamg import (
     solve,
 )
 from .preconditioners import make_lineax_preconditioner, make_preconditioner
-from .sharding import make_sharded_solver, solve_sharded
+from .sharding import make_sharded_solver, make_sharded_vector, solve_sharded
 from .sparsity import cache_coloring
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "cache_coloring",
     "cache_mpi_metadata",
     "make_sharded_solver",
+    "make_sharded_vector",
     "solve_sharded",
     "AMGXStatus",
     "make_preconditioner",

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -13,6 +13,7 @@ from .jaxamg import (
 from .preconditioners import make_lineax_preconditioner, make_preconditioner
 from .sharding import (
     ShardedMatrix,
+    ShardedSolve,
     make_sharded_matrix,
     make_sharded_solver,
     make_sharded_vector,
@@ -26,6 +27,7 @@ __all__ = [
     "cache_coloring",
     "cache_mpi_metadata",
     "ShardedMatrix",
+    "ShardedSolve",
     "make_sharded_matrix",
     "make_sharded_solver",
     "make_sharded_vector",

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -11,6 +11,7 @@ from .jaxamg import (
     solve,
 )
 from .preconditioners import make_lineax_preconditioner, make_preconditioner
+from .sharding import make_sharded_solver, solve_sharded
 from .sparsity import cache_coloring
 
 __all__ = [
@@ -19,6 +20,8 @@ __all__ = [
     "with_cache",
     "cache_coloring",
     "cache_mpi_metadata",
+    "make_sharded_solver",
+    "solve_sharded",
     "AMGXStatus",
     "make_preconditioner",
     "make_lineax_preconditioner",

--- a/jaxamg/__init__.py
+++ b/jaxamg/__init__.py
@@ -16,7 +16,6 @@ from .sharding import (
     make_sharded_matrix,
     make_sharded_solver,
     make_sharded_vector,
-    solve_sharded,
 )
 from .sparsity import cache_coloring
 
@@ -30,7 +29,6 @@ __all__ = [
     "make_sharded_matrix",
     "make_sharded_solver",
     "make_sharded_vector",
-    "solve_sharded",
     "AMGXStatus",
     "make_preconditioner",
     "make_lineax_preconditioner",

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -32,6 +32,7 @@ def _build_mpi_cache(
     save_stats: bool = False,
     block_dim: int = 1,
     lrank: int | None = None,
+    device: jax.Device | None = None,
 ) -> dict[str, Any]:
     """Assemble MPI metadata after structure-dependent collectives are done."""
     from .mpi_utils import register_comm
@@ -44,8 +45,9 @@ def _build_mpi_cache(
     # These plans are solve operands, not setup metadata. Keep one device copy
     # in the cache so repeated eager solves do not re-transfer every routing
     # array from the host. The original NumPy buffers can then be released.
-    local_devices = jax.local_devices()
-    device = local_devices[lrank % len(local_devices)]
+    if device is None:
+        local_devices = jax.local_devices()
+        device = local_devices[lrank % len(local_devices)]
     halo_plan = halo_plan._replace(
         col_to_combined=jax.device_put(halo_plan.col_to_combined, device),
         send_ids_2d=jax.device_put(halo_plan.send_ids_2d, device),
@@ -223,8 +225,13 @@ def cache_mpi_metadata(
 
     # Compute max_nnz across all ranks, and capture this rank's global column
     # indices (needed for nnz_out, the transpose output sizing).
-    # For sparse matrices (BCSR), get nnz/indices from the arrays directly.
-    if all(hasattr(A, field) for field in ("data", "indices", "indptr")):
+    # For CSR-like matrices (BCSR, SciPy CSR), read the arrays directly. SciPy
+    # CSC/BSR also expose these attributes but with different semantics, so
+    # they take the conversion path below instead.
+    if (
+        all(hasattr(A, field) for field in ("data", "indices", "indptr"))
+        and getattr(A, "format", "csr") == "csr"
+    ):
         local_nnz = len(A.data)
         local_col_indices = np.asarray(A.indices)
         local_indptr = np.asarray(A.indptr)

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -33,8 +33,16 @@ def _build_mpi_cache(
     block_dim: int = 1,
     lrank: int | None = None,
     device: jax.Device | None = None,
+    commit: bool = True,
 ) -> dict[str, Any]:
-    """Assemble MPI metadata after structure-dependent collectives are done."""
+    """Assemble MPI metadata after structure-dependent collectives are done.
+
+    ``commit`` controls device placement of the routing arrays. The default pins
+    them to one device, which is what repeated eager MPI solves want. A caller
+    that captures them in a ``jax.shard_map`` spanning the whole mesh must pass
+    ``commit=False``: an array committed to a single device cannot be captured
+    there, while an uncommitted one can.
+    """
     from .mpi_utils import register_comm
 
     rank = comm.Get_rank()
@@ -48,29 +56,27 @@ def _build_mpi_cache(
     if device is None:
         local_devices = jax.local_devices()
         device = local_devices[lrank % len(local_devices)]
+
+    def place(array):
+        return jax.device_put(array, device) if commit else jnp.asarray(array)
+
     halo_plan = halo_plan._replace(
-        col_to_combined=jax.device_put(halo_plan.col_to_combined, device),
-        send_ids_2d=jax.device_put(halo_plan.send_ids_2d, device),
-        recv_ghost_slot_2d=jax.device_put(halo_plan.recv_ghost_slot_2d, device),
+        col_to_combined=place(halo_plan.col_to_combined),
+        send_ids_2d=place(halo_plan.send_ids_2d),
+        recv_ghost_slot_2d=place(halo_plan.recv_ghost_slot_2d),
     )
     if transpose_plan is not None:
         with temp_enable_x64():
             transpose_plan = transpose_plan._replace(
-                indices=jax.device_put(transpose_plan.indices, device),
-                indptr=jax.device_put(transpose_plan.indptr, device),
-                local_source_ids=jax.device_put(
-                    transpose_plan.local_source_ids, device
-                ),
-                local_target_ids=jax.device_put(
-                    transpose_plan.local_target_ids, device
-                ),
-                send_ids_2d=jax.device_put(transpose_plan.send_ids_2d, device),
-                recv_target_ids_2d=jax.device_put(
-                    transpose_plan.recv_target_ids_2d, device
-                ),
+                indices=place(transpose_plan.indices),
+                indptr=place(transpose_plan.indptr),
+                local_source_ids=place(transpose_plan.local_source_ids),
+                local_target_ids=place(transpose_plan.local_target_ids),
+                send_ids_2d=place(transpose_plan.send_ids_2d),
+                recv_target_ids_2d=place(transpose_plan.recv_target_ids_2d),
             )
     if row_indices is not None:
-        row_indices = jax.device_put(row_indices, device)
+        row_indices = place(row_indices)
 
     config_str = amgx_config.prepare_config(
         config, save_stats=save_stats, mpi=True, block_dim=block_dim

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -15,7 +15,7 @@ from .utils import *
 if TYPE_CHECKING:
     from mpi4py.MPI import Comm
 
-    from .mpi_utils import HaloPlan
+    from .mpi_utils import HaloPlan, TransposePlan
 
 
 def _build_mpi_cache(
@@ -27,6 +27,8 @@ def _build_mpi_cache(
     nnz_out: int | None,
     halo_plan: "HaloPlan",
     *,
+    transpose_plan: "TransposePlan | None" = None,
+    row_indices: np.ndarray | jax.Array | None = None,
     save_stats: bool = False,
     block_dim: int = 1,
     lrank: int | None = None,
@@ -38,6 +40,35 @@ def _build_mpi_cache(
     comm_ptr = register_comm(comm)
     if lrank is None:
         lrank = rank % jax.device_count()
+
+    # These plans are solve operands, not setup metadata. Keep one device copy
+    # in the cache so repeated eager solves do not re-transfer every routing
+    # array from the host. The original NumPy buffers can then be released.
+    local_devices = jax.local_devices()
+    device = local_devices[lrank % len(local_devices)]
+    halo_plan = halo_plan._replace(
+        col_to_combined=jax.device_put(halo_plan.col_to_combined, device),
+        send_ids_2d=jax.device_put(halo_plan.send_ids_2d, device),
+        recv_ghost_slot_2d=jax.device_put(halo_plan.recv_ghost_slot_2d, device),
+    )
+    if transpose_plan is not None:
+        with temp_enable_x64():
+            transpose_plan = transpose_plan._replace(
+                indices=jax.device_put(transpose_plan.indices, device),
+                indptr=jax.device_put(transpose_plan.indptr, device),
+                local_source_ids=jax.device_put(
+                    transpose_plan.local_source_ids, device
+                ),
+                local_target_ids=jax.device_put(
+                    transpose_plan.local_target_ids, device
+                ),
+                send_ids_2d=jax.device_put(transpose_plan.send_ids_2d, device),
+                recv_target_ids_2d=jax.device_put(
+                    transpose_plan.recv_target_ids_2d, device
+                ),
+            )
+    if row_indices is not None:
+        row_indices = jax.device_put(row_indices, device)
 
     config_str = amgx_config.prepare_config(
         config, save_stats=save_stats, mpi=True, block_dim=block_dim
@@ -51,6 +82,8 @@ def _build_mpi_cache(
         "max_nnz": max_nnz,
         "nnz_out": nnz_out,
         "halo_plan": halo_plan,
+        "transpose_plan": transpose_plan,
+        "row_indices": row_indices,
         "block_dim": block_dim,
     }
 
@@ -167,6 +200,9 @@ def cache_mpi_metadata(
           `None` when `is_symmetric` is True
         - `halo_plan`: Backward-pass halo-exchange plan for the gradient w.r.t.
           A (fetches only referenced remote solution entries)
+        - `transpose_plan`: Fixed transpose structure and value routing for a
+          nonsymmetric matrix, or `None` when `is_symmetric` is True
+        - `row_indices`: Local CSR row index for every matrix nonzero
     """
     row_start, row_end = partition_info
     n_local = row_end - row_start
@@ -183,14 +219,15 @@ def cache_mpi_metadata(
     # Compute MPI communication metadata
     all_sizes = comm.allgather(n_local)
 
-    from .mpi_utils import build_halo_plan, local_transpose_nnz
+    from .mpi_utils import build_halo_plan, build_transpose_plan
 
     # Compute max_nnz across all ranks, and capture this rank's global column
     # indices (needed for nnz_out, the transpose output sizing).
     # For sparse matrices (BCSR), get nnz/indices from the arrays directly.
-    if hasattr(A, "data"):
+    if all(hasattr(A, field) for field in ("data", "indices", "indptr")):
         local_nnz = len(A.data)
         local_col_indices = np.asarray(A.indices)
+        local_indptr = np.asarray(A.indptr)
     elif callable(A):
         # For distributed operators, we need to use global size for proper materialization
         # The operator shape is (n_local, n_global): takes global vector, returns local portion
@@ -211,11 +248,16 @@ def cache_mpi_metadata(
 
         local_nnz = len(A_materialized.data)
         local_col_indices = np.asarray(A_materialized.indices)
+        local_indptr = np.asarray(A_materialized.indptr)
     else:
-        raise TypeError(
-            f"Matrix A must be BCSR, BCOO, SciPy sparse, dense array, or callable. "
-            f"Got {type(A).__name__}."
+        A_materialized = to_bcsr_matrix(
+            A,
+            b=jnp.empty(n_local, dtype=get_preferred_dtype(A, None)),
+            use_int64_indices=True,
         )
+        local_nnz = len(A_materialized.data)
+        local_col_indices = np.asarray(A_materialized.indices)
+        local_indptr = np.asarray(A_materialized.indptr)
 
     all_nnz = comm.allgather(local_nnz)
     max_nnz = max(all_nnz)
@@ -226,8 +268,16 @@ def cache_mpi_metadata(
     # of non-symmetric solves). Symmetric solves never transpose, so skip it.
     if is_symmetric:
         nnz_out = None
+        transpose_plan = None
     else:
-        nnz_out = local_transpose_nnz(local_col_indices, recvcounts_tuple, comm)
+        transpose_plan = build_transpose_plan(
+            local_col_indices,
+            local_indptr,
+            recvcounts_tuple,
+            partition_info,
+            comm,
+        )
+        nnz_out = transpose_plan.nnz
 
     # Backward-pass halo plan: fetches only the remote solution entries this
     # rank's rows reference for the gradient w.r.t. A, instead of gathering the
@@ -235,6 +285,9 @@ def cache_mpi_metadata(
     halo_plan = build_halo_plan(
         local_col_indices, recvcounts_tuple, partition_info, comm
     )
+    row_indices = np.repeat(
+        np.arange(n_local, dtype=np.int32), np.diff(local_indptr)
+    ).astype(np.int32)
 
     return _build_mpi_cache(
         config,
@@ -244,6 +297,8 @@ def cache_mpi_metadata(
         max_nnz,
         nnz_out,
         halo_plan,
+        transpose_plan=transpose_plan,
+        row_indices=row_indices,
         save_stats=save_stats,
         block_dim=block_dim,
     )

--- a/jaxamg/cache.py
+++ b/jaxamg/cache.py
@@ -15,6 +15,45 @@ from .utils import *
 if TYPE_CHECKING:
     from mpi4py.MPI import Comm
 
+    from .mpi_utils import HaloPlan
+
+
+def _build_mpi_cache(
+    config: dict,
+    comm: "Comm",
+    nglobal: int,
+    recvcounts_tuple: tuple[int, ...],
+    max_nnz: int,
+    nnz_out: int | None,
+    halo_plan: "HaloPlan",
+    *,
+    save_stats: bool = False,
+    block_dim: int = 1,
+    lrank: int | None = None,
+) -> dict[str, Any]:
+    """Assemble MPI metadata after structure-dependent collectives are done."""
+    from .mpi_utils import register_comm
+
+    rank = comm.Get_rank()
+    comm_ptr = register_comm(comm)
+    if lrank is None:
+        lrank = rank % jax.device_count()
+
+    config_str = amgx_config.prepare_config(
+        config, save_stats=save_stats, mpi=True, block_dim=block_dim
+    )
+    return {
+        "recvcounts_tuple": recvcounts_tuple,
+        "comm_ptr": comm_ptr,
+        "lrank": lrank,
+        "nglobal": nglobal,
+        "config_str": config_str,
+        "max_nnz": max_nnz,
+        "nnz_out": nnz_out,
+        "halo_plan": halo_plan,
+        "block_dim": block_dim,
+    }
+
 
 def with_cache(
     A: MatrixOrOperator,
@@ -129,7 +168,6 @@ def cache_mpi_metadata(
         - `halo_plan`: Backward-pass halo-exchange plan for the gradient w.r.t.
           A (fetches only referenced remote solution entries)
     """
-    rank = comm.Get_rank()
     row_start, row_end = partition_info
     n_local = row_end - row_start
 
@@ -145,18 +183,7 @@ def cache_mpi_metadata(
     # Compute MPI communication metadata
     all_sizes = comm.allgather(n_local)
 
-    from .mpi_utils import build_halo_plan, local_transpose_nnz, register_comm
-
-    # Register the communicator so the cached solver's backward pass can recover
-    # it for its collectives; comm_ptr is its address.
-    comm_ptr = register_comm(comm)
-    gpu_count = jax.device_count()
-    lrank = rank % gpu_count
-
-    # Prepare config string
-    config_str = amgx_config.prepare_config(
-        config, save_stats=save_stats, mpi=True, block_dim=block_dim
-    )
+    from .mpi_utils import build_halo_plan, local_transpose_nnz
 
     # Compute max_nnz across all ranks, and capture this rank's global column
     # indices (needed for nnz_out, the transpose output sizing).
@@ -209,16 +236,14 @@ def cache_mpi_metadata(
         local_col_indices, recvcounts_tuple, partition_info, comm
     )
 
-    cache_dict = {
-        "recvcounts_tuple": recvcounts_tuple,
-        "comm_ptr": comm_ptr,
-        "lrank": lrank,
-        "nglobal": nglobal,
-        "config_str": config_str,
-        "max_nnz": max_nnz,
-        "nnz_out": nnz_out,
-        "halo_plan": halo_plan,
-        "block_dim": block_dim,
-    }
-
-    return cache_dict
+    return _build_mpi_cache(
+        config,
+        comm,
+        nglobal,
+        recvcounts_tuple,
+        max_nnz,
+        nnz_out,
+        halo_plan,
+        save_stats=save_stats,
+        block_dim=block_dim,
+    )

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -854,7 +854,9 @@ def solve(
         # initial residual); trim the NaN padding outside a trace.
         "residual_history": info[3 : 4 + int(info[0])],
     }
-    if save_stats_file is not None:
+    # os.devnull enables stats capture in the FFI without writing a file; the
+    # sharding interface uses it and reads the captured stats afterwards.
+    if save_stats_file is not None and str(save_stats_file) != os.devnull:
         _capture_and_save_stats(save_stats_file, comm=comm, mpi_cache=mpi_cache)
     return x, info_dict
 

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -906,9 +906,13 @@ def solve(
     # Null-space projections as JAX ops around the primitive; their
     # transposes are the adjoint projections (see nullspace.py).
     n_local = A_csr.shape[0]
-    N = as_nullspace_basis(nullspace, n_local, target_dtype, "nullspace")
+    if comm_obj is None:
+        n_columns = None
+    else:
+        n_columns = mpi_cache["nglobal"] if mpi_cache is not None else nglobal
+    N = as_nullspace_basis(nullspace, n_local, target_dtype, "nullspace", n_columns)
     M = as_nullspace_basis(
-        transpose_nullspace, n_local, target_dtype, "transpose_nullspace"
+        transpose_nullspace, n_local, target_dtype, "transpose_nullspace", n_columns
     )
     if N is not None:
         validate_basis(N, "nullspace", comm_obj)

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -15,10 +15,11 @@ from jax.typing import ArrayLike
 
 from . import config as amgx_config
 from .mpi_utils import (
-    _mpi4jax_alltoallv_transpose,
+    TransposePlan,
     _mpi4jax_halo_gather,
+    _mpi4jax_transpose_values,
     build_halo_plan,
-    local_transpose_nnz,
+    build_transpose_plan,
     register_comm,
     resolve_comm,
 )
@@ -310,6 +311,26 @@ def _get_solver_primitive(
     return solve
 
 
+def _transpose_plan_operands(
+    A: jsp.BCSR, plan: TransposePlan | None
+) -> tuple[jax.Array, ...]:
+    """Convert transpose metadata to JAX operands."""
+    if plan is None:
+        empty = jnp.empty(0, dtype=jnp.int32)
+        return A.indices, A.indptr, empty, empty, empty, empty
+
+    with temp_enable_x64():
+        indices = jnp.asarray(plan.indices, dtype=jnp.int64)
+    return (
+        indices,
+        jnp.asarray(plan.indptr),
+        jnp.asarray(plan.local_source_ids),
+        jnp.asarray(plan.local_target_ids),
+        jnp.asarray(plan.send_ids_2d),
+        jnp.asarray(plan.recv_target_ids_2d),
+    )
+
+
 @functools.lru_cache(maxsize=32)
 def _get_solver_primitive_mpi(
     config_str: str,
@@ -317,9 +338,7 @@ def _get_solver_primitive_mpi(
     comm_ptr: int,
     lrank: int,
     is_symmetric: bool = False,
-    recvcounts_tuple: tuple[int, ...] | None = None,
-    max_nnz: int | None = None,
-    nnz_out: int | None = None,
+    transpose_nnz: int = 0,
     n_ghost: int = 0,
     return_stats: bool = False,
     reuse_setup: bool = False,
@@ -336,12 +355,6 @@ def _get_solver_primitive_mpi(
     - MPI4JAX_USE_CUDA_MPI=1: Use GPU-aware MPI (requires CUDA-aware MPI library)
     - MPI4JAX_USE_CUDA_MPI=0: Use CPU staging (copies GPU<->CPU for MPI)
 
-    Args:
-        max_nnz: Maximum local nnz of A across ranks, for the transpose send
-                 buffers. Required for non-symmetric matrices (backward pass).
-        nnz_out: This rank's local nnz of A^T, for the transpose output buffers.
-                 Differs from the local nnz of A for structurally nonsymmetric
-                 patterns; required for non-symmetric matrices.
     """
 
     # Backward-pass collectives run on the user's communicator (recovered from
@@ -358,9 +371,8 @@ def _get_solver_primitive_mpi(
         A: jsp.BCSR,
         b: jax.Array,
         x0: jax.Array,
-        col_to_combined: jax.Array,
-        send_ids: jax.Array,
-        recv_ghost_slot: jax.Array,
+        halo: tuple[jax.Array, ...],
+        transpose: tuple[jax.Array, ...],
     ) -> tuple[jax.Array, jax.Array]:
         nglobal_arr = jnp.array([nglobal], dtype=jnp.int32)
 
@@ -394,20 +406,23 @@ def _get_solver_primitive_mpi(
 
         return x, info
 
-    def fwd(A, b, x0, col_to_combined, send_ids, recv_ghost_slot):
-        out = solve(A, b, x0, col_to_combined, send_ids, recv_ghost_slot)
+    def fwd(A, b, x0, halo, transpose):
+        out = solve(A, b, x0, halo, transpose)
         x, info = out
-        return out, (
-            A,
-            x,
-            col_to_combined,
-            send_ids,
-            recv_ghost_slot,
-        )
+        return out, (A, x, halo, transpose)
 
     def bwd(residuals, g):
         g_x, _ = g
-        A, x, col_to_combined, send_ids, recv_ghost_slot = residuals
+        A, x, halo, transpose = residuals
+        col_to_combined, send_ids, recv_ghost_slot, row_indices = halo
+        (
+            transpose_indices,
+            transpose_indptr,
+            local_source_ids,
+            local_target_ids,
+            transpose_send_ids,
+            recv_target_ids,
+        ) = transpose
 
         # Backward solves always start from zero: x0 shifts only the forward
         # iteration, never the solution, so the adjoint ignores it (and skips
@@ -418,9 +433,7 @@ def _get_solver_primitive_mpi(
             comm_ptr,
             lrank,
             is_symmetric=is_symmetric,
-            recvcounts_tuple=recvcounts_tuple,
-            max_nnz=max_nnz,
-            nnz_out=nnz_out,
+            transpose_nnz=len(A.data),
             n_ghost=n_ghost,
             return_stats=return_stats,
             reuse_setup=reuse_setup,
@@ -430,35 +443,42 @@ def _get_solver_primitive_mpi(
         # Backward solve: A^T @ adj_b = g_x
         if is_symmetric:
             # Symmetric: skip the distributed transpose.
-            adj_b, _ = adj_solver(
-                A, g_x, g_x, col_to_combined, send_ids, recv_ghost_slot
-            )
+            adj_b, _ = adj_solver(A, g_x, g_x, halo, transpose)
         else:
             # Distributed transpose via mpi4jax (JIT-compatible, GPU-direct when
             # MPI4JAX_USE_CUDA_MPI=1).
-            if recvcounts_tuple is None or max_nnz is None or nnz_out is None:
+            if transpose_nnz == 0:
                 raise ValueError(
-                    "recvcounts_tuple, max_nnz, and nnz_out are required for the "
-                    "distributed transpose of non-symmetric matrices. Ensure they "
-                    "are computed when creating the solver (via cache_mpi_metadata "
-                    "or dynamic computation)."
+                    "a transpose plan is required for nonsymmetric MPI gradients"
                 )
             # Order the transpose after the forward solve (it otherwise reads
             # only A); without this XLA may interleave their MPI collectives in
             # a rank-inconsistent order and deadlock.
-            a_data, a_indices, a_indptr, _ = jax.lax.optimization_barrier(
-                (A.data, A.indices, A.indptr, x)
-            )
-            at_data, at_indices, at_indptr = _mpi4jax_alltoallv_transpose(
-                a_data, a_indices, a_indptr, recvcounts_tuple, comm, max_nnz, nnz_out
+            a_data, _ = jax.lax.optimization_barrier((A.data, x))
+            at_data = _mpi4jax_transpose_values(
+                a_data,
+                local_source_ids,
+                local_target_ids,
+                transpose_send_ids,
+                recv_target_ids,
+                transpose_nnz,
+                comm,
             )
 
             # Reconstruct BCSR for A^T
-            A_T = jsp.BCSR((at_data, at_indices, at_indptr), shape=A.shape)
-
-            adj_b, _ = adj_solver(
-                A_T, g_x, g_x, col_to_combined, send_ids, recv_ghost_slot
+            A_T = jsp.BCSR(
+                (at_data, transpose_indices, transpose_indptr), shape=A.shape
             )
+
+            reverse_transpose = (
+                A.indices,
+                A.indptr,
+                local_target_ids,
+                local_source_ids,
+                recv_target_ids,
+                transpose_send_ids,
+            )
+            adj_b, _ = adj_solver(A_T, g_x, g_x, halo, reverse_transpose)
 
         # Gradient w.r.t. A: ∂L/∂A_ij = -adj_b[i] * x[j]. Fetch only the solution
         # entries this rank's rows reference via the halo exchange, ordered after
@@ -469,18 +489,17 @@ def _get_solver_primitive_mpi(
             x_bar, send_ids, recv_ghost_slot, n_ghost, comm
         )
 
-        n_local = A.shape[0]
-        row_lengths = A.indptr[1:] - A.indptr[:-1]
-        row_indices = jnp.repeat(
-            jnp.arange(n_local, dtype=jnp.int32),
-            row_lengths,
-            total_repeat_length=len(A.data),
-        )
         grad_values = -adj_b[row_indices] * x_combined[col_to_combined]
         grad_A = jsp.BCSR((grad_values, A.indices, A.indptr), shape=A.shape)
 
         # The exact solution does not depend on the initial guess.
-        return grad_A, adj_b, jnp.zeros_like(adj_b), None, None, None
+        return (
+            grad_A,
+            adj_b,
+            jnp.zeros_like(adj_b),
+            (None, None, None, None),
+            (None, None, None, None, None, None),
+        )
 
     solve.defvjp(fwd, bwd)
     return solve
@@ -644,19 +663,19 @@ def solve(
 
         if mpi_cache is not None:
             # Use pre-cached MPI metadata
-            recvcounts_tuple = mpi_cache["recvcounts_tuple"]
-            max_nnz = mpi_cache["max_nnz"]  # Always present in cache
-            nnz_out = mpi_cache["nnz_out"]  # None when cached as symmetric
             halo_plan = mpi_cache["halo_plan"]
+            row_indices = mpi_cache.get("row_indices")
+            if row_indices is None:
+                row_indices = np.empty(0, dtype=np.int32)
+            transpose_plan = mpi_cache.get("transpose_plan")
+            transpose_operands = _transpose_plan_operands(A_csr, transpose_plan)
             solver = _get_solver_primitive_mpi(
                 mpi_cache["config_str"],
                 mpi_cache["nglobal"],
                 mpi_cache["comm_ptr"],
                 mpi_cache["lrank"],
                 is_symmetric=is_symmetric,
-                recvcounts_tuple=recvcounts_tuple,
-                max_nnz=max_nnz,
-                nnz_out=nnz_out,
+                transpose_nnz=0 if transpose_plan is None else transpose_plan.nnz,
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
                 reuse_setup=reuse_setup,
@@ -669,9 +688,13 @@ def solve(
                 A_csr,
                 b,
                 x0_arg,
-                jnp.asarray(halo_plan.col_to_combined),
-                jnp.asarray(halo_plan.send_ids_2d),
-                jnp.asarray(halo_plan.recv_ghost_slot_2d),
+                (
+                    jnp.asarray(halo_plan.col_to_combined),
+                    jnp.asarray(halo_plan.send_ids_2d),
+                    jnp.asarray(halo_plan.recv_ghost_slot_2d),
+                    jnp.asarray(row_indices),
+                ),
+                transpose_operands,
             )
         elif comm is not None:
             # Compute metadata dynamically
@@ -721,11 +744,6 @@ def solve(
                     "partition."
                 )
 
-            # max nnz across ranks (transpose send buffers) + this rank's local
-            # nnz(A^T) (its output buffers).
-            max_nnz = max(comm.allgather(len(A_csr.data)))
-            nnz_out = local_transpose_nnz(A_csr.indices, recvcounts_tuple, comm)
-
             # Halo-exchange plan for the backward pass (fetches only the remote
             # solution entries this rank references, instead of all-gathering).
             halo_plan = build_halo_plan(
@@ -734,6 +752,22 @@ def solve(
                 (row_start, row_start + n_local),
                 comm,
             )
+            transpose_plan = (
+                None
+                if is_symmetric
+                else build_transpose_plan(
+                    A_csr.indices,
+                    A_csr.indptr,
+                    recvcounts_tuple,
+                    derived_partition,
+                    comm,
+                )
+            )
+            transpose_operands = _transpose_plan_operands(A_csr, transpose_plan)
+            row_indices = np.repeat(
+                np.arange(n_local, dtype=np.int32),
+                np.diff(np.asarray(A_csr.indptr)),
+            ).astype(np.int32)
 
             solver = _get_solver_primitive_mpi(
                 config_str,
@@ -741,9 +775,7 @@ def solve(
                 comm_ptr,
                 lrank,
                 is_symmetric=is_symmetric,
-                recvcounts_tuple=recvcounts_tuple,
-                max_nnz=max_nnz,
-                nnz_out=nnz_out,
+                transpose_nnz=0 if transpose_plan is None else transpose_plan.nnz,
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
                 reuse_setup=reuse_setup,
@@ -755,9 +787,13 @@ def solve(
                 A_csr,
                 b,
                 x0_arg,
-                jnp.asarray(halo_plan.col_to_combined),
-                jnp.asarray(halo_plan.send_ids_2d),
-                jnp.asarray(halo_plan.recv_ghost_slot_2d),
+                (
+                    jnp.asarray(halo_plan.col_to_combined),
+                    jnp.asarray(halo_plan.send_ids_2d),
+                    jnp.asarray(halo_plan.recv_ghost_slot_2d),
+                    jnp.asarray(row_indices),
+                ),
+                transpose_operands,
             )
 
     else:

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -666,7 +666,13 @@ def solve(
             halo_plan = mpi_cache["halo_plan"]
             row_indices = mpi_cache.get("row_indices")
             if row_indices is None:
-                row_indices = np.empty(0, dtype=np.int32)
+                # Caches built without row indices (e.g. the sharding-internal
+                # solver caches) fall back to the traceable computation.
+                row_indices = jnp.repeat(
+                    jnp.arange(A_csr.shape[0], dtype=jnp.int32),
+                    A_csr.indptr[1:] - A_csr.indptr[:-1],
+                    total_repeat_length=len(A_csr.data),
+                )
             transpose_plan = mpi_cache.get("transpose_plan")
             transpose_operands = _transpose_plan_operands(A_csr, transpose_plan)
             solver = _get_solver_primitive_mpi(

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -844,8 +844,11 @@ def solve(
         else:
             assert comm is not None
             comm_obj = comm
-        # Global reductions for the null-space projections.
-        reduce_sum = make_mpi_reduce_sum(comm_obj)
+        # Global reductions for the null-space projections; the sharding
+        # interface supplies its own through the cache (psum inside shard_map).
+        reduce_sum = None if mpi_cache is None else mpi_cache.get("reduce_sum")
+        if reduce_sum is None:
+            reduce_sum = make_mpi_reduce_sum(comm_obj)
 
         def run(b_: jax.Array, x0_: jax.Array) -> tuple[jax.Array, jax.Array]:
             return solver(
@@ -914,9 +917,12 @@ def solve(
     M = as_nullspace_basis(
         transpose_nullspace, n_local, target_dtype, "transpose_nullspace", n_columns
     )
-    if N is not None:
+    # The sharding interface validates its bases collectively when the solver
+    # is created and flags the cache, so no host collective runs in its traces.
+    validated = mpi_cache is not None and mpi_cache.get("nullspaces_validated", False)
+    if N is not None and not validated:
         validate_basis(N, "nullspace", comm_obj)
-    if M is not None:
+    if M is not None and not validated:
         validate_basis(M, "transpose_nullspace", comm_obj)
     if M is None and N is not None:
         if is_symmetric:

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -338,7 +338,7 @@ def _get_solver_primitive_mpi(
     comm_ptr: int,
     lrank: int,
     is_symmetric: bool = False,
-    transpose_nnz: int = 0,
+    transpose_nnz: int | None = None,
     n_ghost: int = 0,
     return_stats: bool = False,
     reuse_setup: bool = False,
@@ -447,7 +447,7 @@ def _get_solver_primitive_mpi(
         else:
             # Distributed transpose via mpi4jax (JIT-compatible, GPU-direct when
             # MPI4JAX_USE_CUDA_MPI=1).
-            if transpose_nnz == 0:
+            if transpose_nnz is None:
                 raise ValueError(
                     "a transpose plan is required for nonsymmetric MPI gradients"
                 )
@@ -520,6 +520,23 @@ def _format_and_save_stats(
     format_amgx_stats(stats_str, save_stats_file, rank=rank)
     if rank is None or rank == 0:
         print(f"Stats saved to {save_stats_file}")
+
+
+def _capture_and_save_stats(
+    save_stats_file: str | os.PathLike,
+    comm: "Comm | None" = None,
+    mpi_cache: dict | None = None,
+) -> None:
+    """Read the captured AmgX statistics from the extension and save them."""
+    try:
+        stats_str = _ensure_backend().get_stats_string()
+    except AttributeError:
+        # Older extension without stats capture; nothing to save.
+        stats_str = None
+    if stats_str is not None:
+        _format_and_save_stats(
+            stats_str, save_stats_file, comm=comm, mpi_cache=mpi_cache
+        )
 
 
 def solve(
@@ -681,7 +698,7 @@ def solve(
                 mpi_cache["comm_ptr"],
                 mpi_cache["lrank"],
                 is_symmetric=is_symmetric,
-                transpose_nnz=0 if transpose_plan is None else transpose_plan.nnz,
+                transpose_nnz=None if transpose_plan is None else transpose_plan.nnz,
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
                 reuse_setup=reuse_setup,
@@ -781,7 +798,7 @@ def solve(
                 comm_ptr,
                 lrank,
                 is_symmetric=is_symmetric,
-                transpose_nnz=0 if transpose_plan is None else transpose_plan.nnz,
+                transpose_nnz=None if transpose_plan is None else transpose_plan.nnz,
                 n_ghost=halo_plan.n_ghost,
                 return_stats=1 if save_stats_file else 0,
                 reuse_setup=reuse_setup,
@@ -838,15 +855,7 @@ def solve(
         "residual_history": info[3 : 4 + int(info[0])],
     }
     if save_stats_file is not None:
-        try:
-            stats_str = _ensure_backend().get_stats_string()
-        except AttributeError:
-            # Older extension without stats capture; nothing to save.
-            stats_str = None
-        if stats_str is not None:
-            _format_and_save_stats(
-                stats_str, save_stats_file, comm=comm, mpi_cache=mpi_cache
-            )
+        _capture_and_save_stats(save_stats_file, comm=comm, mpi_cache=mpi_cache)
     return x, info_dict
 
 

--- a/jaxamg/jaxamg.py
+++ b/jaxamg/jaxamg.py
@@ -122,9 +122,11 @@ def _amgx_solve_impl(
     if b.dtype == jnp.float64:
         call_name = _AMGX_CALL_NAME_DOUBLE
 
+    # AmgX mutates cached solver resources, so this call is not functionally pure.
     call = ffi.ffi_call(
         call_name,
         out_spec,
+        has_side_effect=True,
         input_layouts=[None, None, None, None, None],
         output_layouts=None,
         vmap_method="sequential",
@@ -179,9 +181,11 @@ def _amgx_solve_mpi_impl(
     if b.dtype == jnp.float64:
         call_name = _AMGX_CALL_NAME_MPI_DOUBLE
 
+    # MPI solves also perform collectives whose ordering must be preserved.
     call = ffi.ffi_call(
         call_name,
         out_spec,
+        has_side_effect=True,
         input_layouts=[None, None, None, None, None, None, None, None],
         output_layouts=None,
         vmap_method="sequential",

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -10,8 +10,6 @@ import numpy as np
 import scipy.sparse as sp
 from jax.typing import ArrayLike
 
-from .utils import temp_enable_x64
-
 if TYPE_CHECKING:
     from mpi4py.MPI import Comm
 
@@ -76,34 +74,126 @@ def resolve_comm(comm_ptr: int) -> "Comm":
     return _COMM_BY_PTR.get(comm_ptr, MPI.COMM_WORLD)
 
 
-def local_transpose_nnz(
-    col_indices: ArrayLike, recvcounts_tuple: tuple[int, ...], comm: "Comm"
-) -> int:
-    """This rank's local nonzero count of A^T (for transpose output sizing).
+class TransposePlan(NamedTuple):
+    """Fixed CSR structure and value routing for a distributed transpose."""
 
-    Rank r's A^T rows receive every A nonzero whose column it owns, so the local
-    nnz of A^T equals the local nnz of A only for structurally symmetric
-    patterns; in general it differs per rank, so the distributed transpose sizes
-    its output by this value rather than the input nnz. Computed once on the host
-    via an ``Alltoall`` of per-destination counts.
+    indices: np.ndarray | jax.Array
+    indptr: np.ndarray | jax.Array
+    local_source_ids: np.ndarray | jax.Array
+    local_target_ids: np.ndarray | jax.Array
+    send_ids_2d: np.ndarray | jax.Array
+    recv_target_ids_2d: np.ndarray | jax.Array
+    max_nnz: int
 
-    Args:
-        col_indices: This rank's local (global-numbered) CSR column indices.
-        recvcounts_tuple: Rows owned per rank (the row partition).
-        comm: MPI communicator.
+    @property
+    def nnz(self) -> int:
+        return len(self.indices)
 
-    Returns:
-        This rank's local nnz of A^T (a static Python int).
-    """
-    nranks = len(recvcounts_tuple)
-    # Half-open row-block boundaries [0, r0, r0+r1, ..., n_global].
-    row_bounds = np.cumsum(np.array([0, *recvcounts_tuple], dtype=np.int64))
-    cols = np.asarray(col_indices).astype(np.int64)
-    owner = np.clip(np.searchsorted(row_bounds, cols, side="right") - 1, 0, nranks - 1)
-    send_counts = np.bincount(owner, minlength=nranks).astype(np.int32)
+
+def build_transpose_plan(
+    indices: ArrayLike,
+    indptr: ArrayLike,
+    recvcounts: tuple[int, ...],
+    partition_info: tuple[int, int],
+    comm: "Comm",
+) -> TransposePlan:
+    """Precompute the structure and value routing for ``A.T``."""
+    from mpi4py import MPI
+
+    indices = np.asarray(indices, dtype=np.int64)
+    indptr = np.asarray(indptr, dtype=np.int64)
+    row_start, row_end = partition_info
+    n_local = row_end - row_start
+    n_global = sum(recvcounts)
+    nranks = len(recvcounts)
+
+    source_rows = np.repeat(
+        np.arange(row_start, row_end, dtype=np.int64), np.diff(indptr)
+    )
+    invalid_columns = bool(np.any(indices < 0) or np.any(indices >= n_global))
+    if comm.allreduce(invalid_columns, op=MPI.LOR):
+        raise ValueError("A_local contains a global column index outside the matrix")
+
+    row_bounds = np.cumsum(np.array([0, *recvcounts], dtype=np.int64))
+    owners = np.searchsorted(row_bounds, indices, side="right") - 1
+    send_order = np.argsort(owners, kind="stable")
+    send_counts = np.bincount(owners, minlength=nranks).astype(np.int32)
     recv_counts = np.empty(nranks, dtype=np.int32)
     comm.Alltoall(send_counts, recv_counts)
-    return int(recv_counts.sum())
+    send_displs = np.insert(np.cumsum(send_counts[:-1]), 0, 0).astype(np.int32)
+    recv_displs = np.insert(np.cumsum(recv_counts[:-1]), 0, 0).astype(np.int32)
+
+    send_coordinates = np.ascontiguousarray(
+        np.column_stack((indices[send_order], source_rows[send_order]))
+    )
+    send_ids = np.ascontiguousarray(np.arange(len(indices), dtype=np.int64)[send_order])
+    recv_nnz = int(recv_counts.sum())
+    recv_coordinates = np.empty((recv_nnz, 2), dtype=np.int64)
+    comm.Alltoallv(
+        [send_coordinates, 2 * send_counts, 2 * send_displs, MPI.INT64_T],
+        [recv_coordinates, 2 * recv_counts, 2 * recv_displs, MPI.INT64_T],
+    )
+    recv_rows = recv_coordinates[:, 0]
+    recv_cols = recv_coordinates[:, 1]
+    local_rows = recv_rows - row_start
+    order = np.lexsort((recv_cols, local_rows))
+    local_rows = local_rows[order]
+    recv_cols = recv_cols[order]
+    row_counts = np.bincount(local_rows, minlength=n_local)
+    transpose_indptr = np.concatenate(([0], np.cumsum(row_counts))).astype(np.int32)
+
+    rank = comm.Get_rank()
+    remote_send_counts = send_counts.copy()
+    remote_recv_counts = recv_counts.copy()
+    remote_send_counts[rank] = 0
+    remote_recv_counts[rank] = 0
+    local_maxima = np.array(
+        [max(remote_send_counts.max(), remote_recv_counts.max()), recv_nnz],
+        dtype=np.int64,
+    )
+    global_maxima = np.empty_like(local_maxima)
+    comm.Allreduce(local_maxima, global_maxima, op=MPI.MAX)
+    max_per_rank = max(int(global_maxima[0]), 1)
+    max_nnz = int(global_maxima[1])
+
+    # Padding uses a one-past-the-end sentinel. Applying the plan pads both the
+    # input and output by one zero, so reversing the four routing arrays also
+    # gives the value routing for ``A.T.T``.
+    send_ids_2d = np.full((nranks, max_per_rank), len(indices), dtype=np.int32)
+    recv_target_ids_2d = np.full((nranks, max_per_rank), recv_nnz, dtype=np.int32)
+    inverse_order = np.empty(recv_nnz, dtype=np.int32)
+    inverse_order[order] = np.arange(recv_nnz, dtype=np.int32)
+    for peer in range(nranks):
+        if peer == rank:
+            continue
+        send_count = int(send_counts[peer])
+        if send_count:
+            start = int(send_displs[peer])
+            send_ids_2d[peer, :send_count] = send_ids[start : start + send_count]
+        recv_count = int(recv_counts[peer])
+        if recv_count:
+            start = int(recv_displs[peer])
+            recv_target_ids_2d[peer, :recv_count] = inverse_order[
+                start : start + recv_count
+            ]
+
+    local_send_start = int(send_displs[rank])
+    local_recv_start = int(recv_displs[rank])
+    local_count = int(send_counts[rank])
+    local_source_ids = send_ids[
+        local_send_start : local_send_start + local_count
+    ].astype(np.int32)
+    local_target_ids = inverse_order[local_recv_start : local_recv_start + local_count]
+
+    return TransposePlan(
+        np.asarray(recv_cols, dtype=np.int64),
+        transpose_indptr,
+        local_source_ids,
+        local_target_ids,
+        send_ids_2d,
+        recv_target_ids_2d,
+        max_nnz,
+    )
 
 
 class HaloPlan(NamedTuple):
@@ -135,9 +225,9 @@ class HaloPlan(NamedTuple):
     n_ghost: int
     max_n_ghost: int
     max_per_rank: int
-    col_to_combined: np.ndarray
-    send_ids_2d: np.ndarray
-    recv_ghost_slot_2d: np.ndarray
+    col_to_combined: np.ndarray | jax.Array
+    send_ids_2d: np.ndarray | jax.Array
+    recv_ghost_slot_2d: np.ndarray | jax.Array
 
 
 def build_halo_plan(
@@ -255,236 +345,45 @@ def _mpi4jax_halo_gather(
     return jnp.concatenate([x_local, x_ghost[:n_ghost]])
 
 
-def _mpi4jax_alltoallv_transpose(
+def _apply_transpose_plan(
     data: jax.Array,
-    indices: jax.Array,
-    indptr: jax.Array,
-    recvcounts_tuple: tuple[int, ...],
-    comm: "Comm",
-    max_nnz: int,
+    local_source_ids: jax.Array,
+    local_target_ids: jax.Array,
+    send_ids: jax.Array,
+    recv_target_ids: jax.Array,
     nnz_out: int,
-) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """
-    Pure JAX implementation of distributed matrix transpose using mpi4jax.
+    exchange: Callable[[jax.Array], jax.Array],
+) -> jax.Array:
+    """Apply a fixed transpose plan using the supplied all-to-all operation."""
+    data = jnp.pad(data, (0, 1))
+    values = jnp.zeros(nnz_out + 1, dtype=data.dtype)
+    values = values.at[local_target_ids].set(data[local_source_ids])
+    received = exchange(data[send_ids])
+    values = values.at[recv_target_ids.reshape(-1)].set(received.reshape(-1))
+    return values[:-1]
 
-    This version uses only JAX operations and mpi4jax collectives,
-    making it fully JIT-compatible. All operations stay on GPU.
 
-    The algorithm:
-    1. Convert local CSR to COO format
-    2. Determine destination rank for each element (based on column -> row mapping)
-    3. Exchange element counts via alltoall
-    4. Build padded send buffers using scatter operations
-    5. Exchange data via GPU-direct alltoall
-    6. Extract valid data and rebuild CSR for A^T
-
-    Args:
-        data: CSR data array
-        indices: CSR column indices
-        indptr: CSR row pointers
-        recvcounts_tuple: Partition sizes (rows per rank)
-        comm: MPI communicator
-        max_nnz: Max local nnz of A across ranks, for send-buffer sizing (the
-            send buffers are collective, so all ranks share this size).
-        nnz_out: This rank's local nnz of A^T, the exact output length. Under row
-            partitioning it differs from the input nnz whenever the pattern is
-            structurally nonsymmetric, so it must be provided (see
-            :func:`local_transpose_nnz`). Any slots beyond the actual received
-            count are padded with in-range explicit zeros (a no-op when the count
-            is exact).
-    """
+def _mpi4jax_transpose_values(
+    data: jax.Array,
+    local_source_ids: jax.Array,
+    local_target_ids: jax.Array,
+    send_ids: jax.Array,
+    recv_target_ids: jax.Array,
+    nnz_out: int,
+    comm: "Comm",
+) -> jax.Array:
+    """Exchange only matrix values for a preplanned distributed transpose."""
     import mpi4jax
 
-    rank = comm.Get_rank()
-    size = comm.Get_size()
-    nnz = data.shape[0]
-
-    # Use static Python values from recvcounts_tuple (known at trace time)
-    # This avoids traced array issues with jnp.arange
-    n_local = recvcounts_tuple[rank]  # Python int, not traced
-    my_row_start = sum(recvcounts_tuple[:rank])  # Python int, not traced
-
-    # Compute partition info as JAX arrays for operations that need them
-    r_counts = jnp.array(recvcounts_tuple, dtype=jnp.int32)
-    displs = jnp.concatenate(
-        [jnp.array([0], dtype=jnp.int32), jnp.cumsum(r_counts[:-1]).astype(jnp.int32)]
+    return _apply_transpose_plan(
+        data,
+        local_source_ids,
+        local_target_ids,
+        send_ids,
+        recv_target_ids,
+        nnz_out,
+        lambda values: mpi4jax.alltoall(values, comm=comm),
     )
-
-    # --- Step 1: Convert CSR to COO format ---
-    row_counts = indptr[1:] - indptr[:-1]
-    # Use static n_local for jnp.arange
-    row_indices_local = jnp.repeat(
-        jnp.arange(n_local, dtype=jnp.int32), row_counts, total_repeat_length=nnz
-    )
-    row_indices_global = row_indices_local + my_row_start
-    col_indices_global = indices.astype(jnp.int32)
-
-    # --- Step 2: Determine destination ranks ---
-    dest_ranks = jnp.searchsorted(displs, col_indices_global, side="right") - 1
-    dest_ranks = jnp.clip(dest_ranks, 0, size - 1).astype(jnp.int32)
-
-    # --- Step 3: Sort by destination rank ---
-    sort_order = jnp.argsort(dest_ranks)
-    data_sorted = data[sort_order]
-    rows_sorted = row_indices_global[sort_order]
-    cols_sorted = col_indices_global[sort_order]
-    dest_ranks_sorted = dest_ranks[sort_order]
-
-    # --- Step 4: Count elements per destination ---
-    # Use bincount (much lighter than one_hot for large nnz)
-    send_counts = jnp.bincount(dest_ranks_sorted, length=size).astype(jnp.int32)
-
-    # --- Step 5: Exchange counts and compute buffer sizes ---
-    recv_counts = mpi4jax.alltoall(send_counts, comm=comm)
-
-    # --- Step 6: Build padded send buffers ---
-    # Since dest_ranks_sorted is sorted by destination rank, positions can be
-    # computed via segment offsets (avoids O(nnz*nranks) one-hot masks).
-    send_displs = jnp.concatenate(
-        [
-            jnp.array([0], dtype=jnp.int32),
-            jnp.cumsum(send_counts[:-1]).astype(jnp.int32),
-        ]
-    )
-    positions = jnp.arange(nnz, dtype=jnp.int32) - send_displs[dest_ranks_sorted]
-
-    # Use precalculated max_nnz for buffer sizing
-    # This ensures all ranks use the same buffer size for alltoall
-    max_per_rank = max_nnz
-
-    # Initialize send buffers with zeros
-    send_data = jnp.zeros((size, max_per_rank), dtype=data.dtype)
-    send_rows = jnp.zeros((size, max_per_rank), dtype=jnp.int32)
-    send_cols = jnp.zeros((size, max_per_rank), dtype=jnp.int32)
-
-    # Scatter data into send buffers
-    # 2D indexing: send_data[dest_ranks_sorted[i], positions[i]] = data_sorted[i]
-    send_data = send_data.at[dest_ranks_sorted, positions].set(data_sorted)
-    send_rows = send_rows.at[dest_ranks_sorted, positions].set(
-        rows_sorted.astype(jnp.int32)
-    )
-    send_cols = send_cols.at[dest_ranks_sorted, positions].set(
-        cols_sorted.astype(jnp.int32)
-    )
-
-    # --- Step 7: Exchange data via GPU-direct alltoall ---
-    recv_data = mpi4jax.alltoall(send_data, comm=comm)
-    recv_rows = mpi4jax.alltoall(send_rows, comm=comm)
-    recv_cols = mpi4jax.alltoall(send_cols, comm=comm)
-
-    # --- Step 8: Extract valid received data and build A^T ---
-    # Flatten and concatenate valid portions from each rank
-    recv_displs = jnp.concatenate(
-        [
-            jnp.array([0], dtype=jnp.int32),
-            jnp.cumsum(recv_counts[:-1]).astype(jnp.int32),
-        ]
-    )
-
-    # Create index arrays for gathering valid data
-    # For each rank r, we take recv_data[r, 0:recv_counts[r]]
-    # We'll use a masked approach that works with JIT
-
-    # Build flat indices: for rank r, positions 0..recv_counts[r]-1 are valid
-    # Create a mask for valid positions
-    rank_indices = jnp.repeat(jnp.arange(size, dtype=jnp.int32), max_per_rank)
-    pos_indices = jnp.tile(jnp.arange(max_per_rank, dtype=jnp.int32), size)
-    valid_mask = pos_indices < recv_counts[rank_indices]
-
-    # Flatten recv arrays
-    recv_data_flat_all = recv_data.flatten()
-    recv_rows_flat_all = recv_rows.flatten()
-    recv_cols_flat_all = recv_cols.flatten()
-
-    # Extract valid elements using boolean indexing equivalent
-    # Since we can't use dynamic boolean indexing in JIT, use where + scatter
-    # Compute destination indices in the output array
-    within_rank_pos = pos_indices
-    # Cumsum of recv_counts gives starting position for each rank in output
-    # Position in output = recv_displs[rank] + within_rank_pos (if valid)
-
-    # Create output position for each element (invalid elements get -1 or beyond)
-    flat_output_pos = jnp.where(
-        valid_mask,
-        recv_displs[rank_indices] + within_rank_pos,
-        -1,  # Invalid positions (will be ignored)
-    )
-
-    # Size the output by nnz_out (this rank's local nnz of A^T), not the input
-    # nnz: they differ per rank for structurally nonsymmetric patterns, and using
-    # the input nnz would drop or strand received entries. real_count is the
-    # runtime count and equals nnz_out, so the scatter fills [0, nnz_out) exactly.
-    real_count = jnp.sum(recv_counts).astype(jnp.int32)
-
-    recv_data_flat = jnp.zeros(nnz_out, dtype=data.dtype)
-    recv_rows_flat = jnp.zeros(nnz_out, dtype=jnp.int32)
-    recv_cols_flat = jnp.zeros(nnz_out, dtype=jnp.int32)
-
-    # Scatter valid elements to their positions
-    # Use segment_sum pattern: only positions >= 0 are valid
-    valid_positions = jnp.maximum(flat_output_pos, 0).astype(jnp.int32)
-    scatter_mask = flat_output_pos >= 0
-
-    # Use jnp.where to mask values before scatter (preserves dtype)
-    masked_data = jnp.where(
-        scatter_mask, recv_data_flat_all, jnp.zeros_like(recv_data_flat_all)
-    )
-    masked_rows = jnp.where(
-        scatter_mask, recv_rows_flat_all, jnp.zeros_like(recv_rows_flat_all)
-    )
-    masked_cols = jnp.where(
-        scatter_mask, recv_cols_flat_all, jnp.zeros_like(recv_cols_flat_all)
-    )
-
-    # Use at[].add to scatter (avoids overwrite issues)
-    recv_data_flat = recv_data_flat.at[valid_positions].add(masked_data)
-    recv_rows_flat = recv_rows_flat.at[valid_positions].add(masked_rows)
-    recv_cols_flat = recv_cols_flat.at[valid_positions].add(masked_cols)
-
-    # Defensive: if nnz_out exceeds the received count, pad the tail slots with an
-    # on-rank explicit zero at (A^T row 0, column my_row_start) -- harmless to
-    # AmgX and a no-op when nnz_out is exact (as from local_transpose_nnz). The
-    # pre-transpose fields map recv_cols -> local row, recv_rows -> global column.
-    pad_mask = jnp.arange(nnz_out, dtype=jnp.int32) >= real_count
-    recv_cols_flat = jnp.where(pad_mask, my_row_start, recv_cols_flat)
-    recv_rows_flat = jnp.where(pad_mask, my_row_start, recv_rows_flat)
-
-    # For A^T: recv_cols becomes local row (was column in A), recv_rows becomes col (was row in A)
-    at_rows_local = recv_cols_flat - my_row_start  # Local row index in A^T
-    at_cols = recv_rows_flat  # Column index in A^T (global row in A)
-
-    # Sort by (row, col) for CSR format
-    # Create composite key for sorting: row * n_global + col. This must be int64:
-    # for large grids row*n_global overflows int32 (e.g. 48^3 -> ~6.1e9 > 2.1e9),
-    # which would scramble the row ordering and produce a malformed A^T.
-    n_global = sum(recvcounts_tuple)  # Static Python int
-    with temp_enable_x64():
-        sort_key = at_rows_local.astype(jnp.int64) * n_global + at_cols.astype(
-            jnp.int64
-        )
-        sort_idx = jnp.argsort(sort_key)
-
-    r_sorted = at_rows_local[sort_idx]
-    c_sorted = at_cols[sort_idx]
-    v_sorted = recv_data_flat[sort_idx]
-
-    # Build indptr from row counts (which sum to nnz_out).
-    row_counts_at = jnp.bincount(r_sorted, length=n_local).astype(jnp.int32)
-
-    out_indptr = jnp.zeros(n_local + 1, dtype=indptr.dtype)
-    out_indptr = out_indptr.at[1:].set(jnp.cumsum(row_counts_at).astype(jnp.int32))
-
-    # Output data and indices (already sorted); length is nnz_out, this rank's
-    # local nnz(A^T).
-    out_data = v_sorted
-    out_indices = c_sorted
-    out_indptr = out_indptr.at[-1].set(nnz_out)
-
-    # Convert output indices to int64
-    with temp_enable_x64():
-        out_indices_int64 = out_indices.astype(jnp.int64)
-
-    return out_data, out_indices_int64, out_indptr
 
 
 def partition_csr_matrix(

--- a/jaxamg/mpi_utils.py
+++ b/jaxamg/mpi_utils.py
@@ -119,6 +119,8 @@ class HaloPlan(NamedTuple):
     Fields (all static, captured at setup):
         n_local: Rows owned by this rank.
         n_ghost: Distinct remote columns this rank references.
+        max_n_ghost: Largest ``n_ghost`` across ranks, used for equal shard
+            shapes in the JAX sharding interface.
         max_per_rank: Padded per-rank chunk size for the ``alltoall`` (a global
             max, so every rank uses the same buffer size).
         col_to_combined: For each local nonzero, its index into the combined
@@ -131,6 +133,7 @@ class HaloPlan(NamedTuple):
 
     n_local: int
     n_ghost: int
+    max_n_ghost: int
     max_per_rank: int
     col_to_combined: np.ndarray
     send_ids_2d: np.ndarray
@@ -189,11 +192,15 @@ def build_halo_plan(
     )
     send_local_ids = (requested_ids - row_start).astype(np.int32)
 
-    # alltoall needs one shared chunk size across all ranks.
-    max_per_rank = int(
-        comm.allreduce(int(max(send_counts.max(), recv_counts.max())), op=MPI.MAX)
+    # The all-to-all chunk and sharded ghost-vector sizes must agree globally.
+    # Reduce both maxima together so sharding does not need another collective.
+    local_maxima = np.array(
+        [max(send_counts.max(), recv_counts.max()), n_ghost], dtype=np.int64
     )
-    max_per_rank = max(max_per_rank, 1)
+    global_maxima = np.empty_like(local_maxima)
+    comm.Allreduce(local_maxima, global_maxima, op=MPI.MAX)
+    max_per_rank = max(int(global_maxima[0]), 1)
+    max_n_ghost = int(global_maxima[1])
 
     send_ids_2d = np.zeros((nranks, max_per_rank), dtype=np.int32)
     recv_ghost_slot_2d = np.full((nranks, max_per_rank), n_ghost, dtype=np.int32)
@@ -215,7 +222,13 @@ def build_halo_plan(
     ).astype(np.int32)
 
     return HaloPlan(
-        n_local, n_ghost, max_per_rank, col_to_combined, send_ids_2d, recv_ghost_slot_2d
+        n_local,
+        n_ghost,
+        max_n_ghost,
+        max_per_rank,
+        col_to_combined,
+        send_ids_2d,
+        recv_ghost_slot_2d,
     )
 
 

--- a/jaxamg/nullspace.py
+++ b/jaxamg/nullspace.py
@@ -116,9 +116,16 @@ def _global_max(value: float, comm: "Comm | None") -> float:
 
 
 def as_nullspace_basis(
-    spec: NullSpaceSpec, n: int, dtype: DTypeLike, name: str
+    spec: NullSpaceSpec,
+    n: int,
+    dtype: DTypeLike,
+    name: str,
+    n_global: int | None = None,
 ) -> jax.Array | None:
-    """Normalize ``"constant"`` / vector / ``(n, k)`` array to ``(n, k)`` (or None)."""
+    """Normalize ``"constant"`` / vector / ``(n, k)`` array to ``(n, k)`` (or None).
+
+    ``n_global`` bounds ``k`` for a distributed basis, whose local slice may
+    have fewer rows than columns."""
     if spec is None:
         return None
     if isinstance(spec, str):
@@ -131,10 +138,11 @@ def as_nullspace_basis(
     basis = jnp.asarray(spec)
     if basis.ndim == 1:
         basis = basis[:, None]
-    if basis.ndim != 2 or basis.shape[0] != n or not 0 < basis.shape[1] <= n:
+    max_k = n if n_global is None else n_global
+    if basis.ndim != 2 or basis.shape[0] != n or not 0 < basis.shape[1] <= max_k:
         raise ValueError(
             f"{name} must be a vector of length {n} or an ({n}, k) array with "
-            f"k ≤ {n}; got shape {basis.shape}"
+            f"k ≤ {max_k}; got shape {basis.shape}"
         )
     if basis.dtype != dtype:
         basis = basis.astype(dtype)

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
 ShardedInfo = dict[str, jax.Array]
 
 
+def _row_partition_spec(ndim: int, axis_name: str) -> P:
+    """Partition the leading row axis and replicate all trailing axes."""
+    return P(axis_name, *(None for _ in range(ndim - 1)))
+
+
 class ShardedSolve:
     """Callable sharded solver with differentiable packed matrix values."""
 
@@ -61,7 +66,7 @@ class ShardedSolve:
         return self._local_matrix_gradient_fn(gradient)
 
     def local_vector(self, value: jax.Array) -> jax.Array:
-        """Return this rank's unpadded portion of a solver vector."""
+        """Return this rank's unpadded rows of a solver vector or RHS matrix."""
         return self._local_vector_fn(value)
 
 
@@ -73,14 +78,15 @@ def make_sharded_vector(
     global_size: int | None = None,
     axis_name: str = "rank",
 ) -> jax.Array:
-    """Create a row-sharded vector, padding unequal local partitions.
+    """Create a row-sharded vector or RHS matrix, padding unequal partitions.
 
     The returned JAX array has equal physical shard sizes, as required by
     ``NamedSharding``. ``make_sharded_solver`` ignores each shard's padding and
     uses the true row counts from ``A_local``.
 
     Args:
-        local_values: This rank's unpadded one-dimensional values.
+        local_values: This rank's unpadded values with shape ``(n_local,)`` or
+            ``(n_local, nrhs)``.
         comm: MPI communicator whose rank order matches ``mesh``.
         mesh: One-dimensional JAX device mesh with one device per MPI rank.
         global_size: Optional true global length. When provided, it is checked
@@ -88,12 +94,17 @@ def make_sharded_vector(
         axis_name: Mesh axis used to partition the vector.
 
     Returns:
-        A global JAX array with ``NamedSharding(mesh, P(axis_name))``. Its
-        physical length is ``comm.size * max(local_sizes)``.
+        A global JAX array whose leading axis uses ``P(axis_name)`` and whose
+        optional RHS-column axis is replicated. Its physical leading-axis
+        length is ``comm.size * max(local_sizes)``.
     """
     values = np.asarray(local_values)
-    if values.ndim != 1:
-        raise ValueError(f"local_values must be one-dimensional; got {values.shape}")
+    if values.ndim not in (1, 2):
+        raise ValueError(
+            f"local_values must be one- or two-dimensional; got shape {values.shape}"
+        )
+    if values.ndim == 2 and values.shape[1] == 0:
+        raise ValueError("a batched RHS must contain at least one column")
     if tuple(mesh.axis_names) != (axis_name,):
         raise ValueError(
             f"mesh must have the single axis {axis_name!r}; got {mesh.axis_names!r}"
@@ -106,7 +117,13 @@ def make_sharded_vector(
             f"mesh size {mesh.size} and communicator size {comm_size}"
         )
 
-    local_sizes = tuple(int(size) for size in comm.allgather(values.shape[0]))
+    local_shapes = tuple(tuple(shape) for shape in comm.allgather(values.shape))
+    trailing_shape = values.shape[1:]
+    if any(shape[1:] != trailing_shape for shape in local_shapes):
+        raise ValueError(
+            f"all MPI ranks must use the same trailing RHS shape; got {local_shapes}"
+        )
+    local_sizes = tuple(int(shape[0]) for shape in local_shapes)
     inferred_global_size = sum(local_sizes)
     if global_size is not None and int(global_size) != inferred_global_size:
         raise ValueError(
@@ -115,13 +132,13 @@ def make_sharded_vector(
         )
 
     max_local_size = max(local_sizes)
-    padded_values = np.zeros(max_local_size, dtype=values.dtype)
+    padded_values = np.zeros((max_local_size, *trailing_shape), dtype=values.dtype)
     padded_values[: values.shape[0]] = values
-    sharding = NamedSharding(mesh, P(axis_name))
+    sharding = NamedSharding(mesh, _row_partition_spec(values.ndim, axis_name))
     return jax.make_array_from_process_local_data(
         sharding,
         padded_values,
-        global_shape=(comm_size * max_local_size,),
+        global_shape=(comm_size * max_local_size, *trailing_shape),
     )
 
 
@@ -210,11 +227,13 @@ def _local_partition(
     n_local: int,
     n_global: int,
 ) -> tuple[tuple[int, int], int]:
-    if b.ndim != 1:
-        raise ValueError(f"b must be one-dimensional; got shape {b.shape}")
+    if b.ndim not in (1, 2):
+        raise ValueError(f"b must be one- or two-dimensional; got shape {b.shape}")
+    if b.ndim == 2 and b.shape[1] == 0:
+        raise ValueError("a batched RHS must contain at least one column")
 
     sharding = getattr(b, "sharding", None)
-    expected_spec = P(axis_name)
+    expected_spec = _row_partition_spec(b.ndim, axis_name)
     if not isinstance(sharding, NamedSharding):
         raise ValueError("b must use NamedSharding")
     if sharding.mesh != mesh or sharding.spec != expected_spec:
@@ -229,7 +248,7 @@ def _local_partition(
             f"count; got row counts {local_sizes} and {n_global} columns"
         )
     max_local_size = max(local_sizes)
-    expected_shape = (comm.Get_size() * max_local_size,)
+    expected_shape = (comm.Get_size() * max_local_size, *b.shape[1:])
     if b.shape != expected_shape:
         raise ValueError(
             f"b must have padded sharded shape {expected_shape}; got {b.shape}. "
@@ -243,7 +262,7 @@ def _local_partition(
             f"{len(shards)}"
         )
     index = shards[0].index
-    if len(index) != 1 or not isinstance(index[0], slice):
+    if len(index) != b.ndim or not isinstance(index[0], slice):
         raise ValueError(f"b must have one contiguous local shard; got index {index!r}")
 
     row_slice = index[0]
@@ -304,7 +323,9 @@ def _validate_operand(
         sharding = getattr(value, "sharding", None)
         if not isinstance(sharding, NamedSharding):
             raise ValueError(f"{name} must use NamedSharding")
-        if sharding.mesh != mesh or sharding.spec != P(axis_name):
+        if sharding.mesh != mesh or sharding.spec != _row_partition_spec(
+            value.ndim, axis_name
+        ):
             raise ValueError(
                 f"{name} must use the same NamedSharding as the template RHS"
             )
@@ -426,10 +447,11 @@ def make_sharded_solver(
     Args:
         A_local: Local row partition with shape ``(n_local, n_global)`` and
             global column indices.
-        b: Global one-dimensional JAX array using
-            ``NamedSharding(mesh, PartitionSpec(axis_name))``. For unequal row
+        b: Global JAX array with shape ``(n_global,)`` or
+            ``(n_global, nrhs)`` using row ``NamedSharding``. For unequal row
             counts, construct it with :func:`make_sharded_vector`; physical
-            shards are padded to the largest local partition.
+            shards are padded to the largest local partition. Batched RHS
+            columns are replicated within each row shard.
         comm: MPI communicator whose rank order matches the JAX process order.
         mesh: One-dimensional JAX device mesh. If omitted, use the mesh from
             ``b.sharding``.
@@ -450,9 +472,10 @@ def make_sharded_solver(
         nonzero count. ``solver.local_matrix_gradient(gradient)`` converts its
         gradient back to this rank's unpadded BCSR structure, while
         ``solver.local_vector(value)`` removes vector padding. The solve returns
-        a global sharded solution and an info dictionary. Info values are global
-        arrays with one entry per rank; ``residual_history`` has shape
-        ``(nranks, max_iters + 1)``.
+        a global sharded solution and an info dictionary. For a vector RHS,
+        info values have one entry per rank. For a batched RHS they have shape
+        ``(nranks, nrhs)`` and ``residual_history`` has an additional trailing
+        ``max_iters + 1`` axis.
     """
     _require_shard_map()
     if not isinstance(b, jax.Array):
@@ -472,8 +495,10 @@ def make_sharded_solver(
     block_dim = int(block_dim)
     _validate_matrix(A_local, nglobal, partition_info, block_dim)
 
+    is_batched = b.ndim == 2
     local_rhs = b.addressable_shards[0].data[:n_local]
-    A_bcsr = to_bcsr_matrix(A_local, b=local_rhs, use_int64_indices=True)
+    matrix_probe_rhs = local_rhs[:, 0] if is_batched else local_rhs
+    A_bcsr = to_bcsr_matrix(A_local, b=matrix_probe_rhs, use_int64_indices=True)
     mpi_cache = cache_mpi_metadata(
         config or {},
         comm,
@@ -490,8 +515,9 @@ def make_sharded_solver(
     local_hardware_id = getattr(local_device, "local_hardware_id", local_device.id)
     mpi_cache["lrank"] = int(local_hardware_id)
 
-    row_spec = P(axis_name)
-    A_data_sharding = NamedSharding(mesh, row_spec)
+    rhs_spec = _row_partition_spec(b.ndim, axis_name)
+    A_data_spec = P(axis_name)
+    A_data_sharding = NamedSharding(mesh, A_data_spec)
     local_nnz = int(A_bcsr.data.shape[0])
     max_nnz = int(mpi_cache["max_nnz"])
     local_packed_data = np.zeros(max_nnz, dtype=np.asarray(A_bcsr.data).dtype)
@@ -526,14 +552,29 @@ def make_sharded_solver(
         transpose_cache["lrank"] = int(local_hardware_id)
         transpose_source_ids = jnp.asarray(source_ids, dtype=jnp.int32)
 
-    info_specs = {
-        "iterations": row_spec,
-        "residual": row_spec,
-        "status": row_spec,
-        "residual_history": P(axis_name, None),
-    }
+    if is_batched:
+        info_specs = {
+            "iterations": P(axis_name, None),
+            "residual": P(axis_name, None),
+            "status": P(axis_name, None),
+            "residual_history": P(axis_name, None, None),
+        }
+    else:
+        info_specs = {
+            "iterations": P(axis_name),
+            "residual": P(axis_name),
+            "status": P(axis_name),
+            "residual_history": P(axis_name, None),
+        }
 
     def pack_info(info: ShardedInfo) -> ShardedInfo:
+        if is_batched:
+            return {
+                "iterations": jnp.asarray(info["iterations"], dtype=jnp.int32)[None, :],
+                "residual": jnp.asarray(info["residual"])[None, :],
+                "status": jnp.asarray(info["status"], dtype=jnp.int32)[None, :],
+                "residual_history": jnp.asarray(info["residual_history"])[None, :, :],
+            }
         return {
             "iterations": jnp.asarray(info["iterations"], dtype=jnp.int32)[None],
             "residual": jnp.asarray(info["residual"])[None],
@@ -554,31 +595,70 @@ def make_sharded_solver(
         return with_cache(matrix, mpi=cache, is_symmetric=symmetric)
 
     def pad_local_vector(value: jax.Array) -> jax.Array:
-        return jnp.pad(value, (0, max_n_local - n_local))
+        padding = ((0, max_n_local - n_local),) + ((0, 0),) * (value.ndim - 1)
+        return jnp.pad(value, padding)
+
+    def solve_one_rhs(
+        A_dynamic: jsp.BCSR,
+        rhs_local: jax.Array,
+        x0_local: jax.Array | None = None,
+    ) -> tuple[jax.Array, ShardedInfo]:
+        return solve(
+            A_dynamic,
+            rhs_local[:n_local],
+            x0=None if x0_local is None else x0_local[:n_local],
+            block_dim=block_dim,
+            reuse_setup=reuse_setup,
+        )
+
+    def solve_local_rhs(
+        A_dynamic: jsp.BCSR,
+        rhs_local: jax.Array,
+        x0_local: jax.Array | None = None,
+    ) -> tuple[jax.Array, ShardedInfo]:
+        if not is_batched:
+            return solve_one_rhs(A_dynamic, rhs_local, x0_local)
+
+        solutions: list[jax.Array] = []
+        column_info: list[ShardedInfo] = []
+        for column in range(rhs_local.shape[1]):
+            rhs_column = rhs_local[:, column]
+            x0_column = None if x0_local is None else x0_local[:, column]
+            # XLA schedules each rank independently. Tie every column to the
+            # previous result so all ranks enter AmgX collectives in the same
+            # order.
+            if solutions:
+                if x0_column is None:
+                    rhs_column, _ = jax.lax.optimization_barrier(
+                        (rhs_column, solutions[-1])
+                    )
+                else:
+                    rhs_column, x0_column, _ = jax.lax.optimization_barrier(
+                        (rhs_column, x0_column, solutions[-1])
+                    )
+            solution, info = solve_one_rhs(
+                A_dynamic,
+                rhs_column,
+                x0_column,
+            )
+            solutions.append(solution)
+            column_info.append(info)
+        return jnp.stack(solutions, axis=1), jax.tree.map(
+            lambda *values: jnp.stack(values), *column_info
+        )
 
     def local_solve(
         A_data_local: jax.Array, rhs_local: jax.Array
     ) -> tuple[jax.Array, ShardedInfo]:
         A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
-        x_local, info = solve(
-            A_dynamic,
-            rhs_local[:n_local],
-            block_dim=block_dim,
-            reuse_setup=reuse_setup,
-        )
+        x_local, info = solve_local_rhs(A_dynamic, rhs_local)
         return pad_local_vector(x_local), pack_info(info)
 
     def local_solve_x0(
         A_data_local: jax.Array, rhs_local: jax.Array, x0_local: jax.Array
     ) -> tuple[jax.Array, ShardedInfo]:
         A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
-        x_local, info = solve(
-            A_dynamic,
-            rhs_local[:n_local],
-            x0=x0_local[:n_local],
-            block_dim=block_dim,
-            reuse_setup=reuse_setup,
-        )
+        x_local, info = solve_local_rhs(A_dynamic, rhs_local, x0_local)
         return pad_local_vector(x_local), pack_info(info)
 
     def local_adjoint(A_data_local: jax.Array, g_local: jax.Array) -> jax.Array:
@@ -595,12 +675,7 @@ def make_sharded_solver(
             A_adjoint = matrix_with_data(
                 transpose_data, A_transpose, transpose_cache, symmetric=False
             )
-        adjoint_local, _ = solve(
-            A_adjoint,
-            g_local[:n_local],
-            block_dim=block_dim,
-            reuse_setup=reuse_setup,
-        )
+        adjoint_local, _ = solve_one_rhs(A_adjoint, g_local)
         return adjoint_local
 
     halo_plan = mpi_cache["halo_plan"]
@@ -637,20 +712,12 @@ def make_sharded_solver(
             split_axis=0,
             concat_axis=0,
         )
-        x_ghost = jnp.zeros(max_n_ghost + 1, dtype=x_local.dtype)
+        trailing_shape = x_local.shape[1:]
+        x_ghost = jnp.zeros((max_n_ghost + 1, *trailing_shape), dtype=x_local.dtype)
         x_ghost = x_ghost.at[recv_ghost_slot_local.reshape(-1)].set(
-            recv_buffer.reshape(-1)
+            recv_buffer.reshape((-1, *trailing_shape))
         )
-        return jnp.concatenate([x_local, x_ghost[:max_n_ghost]])
-
-    def local_matrix_gradient(
-        A_data_local: jax.Array,
-        x_at_columns: jax.Array,
-        adjoint_local: jax.Array,
-    ) -> jax.Array:
-        del A_data_local
-        grad_values = -adjoint_local[row_indices] * x_at_columns
-        return jnp.where(valid_values, grad_values, 0)
+        return jnp.concatenate([x_local, x_ghost[:max_n_ghost]], axis=0)
 
     def local_gather_matrix_columns(x_local: jax.Array) -> jax.Array:
         x_combined = gather_solution_halo(x_local[:n_local], send_ids, recv_ghost_slot)
@@ -665,27 +732,24 @@ def make_sharded_solver(
             (A_data_local, g_local, x_at_columns)
         )
         adjoint_local = local_adjoint(A_data_ordered, g_ordered)
-        grad_A_data_local = local_matrix_gradient(
-            A_data_ordered,
-            x_at_columns,
-            adjoint_local,
-        )
+        grad_values = -adjoint_local[row_indices] * x_at_columns
+        grad_A_data_local = jnp.where(valid_values, grad_values, 0)
         return pad_local_vector(adjoint_local), grad_A_data_local
 
     mapped_solve = jax.jit(
         jax.shard_map(
             local_solve,
             mesh=mesh,
-            in_specs=(row_spec, row_spec),
-            out_specs=(row_spec, info_specs),
+            in_specs=(A_data_spec, rhs_spec),
+            out_specs=(rhs_spec, info_specs),
         )
     )
     mapped_solve_x0 = jax.jit(
         jax.shard_map(
             local_solve_x0,
             mesh=mesh,
-            in_specs=(row_spec, row_spec, row_spec),
-            out_specs=(row_spec, info_specs),
+            in_specs=(A_data_spec, rhs_spec, rhs_spec),
+            out_specs=(rhs_spec, info_specs),
         )
     )
 
@@ -697,24 +761,25 @@ def make_sharded_solver(
         jax.shard_map(
             local_cached_matrix_data,
             mesh=mesh,
-            in_specs=(row_spec,),
-            out_specs=row_spec,
+            in_specs=(rhs_spec,),
+            out_specs=A_data_spec,
         )
     )
+    scalar_spec = P(axis_name)
     mapped_gather_matrix_columns = jax.jit(
         jax.shard_map(
             local_gather_matrix_columns,
             mesh=mesh,
-            in_specs=(row_spec,),
-            out_specs=row_spec,
+            in_specs=(scalar_spec,),
+            out_specs=scalar_spec,
         )
     )
     mapped_backward = jax.jit(
         jax.shard_map(
             local_backward,
             mesh=mesh,
-            in_specs=(row_spec, row_spec, row_spec),
-            out_specs=(row_spec, row_spec),
+            in_specs=(A_data_spec, scalar_spec, scalar_spec),
+            out_specs=(scalar_spec, A_data_spec),
         )
     )
 
@@ -733,11 +798,38 @@ def make_sharded_solver(
         x, _ = result
         return result, (matrix_data, x)
 
+    def differentiated_solve_backward(
+        matrix_data: jax.Array, x: jax.Array, g_x: jax.Array
+    ) -> tuple[jax.Array, jax.Array]:
+        if not is_batched:
+            x_at_columns = mapped_gather_matrix_columns(x)
+            return mapped_backward(matrix_data, x_at_columns, g_x)
+
+        adjoint_columns: list[jax.Array] = []
+        matrix_gradients: list[jax.Array] = []
+        for column in range(x.shape[1]):
+            x_column = x[:, column]
+            g_column = g_x[:, column]
+            # Preserve the same collective ordering for adjoint solves and
+            # their preceding halo exchanges.
+            if adjoint_columns:
+                x_column, g_column, _ = jax.lax.optimization_barrier(
+                    (x_column, g_column, adjoint_columns[-1])
+                )
+            x_at_columns = mapped_gather_matrix_columns(x_column)
+            adjoint, matrix_gradient = mapped_backward(
+                matrix_data, x_at_columns, g_column
+            )
+            adjoint_columns.append(adjoint)
+            matrix_gradients.append(matrix_gradient)
+        return jnp.stack(adjoint_columns, axis=1), jnp.sum(
+            jnp.stack(matrix_gradients), axis=0
+        )
+
     def differentiated_solve_bwd(residuals, cotangents):
         matrix_data, x = residuals
         g_x, _ = cotangents
-        x_at_columns = mapped_gather_matrix_columns(x)
-        adjoint, grad_A_data = mapped_backward(matrix_data, x_at_columns, g_x)
+        adjoint, grad_A_data = differentiated_solve_backward(matrix_data, x, g_x)
         return grad_A_data, adjoint
 
     differentiated_solve.defvjp(differentiated_solve_fwd, differentiated_solve_bwd)
@@ -758,8 +850,7 @@ def make_sharded_solver(
     def differentiated_solve_x0_bwd(residuals, cotangents):
         matrix_data, x = residuals
         g_x, _ = cotangents
-        x_at_columns = mapped_gather_matrix_columns(x)
-        adjoint, grad_A_data = mapped_backward(matrix_data, x_at_columns, g_x)
+        adjoint, grad_A_data = differentiated_solve_backward(matrix_data, x, g_x)
         return grad_A_data, adjoint, jnp.zeros_like(adjoint)
 
     differentiated_solve_x0.defvjp(

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -46,21 +46,61 @@ def _row_partition_spec(ndim: int, axis_name: str) -> P:
     return P(axis_name, *(None for _ in range(ndim - 1)))
 
 
+class ShardedMatrix:
+    """Distributed CSR matrix with local structure and sharded values."""
+
+    def __init__(
+        self,
+        local_bcsr: jsp.BCSR,
+        data: jax.Array,
+        local_packed_data: np.ndarray,
+        comm: Comm,
+        mesh: Mesh,
+        axis_name: str,
+        partition_info: tuple[int, int],
+        max_local_size: int,
+    ) -> None:
+        self._local_bcsr = local_bcsr
+        self._local_packed_data = local_packed_data
+        self._comm = comm
+        self.mesh = mesh
+        self.axis_name = axis_name
+        self.partition_info = partition_info
+        self.max_local_size = max_local_size
+        self.data = data
+        self.global_size = int(local_bcsr.shape[1])
+        self.local_size = int(local_bcsr.shape[0])
+        self.local_nnz = int(local_bcsr.data.shape[0])
+        self.max_local_nnz = int(local_packed_data.shape[0])
+        self.shape = (self.global_size, self.global_size)
+        self.local_shape = tuple(local_bcsr.shape)
+
+    def local_matrix(self, data: jax.Array | None = None) -> jsp.BCSR:
+        """Return this rank's unpadded BCSR matrix for ``data`` or cached values."""
+        values = self.data if data is None else data
+        _validate_operand(values, self.data, self.mesh, self.axis_name, "matrix data")
+        local_values = values.addressable_shards[0].data[: self.local_nnz]
+        return jsp.BCSR(
+            (local_values, self._local_bcsr.indices, self._local_bcsr.indptr),
+            shape=self._local_bcsr.shape,
+        )
+
+
 class ShardedSolve:
     """Callable sharded solver with differentiable packed matrix values."""
 
     def __init__(
         self,
         solve_fn: Callable[..., tuple[jax.Array, ShardedInfo]],
-        A_data: jax.Array,
-        local_matrix_gradient_fn: Callable[[jax.Array], jsp.BCSR],
+        matrix: ShardedMatrix,
         local_vector_fn: Callable[[jax.Array], jax.Array],
         global_size: int,
         local_size: int,
     ) -> None:
         self._solve_fn = solve_fn
-        self.A_data = A_data
-        self._local_matrix_gradient_fn = local_matrix_gradient_fn
+        self.matrix = matrix
+        # Backward-compatible alias for the matrix container's sharded values.
+        self.A_data = matrix.data
         self._local_vector_fn = local_vector_fn
         self.global_size = global_size
         self.local_size = local_size
@@ -77,7 +117,7 @@ class ShardedSolve:
 
     def local_matrix_gradient(self, gradient: jax.Array) -> jsp.BCSR:
         """Convert a packed global value gradient to this rank's local BCSR."""
-        return self._local_matrix_gradient_fn(gradient)
+        return self.matrix.local_matrix(gradient)
 
     def local_vector(self, value: jax.Array) -> jax.Array:
         """Return this rank's unpadded rows of a solver vector or RHS matrix."""
@@ -325,6 +365,110 @@ def _validate_matrix(
         )
 
 
+def _normalize_local_matrix(
+    A_local: MatrixOrOperator,
+    b: jax.Array,
+    partition_info: tuple[int, int],
+) -> jsp.BCSR:
+    """Normalize a validated local matrix partition."""
+    n_local = partition_info[1] - partition_info[0]
+    nglobal = int(getattr(A_local, "shape")[1])
+    _validate_matrix(A_local, nglobal, partition_info, block_dim=1)
+
+    local_rhs = b.addressable_shards[0].data[:n_local]
+    matrix_probe_rhs = local_rhs[:, 0] if b.ndim == 2 else local_rhs
+    return to_bcsr_matrix(A_local, b=matrix_probe_rhs, use_int64_indices=True)
+
+
+def _pack_sharded_matrix(
+    A_bcsr: jsp.BCSR,
+    comm: Comm,
+    mesh: Mesh,
+    axis_name: str,
+    partition_info: tuple[int, int],
+    max_local_size: int,
+    max_nnz: int | None = None,
+) -> ShardedMatrix:
+    """Pack normalized local values into a global sharded array."""
+    local_nnz = int(A_bcsr.data.shape[0])
+    if max_nnz is None:
+        max_nnz = max(int(value) for value in comm.allgather(local_nnz))
+    local_packed_data = np.zeros(max_nnz, dtype=np.asarray(A_bcsr.data).dtype)
+    local_packed_data[:local_nnz] = np.asarray(A_bcsr.data)
+    data_sharding = NamedSharding(mesh, P(axis_name))
+    data = jax.make_array_from_process_local_data(
+        data_sharding,
+        local_packed_data,
+        global_shape=(comm.Get_size() * max_nnz,),
+    )
+    return ShardedMatrix(
+        A_bcsr,
+        data,
+        local_packed_data,
+        comm,
+        mesh,
+        axis_name,
+        partition_info,
+        max_local_size,
+    )
+
+
+def make_sharded_matrix(
+    A_local: MatrixOrOperator,
+    b: jax.Array,
+    *,
+    comm: Comm | None = None,
+    mesh: Mesh | None = None,
+    axis_name: str = "rank",
+) -> ShardedMatrix:
+    """Create a distributed CSR container without replicating the global matrix.
+
+    The CSR column indices and row pointers remain rank-local static structure.
+    Matrix values are packed into a global JAX array sharded over the same mesh
+    axis as ``b``. Unequal local nonzero counts are padded to the largest count;
+    the padding is ignored by solves and gradients.
+
+    Args:
+        A_local: This process's CSR row partition with shape
+            ``(n_local, n_global)`` and global column indices.
+        b: Global row-sharded RHS used to validate the matrix partition, mesh,
+            and numerical dtype.
+        comm: MPI communicator whose rank order matches the JAX process order.
+            Defaults to ``MPI.COMM_WORLD``.
+        mesh: One-dimensional JAX device mesh. If omitted, use the mesh from
+            ``b.sharding``.
+        axis_name: Name of the mesh axis that partitions rows and packed values.
+
+    Returns:
+        A :class:`ShardedMatrix` whose ``data`` attribute contains the global
+        sharded values. The original global matrix is never materialized.
+    """
+    _require_shard_map()
+    if not isinstance(b, jax.Array):
+        raise TypeError("b must be a global jax.Array")
+    comm = _resolve_comm(comm)
+    mesh = _resolve_mesh(b, mesh, axis_name)
+    _validate_runtime(comm, mesh, axis_name)
+
+    matrix_shape = getattr(A_local, "shape", None)
+    if matrix_shape is None or len(matrix_shape) != 2:
+        raise ValueError("A_local must have a two-dimensional shape")
+    n_local = int(matrix_shape[0])
+    nglobal = int(matrix_shape[1])
+    partition_info, max_local_size = _local_partition(
+        b, mesh, axis_name, comm, n_local, nglobal
+    )
+    A_bcsr = _normalize_local_matrix(A_local, b, partition_info)
+    return _pack_sharded_matrix(
+        A_bcsr,
+        comm,
+        mesh,
+        axis_name,
+        partition_info,
+        max_local_size,
+    )
+
+
 def _validate_operand(
     value: jax.Array,
     template: jax.Array,
@@ -345,9 +489,7 @@ def _validate_operand(
         if sharding.mesh != mesh or sharding.spec != _row_partition_spec(
             value.ndim, axis_name
         ):
-            raise ValueError(
-                f"{name} must use the same NamedSharding as the template RHS"
-            )
+            raise ValueError(f"{name} must use the same NamedSharding as its template")
 
 
 def _transpose_distributed_matrix(
@@ -437,7 +579,7 @@ def _transpose_distributed_matrix(
 
 
 def make_sharded_solver(
-    A_local: MatrixOrOperator,
+    A_local: MatrixOrOperator | ShardedMatrix,
     b: jax.Array,
     *,
     comm: Comm | None = None,
@@ -465,7 +607,8 @@ def make_sharded_solver(
 
     Args:
         A_local: Local row partition with shape ``(n_local, n_global)`` and
-            global column indices.
+            global column indices, or a :class:`ShardedMatrix` created with
+            :func:`make_sharded_matrix`.
         b: Global JAX array with shape ``(n_global,)`` or
             ``(n_global, nrhs)`` using row ``NamedSharding``. For unequal row
             counts, construct it with :func:`make_sharded_vector`; physical
@@ -500,11 +643,17 @@ def make_sharded_solver(
     _require_shard_map()
     if not isinstance(b, jax.Array):
         raise TypeError("b must be a global jax.Array")
+    if isinstance(A_local, ShardedMatrix) and comm is None:
+        comm = A_local._comm
     comm = _resolve_comm(comm)
     mesh = _resolve_mesh(b, mesh, axis_name)
     _validate_runtime(comm, mesh, axis_name)
 
-    matrix_shape = getattr(A_local, "shape", None)
+    matrix_shape = (
+        A_local.local_shape
+        if isinstance(A_local, ShardedMatrix)
+        else getattr(A_local, "shape", None)
+    )
     if matrix_shape is None or len(matrix_shape) != 2:
         raise ValueError("A_local must have a two-dimensional shape")
     n_local = int(matrix_shape[0])
@@ -514,12 +663,39 @@ def make_sharded_solver(
     )
 
     block_dim = int(block_dim)
-    _validate_matrix(A_local, nglobal, partition_info, block_dim)
-
     is_batched = b.ndim == 2
     local_rhs = b.addressable_shards[0].data[:n_local]
     matrix_probe_rhs = local_rhs[:, 0] if is_batched else local_rhs
-    A_bcsr = to_bcsr_matrix(A_local, b=matrix_probe_rhs, use_int64_indices=True)
+    sharded_matrix: ShardedMatrix | None
+    if isinstance(A_local, ShardedMatrix):
+        sharded_matrix = A_local
+        if sharded_matrix.mesh != mesh or sharded_matrix.axis_name != axis_name:
+            raise ValueError(
+                "the sharded matrix and RHS must use the same mesh and axis name"
+            )
+        if (
+            sharded_matrix.partition_info != partition_info
+            or sharded_matrix.max_local_size != max_n_local
+        ):
+            raise ValueError(
+                "the sharded matrix partition does not match the current RHS"
+            )
+        normalized_matrix = to_bcsr_matrix(
+            sharded_matrix._local_bcsr,
+            b=matrix_probe_rhs,
+            use_int64_indices=True,
+        )
+        if normalized_matrix.data.dtype != sharded_matrix.data.dtype:
+            raise ValueError(
+                "the sharded matrix dtype is incompatible with b; rebuild it "
+                "with make_sharded_matrix(A_local, b)"
+            )
+        A_bcsr = sharded_matrix._local_bcsr
+    else:
+        sharded_matrix = None
+        A_bcsr = _normalize_local_matrix(A_local, b, partition_info)
+
+    _validate_matrix(A_bcsr, nglobal, partition_info, block_dim)
     mpi_cache = cache_mpi_metadata(
         config or {},
         comm,
@@ -538,16 +714,24 @@ def make_sharded_solver(
 
     rhs_spec = _row_partition_spec(b.ndim, axis_name)
     A_data_spec = P(axis_name)
-    A_data_sharding = NamedSharding(mesh, A_data_spec)
-    local_nnz = int(A_bcsr.data.shape[0])
     max_nnz = int(mpi_cache["max_nnz"])
-    local_packed_data = np.zeros(max_nnz, dtype=np.asarray(A_bcsr.data).dtype)
-    local_packed_data[:local_nnz] = np.asarray(A_bcsr.data)
-    A_data = jax.make_array_from_process_local_data(
-        A_data_sharding,
-        local_packed_data,
-        global_shape=(comm.Get_size() * max_nnz,),
-    )
+    if sharded_matrix is None:
+        sharded_matrix = _pack_sharded_matrix(
+            A_bcsr,
+            comm,
+            mesh,
+            axis_name,
+            partition_info,
+            max_n_local,
+            max_nnz=max_nnz,
+        )
+    elif max_nnz != sharded_matrix.max_local_nnz:
+        raise RuntimeError(
+            "matrix packing and MPI cache disagree about the maximum local nnz"
+        )
+    local_nnz = sharded_matrix.local_nnz
+    local_packed_data = sharded_matrix._local_packed_data
+    A_data = sharded_matrix.data
 
     if is_symmetric:
         A_transpose = None
@@ -902,13 +1086,6 @@ def make_sharded_solver(
         _validate_operand(x0, b, mesh, axis_name, "x0")
         return differentiated_solve_x0(matrix_data, rhs, x0)
 
-    def unpad_matrix_gradient(gradient: jax.Array) -> jsp.BCSR:
-        _validate_operand(gradient, A_data, mesh, axis_name, "A_data gradient")
-        local_gradient = gradient.addressable_shards[0].data[:local_nnz]
-        return jsp.BCSR(
-            (local_gradient, A_bcsr.indices, A_bcsr.indptr), shape=A_bcsr.shape
-        )
-
     def unpad_local_vector(value: jax.Array) -> jax.Array:
         _validate_operand(value, b, mesh, axis_name, "solver vector")
         return value.addressable_shards[0].data[:n_local]
@@ -923,8 +1100,7 @@ def make_sharded_solver(
 
     return ShardedSolve(
         solve_fn,
-        A_data,
-        unpad_matrix_gradient,
+        sharded_matrix,
         unpad_local_vector,
         nglobal,
         n_local,
@@ -932,7 +1108,7 @@ def make_sharded_solver(
 
 
 def solve_sharded(
-    A_local: MatrixOrOperator,
+    A_local: MatrixOrOperator | ShardedMatrix,
     b: jax.Array,
     x0: jax.Array | None = None,
     *,

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -248,8 +248,8 @@ def make_sharded_vector(
 
     Args:
         local_values: This rank's unpadded values with shape ``(n_local,)``.
-        comm: MPI communicator whose rank order matches ``mesh``. Defaults to
-            ``MPI.COMM_WORLD``.
+        comm: MPI communicator spanning every JAX process, with rank order
+            matching ``mesh``. Defaults to ``MPI.COMM_WORLD``.
         mesh: One-dimensional JAX device mesh with one device per MPI rank.
             Defaults to a mesh over the first ``comm.size`` JAX devices (all
             devices in a typical multi-process job).
@@ -601,8 +601,8 @@ def make_sharded_matrix(
             and sparsity pattern are known; it is materialized once here.
         b: Global row-sharded RHS used to validate the matrix partition, mesh,
             and numerical dtype.
-        comm: MPI communicator whose rank order matches the JAX process order.
-            Defaults to ``MPI.COMM_WORLD``.
+        comm: MPI communicator spanning every JAX process, with rank order
+            matching the JAX process order. Defaults to ``MPI.COMM_WORLD``.
         mesh: One-dimensional JAX device mesh. If omitted, use the mesh from
             ``b.sharding``.
         axis_name: Name of the mesh axis that partitions rows and packed values.
@@ -680,9 +680,10 @@ def make_sharded_solver(
 
     This interface complements, rather than replaces, ``solve(..., comm=...)``.
     JAX manages the global input and output arrays through ``shard_map`` while
-    the AmgX solve itself uses the supplied MPI communicator. Version one uses
-    a one-dimensional mesh and requires one MPI process with one mesh-local GPU
-    per rank.
+    the AmgX solve itself uses the supplied MPI communicator. The interface is
+    experimental; it uses a one-dimensional mesh and requires one MPI process
+    with one mesh-local GPU per rank and a communicator spanning every JAX
+    process.
 
     ``jax.distributed.initialize()`` must be called before this function in a
     multi-process job. The matrix owns the communicator, mesh, local CSR

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -38,6 +38,50 @@ from .utils import (
 if TYPE_CHECKING:
     from mpi4py.MPI import Comm
 
+# Private API; tells whether XLA_FLAGS can still take effect.
+try:
+    from jax._src.xla_bridge import (
+        backends_are_initialized as _backends_are_initialized,
+    )
+except Exception:  # pragma: no cover - exercised only if the private API moves
+
+    def _backends_are_initialized() -> bool:
+        return False
+
+
+def _disable_shard_autotuning() -> bool:
+    """Disable XLA's cross-process sharded autotuning; return whether it is off.
+
+    That autotuning assumes every process compiles the identical program, but
+    a sharded solve compiles rank-local structure into each process's program
+    and deadlocks under it. Disabling it only affects compile time. XLA reads
+    ``XLA_FLAGS`` when its backend initializes, so an explicit setting is
+    respected and a late import cannot take effect.
+    """
+    flags = os.environ.get("XLA_FLAGS", "")
+    if "xla_gpu_shard_autotuning" in flags:
+        return "xla_gpu_shard_autotuning=false" in flags.lower()
+    if _backends_are_initialized():
+        return False
+    os.environ["XLA_FLAGS"] = f"{flags} --xla_gpu_shard_autotuning=false".strip()
+    return True
+
+
+_SHARD_AUTOTUNING_DISABLED = _disable_shard_autotuning()
+
+
+def _check_shard_autotuning() -> None:
+    if jax.process_count() > 1 and not _SHARD_AUTOTUNING_DISABLED:
+        warnings.warn(
+            "XLA's sharded autotuning is enabled, so compiling a multi-process "
+            "sharded solve will deadlock. Import jaxamg before the first JAX "
+            "device call, set XLA_FLAGS=--xla_gpu_shard_autotuning=false, or "
+            "pass compiler_options={'xla_gpu_shard_autotuning': False} to the "
+            "outer jax.jit.",
+            stacklevel=3,
+        )
+
+
 ShardedInfo = dict[str, jax.Array]
 
 
@@ -634,16 +678,10 @@ def make_sharded_solver(
     ``solver(..., A=A.data)`` to differentiate matrix values. Use
     ``jax.set_mesh(A.mesh)`` around outer transforms such as ``jax.grad``.
 
-    .. warning::
-        The rank-local CSR structure and communication plans are compiled into
-        each process's program as constants, so the processes compile programs
-        that differ. XLA's cross-process sharded autotuning assumes identical
-        programs and deadlocks during compilation when such a program also
-        contains an automatically partitioned collective -- which is what
-        ``jnp.sum(x)`` over a sharded solution inside ``jax.jit`` produces. Run
-        multi-process sharded jobs with ``XLA_FLAGS=--xla_gpu_shard_autotuning=false``
-        (set before JAX initializes its backend) to disable that autotuning;
-        see :doc:`sharding` for details.
+    .. note::
+        Importing jaxamg disables XLA's cross-process sharded autotuning,
+        which deadlocks on the per-process programs a sharded solve compiles
+        to. Import it before the first JAX device call; see :doc:`sharding`.
 
     Args:
         A: Distributed matrix created with :func:`make_sharded_matrix`.
@@ -681,6 +719,7 @@ def make_sharded_solver(
     mesh = A.mesh
     axis_name = A.axis_name
     _validate_runtime(comm, mesh, axis_name)
+    _check_shard_autotuning()
 
     n_local = A.local_size
     nglobal = A.global_size

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -7,6 +7,8 @@ to use one MPI rank per GPU for the distributed solve.
 
 from __future__ import annotations
 
+import os
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -18,7 +20,7 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from .cache import _build_mpi_cache, with_cache
-from .jaxamg import solve
+from .jaxamg import _capture_and_save_stats, solve
 from .mpi_utils import (
     HaloPlan,
     _apply_transpose_plan,
@@ -114,7 +116,13 @@ class ShardedMatrix:
         self.local_shape = tuple(local_bcsr.shape)
 
     def local_matrix(self, data: jax.Array | None = None) -> jsp.BCSR:
-        """Return this rank's unpadded BCSR matrix for ``data`` or cached values."""
+        """Return this rank's unpadded BCSR matrix for ``data`` or cached values.
+
+        This is an eager helper: it reads the addressable shard of the packed
+        values (typically to unpack a computed matrix gradient), so it cannot
+        be applied to traced values inside ``jax.jit`` or another JAX
+        transformation.
+        """
         values = self.data if data is None else data
         _validate_operand(values, self.data, self.mesh, self.axis_name, "matrix data")
         local_values = values.addressable_shards[0].data[: self.local_nnz]
@@ -145,16 +153,25 @@ class ShardedSolve:
         x0: jax.Array | None = None,
         *,
         A_data: jax.Array | None = None,
+        save_stats_file: str | os.PathLike | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
         """Solve with cached values or an explicit differentiable ``A_data``.
 
         ``A_data`` may be omitted for a direct call but is required inside a
         JAX transformation so matrix values remain a dynamic operand.
+        ``save_stats_file`` writes formatted AmgX statistics after a direct
+        call (rank 0 writes the file); the solver must have been created with
+        ``save_stats=True`` for the file to contain solver statistics.
         """
-        return self._solve_fn(b, x0, A_data=A_data)
+        return self._solve_fn(b, x0, A_data=A_data, save_stats_file=save_stats_file)
 
     def local_vector(self, value: jax.Array) -> jax.Array:
-        """Return this rank's unpadded rows of a solver vector."""
+        """Return this rank's unpadded rows of a solver vector.
+
+        This is an eager helper: it reads the vector's addressable shard, so
+        it cannot be applied to traced values inside ``jax.jit`` or another
+        JAX transformation.
+        """
         return self._local_vector_fn(value)
 
 
@@ -553,6 +570,7 @@ def make_sharded_solver(
     is_symmetric: bool = False,
     block_dim: int = 1,
     reuse_setup: bool = False,
+    save_stats: bool = False,
 ) -> ShardedSolve:
     """Create a JIT-compiled solver for a globally sharded RHS.
 
@@ -581,9 +599,13 @@ def make_sharded_solver(
             this value.
         reuse_setup: Reuse the cached AmgX hierarchy across solves with the
             same sparsity pattern.
+        save_stats: Prepare the AmgX configuration with solver-statistics
+            output enabled so a later direct call with
+            ``solver(..., save_stats_file=...)`` produces a complete stats
+            file.
 
     Returns:
-        A callable ``solver(b, x0=None, *, A_data=None)``. Use
+        A callable ``solver(b, x0=None, *, A_data=None, save_stats_file=None)``. Use
         ``A.local_matrix(gradient)`` to convert packed matrix gradients to this
         rank's unpadded BCSR structure. ``solver.local_vector(value)`` removes
         vector padding. ``A_data`` may be omitted for a direct call but must be
@@ -678,6 +700,7 @@ def make_sharded_solver(
         max_nnz,
         nnz_out,
         halo_plan,
+        save_stats=save_stats,
         block_dim=block_dim,
         lrank=int(local_hardware_id),
         device=local_device,
@@ -736,6 +759,10 @@ def make_sharded_solver(
             x0=None if x0_local is None else x0_local[:n_local],
             block_dim=block_dim,
             reuse_setup=reuse_setup,
+            # Under the shard_map trace this only enables stats capture in the
+            # FFI call; solve() never writes a file for traced results. The
+            # actual file is written by ``sharded_solver`` after execution.
+            save_stats_file=os.devnull if save_stats else None,
         )
 
     def local_solve(
@@ -953,6 +980,7 @@ def make_sharded_solver(
         x0: jax.Array | None = None,
         *,
         A_data_override: jax.Array | None = None,
+        save_stats_file: str | os.PathLike | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
         _validate_operand(rhs, b, mesh, axis_name, "b")
         if A_data_override is None:
@@ -965,10 +993,34 @@ def make_sharded_solver(
         else:
             matrix_data = A_data_override
         _validate_operand(matrix_data, A_data, mesh, axis_name, "A_data")
+        if save_stats_file is not None:
+            if any(
+                isinstance(operand, jax.core.Tracer)
+                for operand in (matrix_data, rhs, x0)
+            ):
+                raise ValueError(
+                    "save_stats_file requires a direct solver call outside "
+                    "jax.jit, jax.grad, and other JAX transforms"
+                )
+            if not save_stats:
+                warnings.warn(
+                    "save_stats_file was passed, but the solver was created "
+                    "without stats output; the stats file will be missing "
+                    "solver statistics. Pass save_stats=True to "
+                    "make_sharded_solver().",
+                    stacklevel=4,
+                )
         if x0 is None:
-            return differentiated_solve(matrix_data, rhs)
-        _validate_operand(x0, b, mesh, axis_name, "x0")
-        return differentiated_solve_x0(matrix_data, rhs, x0)
+            result = differentiated_solve(matrix_data, rhs)
+        else:
+            _validate_operand(x0, b, mesh, axis_name, "x0")
+            result = differentiated_solve_x0(matrix_data, rhs, x0)
+        if save_stats_file is not None:
+            # Statistics are captured during execution, so wait for the solve
+            # to finish before reading them back from the extension.
+            result[0].block_until_ready()
+            _capture_and_save_stats(save_stats_file, comm=comm)
+        return result
 
     def unpad_local_vector(value: jax.Array) -> jax.Array:
         _validate_operand(value, b, mesh, axis_name, "solver vector")
@@ -979,8 +1031,11 @@ def make_sharded_solver(
         x0: jax.Array | None = None,
         *,
         A_data: jax.Array | None = None,
+        save_stats_file: str | os.PathLike | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
-        return sharded_solver(rhs, x0, A_data_override=A_data)
+        return sharded_solver(
+            rhs, x0, A_data_override=A_data, save_stats_file=save_stats_file
+        )
 
     return ShardedSolve(
         solve_fn,

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -75,7 +75,7 @@ def _resolve_comm(comm: Comm | None) -> Comm:
 
 
 class ShardedMatrix:
-    """Distributed CSR matrix with local structure and sharded values."""
+    """Distributed CSR matrix created by :func:`make_sharded_matrix`."""
 
     def __init__(
         self,
@@ -128,7 +128,7 @@ class ShardedMatrix:
 
 
 class ShardedSolve:
-    """Callable sharded solver with differentiable packed matrix values."""
+    """Callable sharded solver created by :func:`make_sharded_solver`."""
 
     def __init__(
         self,
@@ -567,10 +567,8 @@ def make_sharded_solver(
 
     Args:
         A: Distributed matrix created with :func:`make_sharded_matrix`.
-        b: Global JAX array with shape ``(n_global,)`` using row
-            ``NamedSharding``. For unequal row counts, construct it with
-            :func:`make_sharded_vector`; physical shards are padded to the
-            largest local partition.
+        b: Global row-sharded JAX vector. Construct it with
+            :func:`make_sharded_vector`, which handles unequal row counts.
         config: AmgX configuration. Defaults to the JAX-AMG MPI configuration.
         is_symmetric: Whether the global matrix is symmetric. When ``False``
             (the default), the distributed transpose is prepared once during

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -1156,7 +1156,11 @@ def make_sharded_solver(
     local_mesh = _local_mesh(mesh, axis_name)
 
     def local_shard(value: jax.Array) -> jax.Array:
-        return value.addressable_shards[0].data
+        # Typed as replicated on the one-device mesh (no copy): JAX 0.11
+        # rejects gathers on an untyped shard under jax.set_mesh.
+        return jax.device_put(
+            value.addressable_shards[0].data, NamedSharding(local_mesh, P())
+        )
 
     def assemble_global(local_value: jax.Array) -> jax.Array:
         spec = P(axis_name, *(None,) * (local_value.ndim - 1))

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -8,7 +8,7 @@ to use one MPI rank per GPU for the distributed solve.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import jax
 import jax.experimental.sparse as jsp
@@ -25,6 +25,24 @@ if TYPE_CHECKING:
     from mpi4py.MPI import Comm
 
 ShardedInfo = dict[str, jax.Array]
+
+
+class _CSRStructure(NamedTuple):
+    """Rank-local CSR structure without an otherwise unused values buffer."""
+
+    indices: jax.Array
+    indptr: jax.Array
+    shape: tuple[int, int]
+    nnz: int
+
+
+class _TransposeValuePlan(NamedTuple):
+    """Static sparse exchange plan for values of a distributed transpose."""
+
+    local_source_ids: np.ndarray
+    local_target_ids: np.ndarray
+    send_ids_2d: np.ndarray
+    recv_target_ids_2d: np.ndarray
 
 
 def _resolve_comm(comm: Comm | None) -> Comm:
@@ -53,15 +71,26 @@ class ShardedMatrix:
         self,
         local_bcsr: jsp.BCSR,
         data: jax.Array,
-        local_packed_data: jax.Array,
         comm: Comm,
         mesh: Mesh,
         axis_name: str,
         partition_info: tuple[int, int],
         max_local_size: int,
     ) -> None:
-        self._local_bcsr = local_bcsr
-        self._local_packed_data = local_packed_data
+        local_device = mesh.local_devices[0]
+        local_nnz = int(local_bcsr.data.shape[0])
+        local_values = data.addressable_shards[0].data[:local_nnz]
+        # Keep only one local matrix-value buffer. In particular, an uneven
+        # partition must not retain both the original unpadded values and the
+        # padded shard used by ``data``.
+        self._local_bcsr = jsp.BCSR(
+            (
+                local_values,
+                jax.device_put(local_bcsr.indices, local_device),
+                jax.device_put(local_bcsr.indptr, local_device),
+            ),
+            shape=local_bcsr.shape,
+        )
         self._comm = comm
         self.mesh = mesh
         self.axis_name = axis_name
@@ -70,8 +99,8 @@ class ShardedMatrix:
         self.data = data
         self.global_size = int(local_bcsr.shape[1])
         self.local_size = int(local_bcsr.shape[0])
-        self.local_nnz = int(local_bcsr.data.shape[0])
-        self.max_local_nnz = int(local_packed_data.shape[0])
+        self.local_nnz = local_nnz
+        self.max_local_nnz = int(data.addressable_shards[0].data.shape[0])
         self.shape = (self.global_size, self.global_size)
         self.local_shape = tuple(local_bcsr.shape)
 
@@ -108,7 +137,11 @@ class ShardedSolve:
         *,
         A_data: jax.Array | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
-        """Solve with the cached values or a differentiable ``A_data`` operand."""
+        """Solve with cached values or an explicit differentiable ``A_data``.
+
+        ``A_data`` may be omitted for a direct call but is required inside a
+        JAX transformation so matrix values remain a dynamic operand.
+        """
         return self._solve_fn(b, x0, A_data=A_data)
 
     def local_vector(self, value: jax.Array) -> jax.Array:
@@ -424,7 +457,6 @@ def _pack_sharded_matrix(
     return ShardedMatrix(
         A_bcsr,
         data,
-        local_packed_data,
         comm,
         mesh,
         axis_name,
@@ -516,10 +548,10 @@ def _transpose_distributed_matrix(
     A: jsp.BCSR,
     recvcounts: tuple[int, ...],
     partition_info: tuple[int, int],
-    max_nnz: int,
     comm: Comm,
-) -> tuple[jsp.BCSR, np.ndarray]:
-    """Transpose fixed CSR structure and return its packed value-source map."""
+    local_device: jax.Device,
+) -> tuple[jsp.BCSR, _TransposeValuePlan]:
+    """Transpose fixed CSR structure and build a sparse value-exchange plan."""
     from mpi4py import MPI
 
     row_start, row_end = partition_info
@@ -548,12 +580,10 @@ def _transpose_distributed_matrix(
 
     send_rows = np.ascontiguousarray(indices[send_order])
     send_cols = np.ascontiguousarray(source_rows[send_order])
-    packed_ids = comm.Get_rank() * max_nnz + np.arange(len(indices), dtype=np.int64)
-    send_ids = np.ascontiguousarray(packed_ids[send_order])
+    send_ids = np.ascontiguousarray(np.arange(len(indices), dtype=np.int64)[send_order])
     recv_nnz = int(recv_counts.sum())
     recv_rows = np.empty(recv_nnz, dtype=np.int64)
     recv_cols = np.empty(recv_nnz, dtype=np.int64)
-    recv_ids = np.empty(recv_nnz, dtype=np.int64)
     comm.Alltoallv(
         [send_rows, send_counts, send_displs, MPI.INT64_T],
         [recv_rows, recv_counts, recv_displs, MPI.INT64_T],
@@ -562,31 +592,72 @@ def _transpose_distributed_matrix(
         [send_cols, send_counts, send_displs, MPI.INT64_T],
         [recv_cols, recv_counts, recv_displs, MPI.INT64_T],
     )
-    comm.Alltoallv(
-        [send_ids, send_counts, send_displs, MPI.INT64_T],
-        [recv_ids, recv_counts, recv_displs, MPI.INT64_T],
-    )
-
     local_rows = recv_rows - row_start
     order = np.lexsort((recv_cols, local_rows))
     local_rows = local_rows[order]
     recv_cols = recv_cols[order]
-    recv_ids = recv_ids[order]
     row_counts = np.bincount(local_rows, minlength=n_local)
     transpose_indptr = np.concatenate(([0], np.cumsum(row_counts))).astype(np.int32)
 
+    # The dynamic transpose communicates only off-rank values. Entries whose
+    # transpose rows remain on this rank are gathered locally, so the padded
+    # all-to-all chunk is governed by the largest remote rank pair rather than
+    # by the (usually much larger) on-rank diagonal block.
+    rank = comm.Get_rank()
+    remote_send_counts = send_counts.copy()
+    remote_recv_counts = recv_counts.copy()
+    remote_send_counts[rank] = 0
+    remote_recv_counts[rank] = 0
+    local_pair_max = int(max(remote_send_counts.max(), remote_recv_counts.max()))
+    max_per_rank = max(int(comm.allreduce(local_pair_max, op=MPI.MAX)), 1)
+
+    send_ids_2d = np.zeros((nranks, max_per_rank), dtype=np.int32)
+    recv_target_ids_2d = np.full((nranks, max_per_rank), recv_nnz, dtype=np.int32)
+    inverse_order = np.empty(recv_nnz, dtype=np.int32)
+    inverse_order[order] = np.arange(recv_nnz, dtype=np.int32)
+    for peer in range(nranks):
+        if peer == rank:
+            continue
+        send_count = int(send_counts[peer])
+        if send_count:
+            start = int(send_displs[peer])
+            send_ids_2d[peer, :send_count] = send_ids[start : start + send_count]
+        recv_count = int(recv_counts[peer])
+        if recv_count:
+            start = int(recv_displs[peer])
+            recv_target_ids_2d[peer, :recv_count] = inverse_order[
+                start : start + recv_count
+            ]
+
+    local_send_start = int(send_displs[rank])
+    local_recv_start = int(recv_displs[rank])
+    local_count = int(send_counts[rank])
+    local_source_ids = send_ids[
+        local_send_start : local_send_start + local_count
+    ].astype(np.int32)
+    local_target_ids = inverse_order[local_recv_start : local_recv_start + local_count]
+
     with temp_enable_x64():
-        transpose_data = jnp.zeros(recv_nnz, dtype=A.data.dtype)
-        transpose_indices = jnp.asarray(recv_cols, dtype=jnp.int64)
+        transpose_data = jax.device_put(
+            np.zeros(recv_nnz, dtype=np.dtype(A.data.dtype)), local_device
+        )
+        transpose_indices = jax.device_put(
+            np.asarray(recv_cols, dtype=np.int64), local_device
+        )
         transpose = jsp.BCSR(
             (
                 transpose_data,
                 transpose_indices,
-                jnp.asarray(transpose_indptr),
+                jax.device_put(transpose_indptr, local_device),
             ),
             shape=(n_local, n_global),
         )
-    return transpose, recv_ids
+    return transpose, _TransposeValuePlan(
+        local_source_ids,
+        local_target_ids,
+        send_ids_2d,
+        recv_target_ids_2d,
+    )
 
 
 def make_sharded_solver(
@@ -633,9 +704,11 @@ def make_sharded_solver(
         A callable ``solver(b, x0=None, *, A_data=None)``. Use
         ``A.local_matrix(gradient)`` to convert packed matrix gradients to this
         rank's unpadded BCSR structure. ``solver.local_vector(value)`` removes
-        vector padding. For a vector RHS, info values have one entry per rank.
-        For a batched RHS they have shape ``(nranks, nrhs)`` and
-        ``residual_history`` has an additional trailing ``max_iters + 1`` axis.
+        vector padding. ``A_data`` may be omitted for a direct call but must be
+        explicit under ``jax.jit``, ``jax.grad``, or another JAX transform. For
+        a vector RHS, info values have one entry per rank. For a batched RHS
+        they have shape ``(nranks, nrhs)`` and ``residual_history`` has an
+        additional trailing ``max_iters + 1`` axis.
     """
     _require_shard_map()
     if not isinstance(A, ShardedMatrix):
@@ -694,20 +767,29 @@ def make_sharded_solver(
             "matrix packing and MPI cache disagree about the maximum local nnz"
         )
     local_nnz = A.local_nnz
-    local_packed_data = A._local_packed_data
     A_data = A.data
+    A_structure = _CSRStructure(
+        A_bcsr.indices,
+        A_bcsr.indptr,
+        tuple(A_bcsr.shape),
+        local_nnz,
+    )
 
     if is_symmetric:
-        A_transpose = None
+        transpose_structure = None
         transpose_cache = None
-        transpose_source_ids = None
+        max_transpose_nnz = None
+        transpose_local_source_ids = None
+        transpose_local_target_ids = None
+        transpose_send_ids = None
+        transpose_recv_target_ids = None
     else:
-        A_transpose, source_ids = _transpose_distributed_matrix(
+        A_transpose, transpose_plan = _transpose_distributed_matrix(
             A_bcsr,
             mpi_cache["recvcounts_tuple"],
             partition_info,
-            max_nnz,
             comm,
+            local_device,
         )
         transpose_cache = cache_mpi_metadata(
             config or {},
@@ -719,7 +801,26 @@ def make_sharded_solver(
             block_dim=block_dim,
         )
         transpose_cache["lrank"] = int(local_hardware_id)
-        transpose_source_ids = jnp.asarray(source_ids, dtype=jnp.int32)
+        transpose_structure = _CSRStructure(
+            A_transpose.indices,
+            A_transpose.indptr,
+            tuple(A_transpose.shape),
+            int(A_transpose.data.shape[0]),
+        )
+        max_transpose_nnz = int(transpose_cache["max_nnz"])
+        # Explicit single-device placement keeps rank-local constants local even
+        # when solver construction happens inside a global ``jax.set_mesh``
+        # context.
+        transpose_local_source_ids = jax.device_put(
+            transpose_plan.local_source_ids, local_device
+        )
+        transpose_local_target_ids = jax.device_put(
+            transpose_plan.local_target_ids, local_device
+        )
+        transpose_send_ids = jax.device_put(transpose_plan.send_ids_2d, local_device)
+        transpose_recv_target_ids = jax.device_put(
+            transpose_plan.recv_target_ids_2d, local_device
+        )
 
     if is_batched:
         info_specs = {
@@ -753,13 +854,17 @@ def make_sharded_solver(
 
     def matrix_with_data(
         data_local: jax.Array,
-        template: jsp.BCSR,
+        structure: _CSRStructure,
         cache: dict[str, Any],
         symmetric: bool,
     ) -> jsp.BCSR:
         matrix = jsp.BCSR(
-            (data_local[: template.data.shape[0]], template.indices, template.indptr),
-            shape=template.shape,
+            (
+                data_local[: structure.nnz],
+                structure.indices,
+                structure.indptr,
+            ),
+            shape=structure.shape,
         )
         return with_cache(matrix, mpi=cache, is_symmetric=symmetric)
 
@@ -771,13 +876,15 @@ def make_sharded_solver(
         A_dynamic: jsp.BCSR,
         rhs_local: jax.Array,
         x0_local: jax.Array | None = None,
+        *,
+        reuse: bool = reuse_setup,
     ) -> tuple[jax.Array, ShardedInfo]:
         return solve(
             A_dynamic,
             rhs_local[:n_local],
             x0=None if x0_local is None else x0_local[:n_local],
             block_dim=block_dim,
-            reuse_setup=reuse_setup,
+            reuse_setup=reuse,
         )
 
     def solve_local_rhs(
@@ -809,6 +916,10 @@ def make_sharded_solver(
                 A_dynamic,
                 rhs_column,
                 x0_column,
+                # All columns use identical matrix values. Once the first
+                # column has prepared the hierarchy, resetting it again is
+                # unnecessary even when cross-call reuse was not requested.
+                reuse=reuse_setup or column > 0,
             )
             solutions.append(solution)
             column_info.append(info)
@@ -819,33 +930,65 @@ def make_sharded_solver(
     def local_solve(
         A_data_local: jax.Array, rhs_local: jax.Array
     ) -> tuple[jax.Array, ShardedInfo]:
-        A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
+        A_dynamic = matrix_with_data(A_data_local, A_structure, mpi_cache, is_symmetric)
         x_local, info = solve_local_rhs(A_dynamic, rhs_local)
         return pad_local_vector(x_local), pack_info(info)
 
     def local_solve_x0(
         A_data_local: jax.Array, rhs_local: jax.Array, x0_local: jax.Array
     ) -> tuple[jax.Array, ShardedInfo]:
-        A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
+        A_dynamic = matrix_with_data(A_data_local, A_structure, mpi_cache, is_symmetric)
         x_local, info = solve_local_rhs(A_dynamic, rhs_local, x0_local)
         return pad_local_vector(x_local), pack_info(info)
 
-    def local_adjoint(A_data_local: jax.Array, g_local: jax.Array) -> jax.Array:
-        if is_symmetric:
+    def local_transpose_values(A_data_local: jax.Array) -> jax.Array:
+        assert transpose_structure is not None
+        assert max_transpose_nnz is not None
+        assert transpose_local_source_ids is not None
+        assert transpose_local_target_ids is not None
+        assert transpose_send_ids is not None
+        assert transpose_recv_target_ids is not None
+
+        transpose_values = jnp.zeros(
+            transpose_structure.nnz + 1, dtype=A_data_local.dtype
+        )
+        transpose_values = transpose_values.at[transpose_local_target_ids].set(
+            A_data_local[transpose_local_source_ids]
+        )
+        send_buffer = A_data_local[transpose_send_ids]
+        recv_buffer = jax.lax.all_to_all(
+            send_buffer,
+            axis_name,
+            split_axis=0,
+            concat_axis=0,
+        )
+        transpose_values = transpose_values.at[
+            transpose_recv_target_ids.reshape(-1)
+        ].set(recv_buffer.reshape(-1))
+        return jnp.pad(
+            transpose_values[:-1],
+            (0, max_transpose_nnz - transpose_structure.nnz),
+        )
+
+    def make_local_adjoint(reuse: bool):
+        def local_adjoint(
+            adjoint_data_local: jax.Array, g_local: jax.Array
+        ) -> jax.Array:
+            if is_symmetric:
+                structure = A_structure
+                cache = mpi_cache
+            else:
+                assert transpose_structure is not None
+                assert transpose_cache is not None
+                structure = transpose_structure
+                cache = transpose_cache
             A_adjoint = matrix_with_data(
-                A_data_local, A_bcsr, mpi_cache, symmetric=True
+                adjoint_data_local, structure, cache, symmetric=is_symmetric
             )
-        else:
-            assert A_transpose is not None
-            assert transpose_cache is not None
-            assert transpose_source_ids is not None
-            all_A_data = jax.lax.all_gather(A_data_local, axis_name, axis=0, tiled=True)
-            transpose_data = all_A_data[transpose_source_ids]
-            A_adjoint = matrix_with_data(
-                transpose_data, A_transpose, transpose_cache, symmetric=False
-            )
-        adjoint_local, _ = solve_one_rhs(A_adjoint, g_local)
-        return adjoint_local
+            adjoint_local, _ = solve_one_rhs(A_adjoint, g_local, reuse=reuse)
+            return pad_local_vector(adjoint_local)
+
+        return local_adjoint
 
     halo_plan = mpi_cache["halo_plan"]
     max_n_ghost = max(comm.allgather(halo_plan.n_ghost))
@@ -853,21 +996,15 @@ def make_sharded_solver(
         np.arange(A_bcsr.shape[0], dtype=np.int32),
         np.diff(np.asarray(A_bcsr.indptr, dtype=np.int64)),
     )
-    padded_row_indices = np.zeros(max_nnz, dtype=np.int32)
-    padded_row_indices[:local_nnz] = local_row_indices
-    padded_col_to_combined = np.zeros(max_nnz, dtype=np.int32)
-    padded_col_to_combined[:local_nnz] = halo_plan.col_to_combined
-    local_valid_values = np.arange(max_nnz) < local_nnz
 
     # Keep rank-local halo metadata inside the shard_map bodies. Making these
     # arrays global and closing over them in the custom VJP prevents an outer
     # multi-process jax.jit from lowering because their remote shards are not
     # addressable by the current process.
-    row_indices = jnp.asarray(padded_row_indices)
-    col_to_combined = jnp.asarray(padded_col_to_combined)
-    valid_values = jnp.asarray(local_valid_values)
-    send_ids = jnp.asarray(halo_plan.send_ids_2d)
-    recv_ghost_slot = jnp.asarray(halo_plan.recv_ghost_slot_2d)
+    row_indices = jax.device_put(local_row_indices, local_device)
+    col_to_combined = jax.device_put(halo_plan.col_to_combined, local_device)
+    send_ids = jax.device_put(halo_plan.send_ids_2d, local_device)
+    recv_ghost_slot = jax.device_put(halo_plan.recv_ghost_slot_2d, local_device)
 
     def gather_solution_halo(
         x_local: jax.Array,
@@ -888,22 +1025,20 @@ def make_sharded_solver(
         )
         return jnp.concatenate([x_local, x_ghost[:max_n_ghost]], axis=0)
 
-    def local_gather_matrix_columns(x_local: jax.Array) -> jax.Array:
-        x_combined = gather_solution_halo(x_local[:n_local], send_ids, recv_ghost_slot)
-        return jnp.where(valid_values, x_combined[col_to_combined], 0)
-
-    def local_backward(
-        A_data_local: jax.Array,
-        x_at_columns: jax.Array,
-        g_local: jax.Array,
-    ) -> tuple[jax.Array, jax.Array]:
-        A_data_ordered, g_ordered, x_at_columns = jax.lax.optimization_barrier(
-            (A_data_local, g_local, x_at_columns)
+    def local_matrix_gradient(
+        x_local: jax.Array, adjoint_local: jax.Array
+    ) -> jax.Array:
+        # Order the JAX halo exchange after the preceding AmgX adjoint solve.
+        x_ordered, adjoint_ordered = jax.lax.optimization_barrier(
+            (x_local, adjoint_local)
         )
-        adjoint_local = local_adjoint(A_data_ordered, g_ordered)
-        grad_values = -adjoint_local[row_indices] * x_at_columns
-        grad_A_data_local = jnp.where(valid_values, grad_values, 0)
-        return pad_local_vector(adjoint_local), grad_A_data_local
+        x_combined = gather_solution_halo(
+            x_ordered[:n_local], send_ids, recv_ghost_slot
+        )
+        grad_values = (
+            -adjoint_ordered[:n_local][row_indices] * x_combined[col_to_combined]
+        )
+        return jnp.pad(grad_values, (0, max_nnz - local_nnz))
 
     mapped_solve = jax.jit(
         jax.shard_map(
@@ -922,33 +1057,44 @@ def make_sharded_solver(
         )
     )
 
-    def local_cached_matrix_data(rhs_local: jax.Array) -> jax.Array:
-        del rhs_local
-        return jnp.asarray(local_packed_data)
-
-    mapped_cached_matrix_data = jax.jit(
-        jax.shard_map(
-            local_cached_matrix_data,
-            mesh=mesh,
-            in_specs=(rhs_spec,),
-            out_specs=A_data_spec,
-        )
-    )
     scalar_spec = P(axis_name)
-    mapped_gather_matrix_columns = jax.jit(
+    if is_symmetric:
+        mapped_transpose_values = None
+    else:
+        mapped_transpose_values = jax.jit(
+            jax.shard_map(
+                local_transpose_values,
+                mesh=mesh,
+                in_specs=(A_data_spec,),
+                out_specs=A_data_spec,
+            )
+        )
+    mapped_adjoint = jax.jit(
         jax.shard_map(
-            local_gather_matrix_columns,
+            make_local_adjoint(reuse_setup),
             mesh=mesh,
-            in_specs=(scalar_spec,),
+            in_specs=(A_data_spec, scalar_spec),
             out_specs=scalar_spec,
         )
     )
-    mapped_backward = jax.jit(
+    mapped_adjoint_reuse = (
+        mapped_adjoint
+        if reuse_setup or not is_batched
+        else jax.jit(
+            jax.shard_map(
+                make_local_adjoint(True),
+                mesh=mesh,
+                in_specs=(A_data_spec, scalar_spec),
+                out_specs=scalar_spec,
+            )
+        )
+    )
+    mapped_matrix_gradient = jax.jit(
         jax.shard_map(
-            local_backward,
+            local_matrix_gradient,
             mesh=mesh,
-            in_specs=(A_data_spec, scalar_spec, scalar_spec),
-            out_specs=(scalar_spec, A_data_spec),
+            in_specs=(scalar_spec, scalar_spec),
+            out_specs=A_data_spec,
         )
     )
 
@@ -970,30 +1116,56 @@ def make_sharded_solver(
     def differentiated_solve_backward(
         matrix_data: jax.Array, x: jax.Array, g_x: jax.Array
     ) -> tuple[jax.Array, jax.Array]:
+        if is_symmetric:
+            adjoint_data = matrix_data
+        else:
+            assert mapped_transpose_values is not None
+            # Matrix values are identical for every RHS column, so prepare the
+            # distributed transpose exactly once per backward pass. Tie the
+            # exchange to the completed forward solution so XLA cannot overlap
+            # its JAX collective with AmgX's preceding MPI collectives.
+            matrix_data_ordered, _ = jax.lax.optimization_barrier((matrix_data, x))
+            adjoint_data = mapped_transpose_values(matrix_data_ordered)
+
         if not is_batched:
-            x_at_columns = mapped_gather_matrix_columns(x)
-            return mapped_backward(matrix_data, x_at_columns, g_x)
+            adjoint = mapped_adjoint(adjoint_data, g_x)
+            return adjoint, mapped_matrix_gradient(x, adjoint)
 
         adjoint_columns: list[jax.Array] = []
-        matrix_gradients: list[jax.Array] = []
         for column in range(x.shape[1]):
-            x_column = x[:, column]
             g_column = g_x[:, column]
-            # Preserve the same collective ordering for adjoint solves and
-            # their preceding halo exchanges.
+            # Preserve one cross-rank order for the sequential AmgX solves.
             if adjoint_columns:
-                x_column, g_column, _ = jax.lax.optimization_barrier(
-                    (x_column, g_column, adjoint_columns[-1])
+                g_column, _ = jax.lax.optimization_barrier(
+                    (g_column, adjoint_columns[-1])
                 )
-            x_at_columns = mapped_gather_matrix_columns(x_column)
-            adjoint, matrix_gradient = mapped_backward(
-                matrix_data, x_at_columns, g_column
+            adjoint = (mapped_adjoint if column == 0 else mapped_adjoint_reuse)(
+                adjoint_data,
+                g_column,
             )
             adjoint_columns.append(adjoint)
-            matrix_gradients.append(matrix_gradient)
-        return jnp.stack(adjoint_columns, axis=1), jnp.sum(
-            jnp.stack(matrix_gradients), axis=0
-        )
+
+        # Run matrix-gradient halo exchanges only after all AmgX adjoint
+        # collectives have completed. Accumulating immediately avoids an
+        # ``(nrhs, nnz)`` stack of temporary matrix gradients.
+        matrix_gradient_sum = None
+        last_adjoint = adjoint_columns[-1]
+        for column, adjoint in enumerate(adjoint_columns):
+            x_column = x[:, column]
+            order_dependency = (
+                last_adjoint if matrix_gradient_sum is None else matrix_gradient_sum
+            )
+            x_column, adjoint, _ = jax.lax.optimization_barrier(
+                (x_column, adjoint, order_dependency)
+            )
+            matrix_gradient = mapped_matrix_gradient(x_column, adjoint)
+            matrix_gradient_sum = (
+                matrix_gradient
+                if matrix_gradient_sum is None
+                else matrix_gradient_sum + matrix_gradient
+            )
+        assert matrix_gradient_sum is not None
+        return jnp.stack(adjoint_columns, axis=1), matrix_gradient_sum
 
     def differentiated_solve_bwd(residuals, cotangents):
         matrix_data, x = residuals
@@ -1034,14 +1206,12 @@ def make_sharded_solver(
     ) -> tuple[jax.Array, ShardedInfo]:
         _validate_operand(rhs, b, mesh, axis_name, "b")
         if A_data_override is None:
-            # A non-addressable global array cannot be captured as a constant
-            # by an outer multi-process jax.jit. Materialize the same cached
-            # rank-local values through shard_map while tracing instead.
-            matrix_data = (
-                mapped_cached_matrix_data(rhs)
-                if isinstance(rhs, jax.core.Tracer)
-                else A_data
-            )
+            if isinstance(rhs, jax.core.Tracer):
+                raise ValueError(
+                    "A_data must be passed explicitly when a sharded solver is "
+                    "used inside jax.jit, jax.grad, or another JAX transform"
+                )
+            matrix_data = A_data
         else:
             matrix_data = A_data_override
         _validate_operand(matrix_data, A_data, mesh, axis_name, "A_data")

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -46,7 +46,7 @@ try:
 except Exception:  # pragma: no cover - exercised only if the private API moves
 
     def _backends_are_initialized() -> bool:
-        return False
+        return True  # never report a flag as effective without knowing
 
 
 def _disable_shard_autotuning() -> bool:
@@ -259,7 +259,8 @@ def make_sharded_vector(
 
     Returns:
         A global JAX array whose axis uses ``P(axis_name)``. Its physical
-        length is ``comm.size * max(local_sizes)``.
+        length is ``comm.size * max(local_sizes)``; values are cast to
+        ``float32`` unless already ``float32`` or ``float64``.
     """
     comm = _resolve_comm(comm)
     if mesh is None:
@@ -281,6 +282,9 @@ def make_sharded_vector(
         values = np.asarray(local_values)
     if values.ndim != 1:
         raise ValueError(f"local_values must be one-dimensional; got {values.shape}")
+    if values.dtype not in (jnp.float32, jnp.float64):
+        # The solver's precision rule, so solutions share the RHS dtype.
+        values = values.astype(jnp.float32)
     if tuple(mesh.axis_names) != (axis_name,):
         raise ValueError(
             f"mesh must have the single axis {axis_name!r}; got {mesh.axis_names!r}"
@@ -295,6 +299,10 @@ def make_sharded_vector(
 
     local_shapes = tuple(tuple(shape) for shape in comm.allgather(values.shape))
     local_sizes = tuple(int(shape[0]) for shape in local_shapes)
+    if min(local_sizes) == 0:
+        raise ValueError(
+            f"every rank must own at least one row; got local sizes {local_sizes}"
+        )
     inferred_global_size = sum(local_sizes)
     if global_size is not None and int(global_size) != inferred_global_size:
         raise ValueError(
@@ -456,6 +464,10 @@ def _local_partition(
     n_global: int,
 ) -> tuple[tuple[int, int], tuple[int, ...], int]:
     local_sizes = tuple(int(size) for size in comm.allgather(n_local))
+    if min(local_sizes) == 0:
+        raise ValueError(
+            f"every rank must own at least one row; got row counts {local_sizes}"
+        )
     if sum(local_sizes) != n_global:
         raise ValueError(
             "the distributed matrix row counts must sum to its global column "

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -506,35 +506,15 @@ def make_sharded_solver(
     padded_col_to_combined[:local_nnz] = halo_plan.col_to_combined
     local_valid_values = np.arange(max_nnz) < local_nnz
 
-    plan_vector_sharding = NamedSharding(mesh, row_spec)
-    plan_matrix_sharding = NamedSharding(mesh, P(axis_name, None))
-
-    def global_plan_vector(local_value: np.ndarray) -> jax.Array:
-        return jax.make_array_from_process_local_data(
-            plan_vector_sharding,
-            local_value,
-            global_shape=(comm.Get_size() * local_value.shape[0],),
-        )
-
-    row_indices = global_plan_vector(padded_row_indices)
-    col_to_combined = global_plan_vector(padded_col_to_combined)
-    valid_values = global_plan_vector(local_valid_values)
-    send_ids = jax.make_array_from_process_local_data(
-        plan_matrix_sharding,
-        halo_plan.send_ids_2d,
-        global_shape=(
-            comm.Get_size() * halo_plan.send_ids_2d.shape[0],
-            halo_plan.send_ids_2d.shape[1],
-        ),
-    )
-    recv_ghost_slot = jax.make_array_from_process_local_data(
-        plan_matrix_sharding,
-        halo_plan.recv_ghost_slot_2d,
-        global_shape=(
-            comm.Get_size() * halo_plan.recv_ghost_slot_2d.shape[0],
-            halo_plan.recv_ghost_slot_2d.shape[1],
-        ),
-    )
+    # Keep rank-local halo metadata inside the shard_map bodies. Making these
+    # arrays global and closing over them in the custom VJP prevents an outer
+    # multi-process jax.jit from lowering because their remote shards are not
+    # addressable by the current process.
+    row_indices = jnp.asarray(padded_row_indices)
+    col_to_combined = jnp.asarray(padded_col_to_combined)
+    valid_values = jnp.asarray(local_valid_values)
+    send_ids = jnp.asarray(halo_plan.send_ids_2d)
+    recv_ghost_slot = jnp.asarray(halo_plan.recv_ghost_slot_2d)
 
     def gather_solution_halo(
         x_local: jax.Array,
@@ -558,30 +538,19 @@ def make_sharded_solver(
         A_data_local: jax.Array,
         x_at_columns: jax.Array,
         adjoint_local: jax.Array,
-        row_indices_local: jax.Array,
-        valid_values_local: jax.Array,
     ) -> jax.Array:
-        grad_values = -adjoint_local[row_indices_local] * x_at_columns
-        return jnp.where(valid_values_local, grad_values, 0)
+        del A_data_local
+        grad_values = -adjoint_local[row_indices] * x_at_columns
+        return jnp.where(valid_values, grad_values, 0)
 
-    def local_gather_matrix_columns(
-        x_local: jax.Array,
-        send_ids_local: jax.Array,
-        recv_ghost_slot_local: jax.Array,
-        col_to_combined_local: jax.Array,
-        valid_values_local: jax.Array,
-    ) -> jax.Array:
-        x_combined = gather_solution_halo(
-            x_local, send_ids_local, recv_ghost_slot_local
-        )
-        return jnp.where(valid_values_local, x_combined[col_to_combined_local], 0)
+    def local_gather_matrix_columns(x_local: jax.Array) -> jax.Array:
+        x_combined = gather_solution_halo(x_local, send_ids, recv_ghost_slot)
+        return jnp.where(valid_values, x_combined[col_to_combined], 0)
 
     def local_backward(
         A_data_local: jax.Array,
         x_at_columns: jax.Array,
         g_local: jax.Array,
-        row_indices_local: jax.Array,
-        valid_values_local: jax.Array,
     ) -> tuple[jax.Array, jax.Array]:
         A_data_ordered, g_ordered, x_at_columns = jax.lax.optimization_barrier(
             (A_data_local, g_local, x_at_columns)
@@ -591,8 +560,6 @@ def make_sharded_solver(
             A_data_ordered,
             x_at_columns,
             adjoint_local,
-            row_indices_local,
-            valid_values_local,
         )
         return adjoint_local, grad_A_data_local
 
@@ -612,11 +579,24 @@ def make_sharded_solver(
             out_specs=(row_spec, info_specs),
         )
     )
+
+    def local_cached_matrix_data(rhs_local: jax.Array) -> jax.Array:
+        del rhs_local
+        return jnp.asarray(local_packed_data)
+
+    mapped_cached_matrix_data = jax.jit(
+        jax.shard_map(
+            local_cached_matrix_data,
+            mesh=mesh,
+            in_specs=(row_spec,),
+            out_specs=row_spec,
+        )
+    )
     mapped_gather_matrix_columns = jax.jit(
         jax.shard_map(
             local_gather_matrix_columns,
             mesh=mesh,
-            in_specs=(row_spec, row_spec, row_spec, row_spec, row_spec),
+            in_specs=(row_spec,),
             out_specs=row_spec,
         )
     )
@@ -624,7 +604,7 @@ def make_sharded_solver(
         jax.shard_map(
             local_backward,
             mesh=mesh,
-            in_specs=(row_spec, row_spec, row_spec, row_spec, row_spec),
+            in_specs=(row_spec, row_spec, row_spec),
             out_specs=(row_spec, row_spec),
         )
     )
@@ -647,12 +627,8 @@ def make_sharded_solver(
     def differentiated_solve_bwd(residuals, cotangents):
         matrix_data, x = residuals
         g_x, _ = cotangents
-        x_at_columns = mapped_gather_matrix_columns(
-            x, send_ids, recv_ghost_slot, col_to_combined, valid_values
-        )
-        adjoint, grad_A_data = mapped_backward(
-            matrix_data, x_at_columns, g_x, row_indices, valid_values
-        )
+        x_at_columns = mapped_gather_matrix_columns(x)
+        adjoint, grad_A_data = mapped_backward(matrix_data, x_at_columns, g_x)
         return grad_A_data, adjoint
 
     differentiated_solve.defvjp(differentiated_solve_fwd, differentiated_solve_bwd)
@@ -673,12 +649,8 @@ def make_sharded_solver(
     def differentiated_solve_x0_bwd(residuals, cotangents):
         matrix_data, x = residuals
         g_x, _ = cotangents
-        x_at_columns = mapped_gather_matrix_columns(
-            x, send_ids, recv_ghost_slot, col_to_combined, valid_values
-        )
-        adjoint, grad_A_data = mapped_backward(
-            matrix_data, x_at_columns, g_x, row_indices, valid_values
-        )
+        x_at_columns = mapped_gather_matrix_columns(x)
+        adjoint, grad_A_data = mapped_backward(matrix_data, x_at_columns, g_x)
         return grad_A_data, adjoint, jnp.zeros_like(adjoint)
 
     differentiated_solve_x0.defvjp(
@@ -692,7 +664,17 @@ def make_sharded_solver(
         A_data_override: jax.Array | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
         _validate_operand(rhs, b, mesh, axis_name, "b")
-        matrix_data = A_data if A_data_override is None else A_data_override
+        if A_data_override is None:
+            # A non-addressable global array cannot be captured as a constant
+            # by an outer multi-process jax.jit. Materialize the same cached
+            # rank-local values through shard_map while tracing instead.
+            matrix_data = (
+                mapped_cached_matrix_data(rhs)
+                if isinstance(rhs, jax.core.Tracer)
+                else A_data
+            )
+        else:
+            matrix_data = A_data_override
         _validate_operand(matrix_data, A_data, mesh, axis_name, "A_data")
         if x0 is None:
             return differentiated_solve(matrix_data, rhs)

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -53,7 +53,7 @@ class ShardedMatrix:
         self,
         local_bcsr: jsp.BCSR,
         data: jax.Array,
-        local_packed_data: np.ndarray,
+        local_packed_data: jax.Array,
         comm: Comm,
         mesh: Mesh,
         axis_name: str,
@@ -136,7 +136,8 @@ def make_sharded_vector(
 
     The returned JAX array has equal physical shard sizes, as required by
     ``NamedSharding``. ``make_sharded_solver`` ignores each shard's padding and
-    uses the true row counts from ``A_local``.
+    uses the true row counts from ``A_local``. JAX array inputs are padded and
+    assembled on device; other array-like inputs use a NumPy host staging path.
 
     Args:
         local_values: This rank's unpadded values with shape ``(n_local,)`` or
@@ -157,7 +158,16 @@ def make_sharded_vector(
     comm = _resolve_comm(comm)
     if mesh is None:
         mesh = jax.make_mesh((jax.device_count(),), (axis_name,))
-    values = np.asarray(local_values)
+    values: jax.Array | np.ndarray
+    if isinstance(local_values, jax.Array):
+        if not local_values.is_fully_addressable:
+            raise ValueError(
+                "local_values must be a process-local JAX array, not an already "
+                "distributed global array"
+            )
+        values = local_values
+    else:
+        values = np.asarray(local_values)
     if values.ndim not in (1, 2):
         raise ValueError(
             f"local_values must be one- or two-dimensional; got shape {values.shape}"
@@ -191,8 +201,13 @@ def make_sharded_vector(
         )
 
     max_local_size = max(local_sizes)
-    padded_values = np.zeros((max_local_size, *trailing_shape), dtype=values.dtype)
-    padded_values[: values.shape[0]] = values
+    padding = ((0, max_local_size - values.shape[0]),) + ((0, 0),) * (values.ndim - 1)
+    if max_local_size == values.shape[0]:
+        padded_values = values
+    elif isinstance(values, jax.Array):
+        padded_values = jnp.pad(values, padding)
+    else:
+        padded_values = np.pad(values, padding)
     sharding = NamedSharding(mesh, _row_partition_spec(values.ndim, axis_name))
     return jax.make_array_from_process_local_data(
         sharding,
@@ -393,8 +408,11 @@ def _pack_sharded_matrix(
     local_nnz = int(A_bcsr.data.shape[0])
     if max_nnz is None:
         max_nnz = max(int(value) for value in comm.allgather(local_nnz))
-    local_packed_data = np.zeros(max_nnz, dtype=np.asarray(A_bcsr.data).dtype)
-    local_packed_data[:local_nnz] = np.asarray(A_bcsr.data)
+    local_packed_data = (
+        A_bcsr.data
+        if max_nnz == local_nnz
+        else jnp.pad(A_bcsr.data, (0, max_nnz - local_nnz))
+    )
     data_sharding = NamedSharding(mesh, P(axis_name))
     data = jax.make_array_from_process_local_data(
         data_sharding,
@@ -507,7 +525,6 @@ def _transpose_distributed_matrix(
     n_global = sum(recvcounts)
     nranks = len(recvcounts)
 
-    data = np.asarray(A.data)
     indices = np.asarray(A.indices, dtype=np.int64)
     indptr = np.asarray(A.indptr, dtype=np.int64)
     source_rows = np.repeat(
@@ -527,22 +544,14 @@ def _transpose_distributed_matrix(
     send_displs = np.insert(np.cumsum(send_counts[:-1]), 0, 0).astype(np.int32)
     recv_displs = np.insert(np.cumsum(recv_counts[:-1]), 0, 0).astype(np.int32)
 
-    send_data = np.ascontiguousarray(data[send_order])
     send_rows = np.ascontiguousarray(indices[send_order])
     send_cols = np.ascontiguousarray(source_rows[send_order])
-    packed_ids = comm.Get_rank() * max_nnz + np.arange(len(data), dtype=np.int64)
+    packed_ids = comm.Get_rank() * max_nnz + np.arange(len(indices), dtype=np.int64)
     send_ids = np.ascontiguousarray(packed_ids[send_order])
     recv_nnz = int(recv_counts.sum())
-    recv_data = np.empty(recv_nnz, dtype=data.dtype)
     recv_rows = np.empty(recv_nnz, dtype=np.int64)
     recv_cols = np.empty(recv_nnz, dtype=np.int64)
     recv_ids = np.empty(recv_nnz, dtype=np.int64)
-    value_mpi_type = MPI.FLOAT if data.dtype == np.float32 else MPI.DOUBLE
-
-    comm.Alltoallv(
-        [send_data, send_counts, send_displs, value_mpi_type],
-        [recv_data, recv_counts, recv_displs, value_mpi_type],
-    )
     comm.Alltoallv(
         [send_rows, send_counts, send_displs, MPI.INT64_T],
         [recv_rows, recv_counts, recv_displs, MPI.INT64_T],
@@ -560,16 +569,16 @@ def _transpose_distributed_matrix(
     order = np.lexsort((recv_cols, local_rows))
     local_rows = local_rows[order]
     recv_cols = recv_cols[order]
-    recv_data = recv_data[order]
     recv_ids = recv_ids[order]
     row_counts = np.bincount(local_rows, minlength=n_local)
     transpose_indptr = np.concatenate(([0], np.cumsum(row_counts))).astype(np.int32)
 
     with temp_enable_x64():
+        transpose_data = jnp.zeros(recv_nnz, dtype=A.data.dtype)
         transpose_indices = jnp.asarray(recv_cols, dtype=jnp.int64)
         transpose = jsp.BCSR(
             (
-                jnp.asarray(recv_data),
+                transpose_data,
                 transpose_indices,
                 jnp.asarray(transpose_indptr),
             ),

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -17,9 +17,15 @@ import numpy as np
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from .cache import cache_mpi_metadata, with_cache
+from .cache import _build_mpi_cache, with_cache
 from .jaxamg import solve
-from .utils import MatrixOrOperator, temp_enable_x64, to_bcsr_matrix
+from .mpi_utils import build_halo_plan
+from .utils import (
+    MatrixOrOperator,
+    get_preferred_dtype,
+    temp_enable_x64,
+    to_bcsr_matrix,
+)
 
 if TYPE_CHECKING:
     from mpi4py.MPI import Comm
@@ -36,13 +42,16 @@ class _CSRStructure(NamedTuple):
     nnz: int
 
 
-class _TransposeValuePlan(NamedTuple):
-    """Static sparse exchange plan for values of a distributed transpose."""
+class _TransposePlan(NamedTuple):
+    """Static structure and sparse value-exchange plan for a transpose."""
 
     local_source_ids: np.ndarray
     local_target_ids: np.ndarray
     send_ids_2d: np.ndarray
     recv_target_ids_2d: np.ndarray
+    indices_host: np.ndarray
+    indptr_host: np.ndarray
+    max_nnz: int
 
 
 def _resolve_comm(comm: Comm | None) -> Comm:
@@ -75,6 +84,7 @@ class ShardedMatrix:
         mesh: Mesh,
         axis_name: str,
         partition_info: tuple[int, int],
+        row_counts: tuple[int, ...],
         max_local_size: int,
     ) -> None:
         local_device = mesh.local_devices[0]
@@ -95,6 +105,7 @@ class ShardedMatrix:
         self.mesh = mesh
         self.axis_name = axis_name
         self.partition_info = partition_info
+        self.row_counts = row_counts
         self.max_local_size = max_local_size
         self.data = data
         self.global_size = int(local_bcsr.shape[1])
@@ -375,7 +386,7 @@ def _local_partition(
     comm: Comm,
     n_local: int,
     n_global: int,
-) -> tuple[tuple[int, int], int]:
+) -> tuple[tuple[int, int], tuple[int, ...], int]:
     local_sizes = tuple(int(size) for size in comm.allgather(n_local))
     if sum(local_sizes) != n_global:
         raise ValueError(
@@ -387,7 +398,7 @@ def _local_partition(
 
     comm_rank = comm.Get_rank()
     row_start = sum(local_sizes[:comm_rank])
-    return (row_start, row_start + n_local), max_local_size
+    return (row_start, row_start + n_local), local_sizes, max_local_size
 
 
 def _validate_matrix(
@@ -436,6 +447,7 @@ def _pack_sharded_matrix(
     mesh: Mesh,
     axis_name: str,
     partition_info: tuple[int, int],
+    row_counts: tuple[int, ...],
     max_local_size: int,
     max_nnz: int | None = None,
 ) -> ShardedMatrix:
@@ -461,6 +473,7 @@ def _pack_sharded_matrix(
         mesh,
         axis_name,
         partition_info,
+        row_counts,
         max_local_size,
     )
 
@@ -507,7 +520,7 @@ def make_sharded_matrix(
         raise ValueError("A_local must have a two-dimensional shape")
     n_local = int(matrix_shape[0])
     nglobal = int(matrix_shape[1])
-    partition_info, max_local_size = _local_partition(
+    partition_info, row_counts, max_local_size = _local_partition(
         b, mesh, axis_name, comm, n_local, nglobal
     )
     A_bcsr = _normalize_local_matrix(A_local, b, partition_info)
@@ -517,6 +530,7 @@ def make_sharded_matrix(
         mesh,
         axis_name,
         partition_info,
+        row_counts,
         max_local_size,
     )
 
@@ -545,12 +559,13 @@ def _validate_operand(
 
 
 def _transpose_distributed_matrix(
-    A: jsp.BCSR,
+    indices: np.ndarray,
+    indptr: np.ndarray,
     recvcounts: tuple[int, ...],
     partition_info: tuple[int, int],
     comm: Comm,
     local_device: jax.Device,
-) -> tuple[jsp.BCSR, _TransposeValuePlan]:
+) -> tuple[_CSRStructure, _TransposePlan]:
     """Transpose fixed CSR structure and build a sparse value-exchange plan."""
     from mpi4py import MPI
 
@@ -559,8 +574,6 @@ def _transpose_distributed_matrix(
     n_global = sum(recvcounts)
     nranks = len(recvcounts)
 
-    indices = np.asarray(A.indices, dtype=np.int64)
-    indptr = np.asarray(A.indptr, dtype=np.int64)
     source_rows = np.repeat(
         np.arange(row_start, row_end, dtype=np.int64), np.diff(indptr)
     )
@@ -578,20 +591,32 @@ def _transpose_distributed_matrix(
     send_displs = np.insert(np.cumsum(send_counts[:-1]), 0, 0).astype(np.int32)
     recv_displs = np.insert(np.cumsum(recv_counts[:-1]), 0, 0).astype(np.int32)
 
-    send_rows = np.ascontiguousarray(indices[send_order])
-    send_cols = np.ascontiguousarray(source_rows[send_order])
+    send_coordinates = np.ascontiguousarray(
+        np.column_stack((indices[send_order], source_rows[send_order]))
+    )
     send_ids = np.ascontiguousarray(np.arange(len(indices), dtype=np.int64)[send_order])
     recv_nnz = int(recv_counts.sum())
-    recv_rows = np.empty(recv_nnz, dtype=np.int64)
-    recv_cols = np.empty(recv_nnz, dtype=np.int64)
+    recv_coordinates = np.empty((recv_nnz, 2), dtype=np.int64)
+    coordinate_send_counts = 2 * send_counts
+    coordinate_recv_counts = 2 * recv_counts
+    coordinate_send_displs = 2 * send_displs
+    coordinate_recv_displs = 2 * recv_displs
     comm.Alltoallv(
-        [send_rows, send_counts, send_displs, MPI.INT64_T],
-        [recv_rows, recv_counts, recv_displs, MPI.INT64_T],
+        [
+            send_coordinates,
+            coordinate_send_counts,
+            coordinate_send_displs,
+            MPI.INT64_T,
+        ],
+        [
+            recv_coordinates,
+            coordinate_recv_counts,
+            coordinate_recv_displs,
+            MPI.INT64_T,
+        ],
     )
-    comm.Alltoallv(
-        [send_cols, send_counts, send_displs, MPI.INT64_T],
-        [recv_cols, recv_counts, recv_displs, MPI.INT64_T],
-    )
+    recv_rows = recv_coordinates[:, 0]
+    recv_cols = recv_coordinates[:, 1]
     local_rows = recv_rows - row_start
     order = np.lexsort((recv_cols, local_rows))
     local_rows = local_rows[order]
@@ -608,8 +633,14 @@ def _transpose_distributed_matrix(
     remote_recv_counts = recv_counts.copy()
     remote_send_counts[rank] = 0
     remote_recv_counts[rank] = 0
-    local_pair_max = int(max(remote_send_counts.max(), remote_recv_counts.max()))
-    max_per_rank = max(int(comm.allreduce(local_pair_max, op=MPI.MAX)), 1)
+    local_maxima = np.array(
+        [max(remote_send_counts.max(), remote_recv_counts.max()), recv_nnz],
+        dtype=np.int64,
+    )
+    global_maxima = np.empty_like(local_maxima)
+    comm.Allreduce(local_maxima, global_maxima, op=MPI.MAX)
+    max_per_rank = max(int(global_maxima[0]), 1)
+    max_nnz = int(global_maxima[1])
 
     send_ids_2d = np.zeros((nranks, max_per_rank), dtype=np.int32)
     recv_target_ids_2d = np.full((nranks, max_per_rank), recv_nnz, dtype=np.int32)
@@ -638,25 +669,23 @@ def _transpose_distributed_matrix(
     local_target_ids = inverse_order[local_recv_start : local_recv_start + local_count]
 
     with temp_enable_x64():
-        transpose_data = jax.device_put(
-            np.zeros(recv_nnz, dtype=np.dtype(A.data.dtype)), local_device
-        )
         transpose_indices = jax.device_put(
             np.asarray(recv_cols, dtype=np.int64), local_device
         )
-        transpose = jsp.BCSR(
-            (
-                transpose_data,
-                transpose_indices,
-                jax.device_put(transpose_indptr, local_device),
-            ),
-            shape=(n_local, n_global),
+        transpose_structure = _CSRStructure(
+            transpose_indices,
+            jax.device_put(transpose_indptr, local_device),
+            (n_local, n_global),
+            recv_nnz,
         )
-    return transpose, _TransposeValuePlan(
+    return transpose_structure, _TransposePlan(
         local_source_ids,
         local_target_ids,
         send_ids_2d,
         recv_target_ids_2d,
+        recv_cols,
+        transpose_indptr,
+        max_nnz,
     )
 
 
@@ -730,42 +759,26 @@ def make_sharded_solver(
     is_batched = b.ndim == 2
     local_rhs = b.addressable_shards[0].data[:n_local]
     matrix_probe_rhs = local_rhs[:, 0] if is_batched else local_rhs
-    normalized_matrix = to_bcsr_matrix(
-        A._local_bcsr,
-        b=matrix_probe_rhs,
-        use_int64_indices=True,
-    )
-    if normalized_matrix.data.dtype != A.data.dtype:
+    A_bcsr = A._local_bcsr
+    if get_preferred_dtype(A_bcsr, matrix_probe_rhs) != A.data.dtype:
         raise ValueError(
             "the sharded matrix dtype is incompatible with b; rebuild it "
             "with make_sharded_matrix(A_local, b)"
         )
-    A_bcsr = A._local_bcsr
 
     _validate_matrix(A_bcsr, nglobal, partition_info, block_dim)
-    mpi_cache = cache_mpi_metadata(
-        config or {},
-        comm,
-        nglobal,
-        partition_info,
-        A_bcsr,
-        is_symmetric=is_symmetric,
-        block_dim=block_dim,
-    )
-    # cache_mpi_metadata's lrank preserves the existing MPI API's device
-    # selection. In sharded mode JAX has already selected this process's one
-    # mesh-local GPU, so pass its CUDA-local hardware ordinal to AmgX.
     local_device = mesh.local_devices[0]
     local_hardware_id = getattr(local_device, "local_hardware_id", local_device.id)
-    mpi_cache["lrank"] = int(local_hardware_id)
+
+    # MPI setup needs CSR structure on the host. Materialize it exactly once;
+    # the halo and transpose plans below share these arrays.
+    indices_host = np.asarray(A_bcsr.indices, dtype=np.int64)
+    indptr_host = np.asarray(A_bcsr.indptr, dtype=np.int64)
+    halo_plan = build_halo_plan(indices_host, A.row_counts, partition_info, comm)
 
     rhs_spec = _row_partition_spec(b.ndim, axis_name)
     A_data_spec = P(axis_name)
-    max_nnz = int(mpi_cache["max_nnz"])
-    if max_nnz != A.max_local_nnz:
-        raise RuntimeError(
-            "matrix packing and MPI cache disagree about the maximum local nnz"
-        )
+    max_nnz = A.max_local_nnz
     local_nnz = A.local_nnz
     A_data = A.data
     A_structure = _CSRStructure(
@@ -776,6 +789,7 @@ def make_sharded_solver(
     )
 
     if is_symmetric:
+        nnz_out = None
         transpose_structure = None
         transpose_cache = None
         max_transpose_nnz = None
@@ -784,30 +798,22 @@ def make_sharded_solver(
         transpose_send_ids = None
         transpose_recv_target_ids = None
     else:
-        A_transpose, transpose_plan = _transpose_distributed_matrix(
-            A_bcsr,
-            mpi_cache["recvcounts_tuple"],
+        transpose_structure, transpose_plan = _transpose_distributed_matrix(
+            indices_host,
+            indptr_host,
+            A.row_counts,
             partition_info,
             comm,
             local_device,
         )
-        transpose_cache = cache_mpi_metadata(
-            config or {},
-            comm,
-            nglobal,
+        nnz_out = transpose_structure.nnz
+        max_transpose_nnz = transpose_plan.max_nnz
+        transpose_halo_plan = build_halo_plan(
+            transpose_plan.indices_host,
+            A.row_counts,
             partition_info,
-            A_transpose,
-            is_symmetric=False,
-            block_dim=block_dim,
+            comm,
         )
-        transpose_cache["lrank"] = int(local_hardware_id)
-        transpose_structure = _CSRStructure(
-            A_transpose.indices,
-            A_transpose.indptr,
-            tuple(A_transpose.shape),
-            int(A_transpose.data.shape[0]),
-        )
-        max_transpose_nnz = int(transpose_cache["max_nnz"])
         # Explicit single-device placement keeps rank-local constants local even
         # when solver construction happens inside a global ``jax.set_mesh``
         # context.
@@ -821,6 +827,28 @@ def make_sharded_solver(
         transpose_recv_target_ids = jax.device_put(
             transpose_plan.recv_target_ids_2d, local_device
         )
+
+    mpi_cache = _build_mpi_cache(
+        config or {},
+        comm,
+        nglobal,
+        A.row_counts,
+        max_nnz,
+        nnz_out,
+        halo_plan,
+        block_dim=block_dim,
+        lrank=int(local_hardware_id),
+    )
+    if not is_symmetric:
+        # A and A^T share the communicator, row partition, configuration, and
+        # device. Only structure-dependent buffer and halo metadata differ.
+        assert transpose_halo_plan is not None
+        transpose_cache = {
+            **mpi_cache,
+            "max_nnz": max_transpose_nnz,
+            "nnz_out": local_nnz,
+            "halo_plan": transpose_halo_plan,
+        }
 
     if is_batched:
         info_specs = {
@@ -991,10 +1019,10 @@ def make_sharded_solver(
         return local_adjoint
 
     halo_plan = mpi_cache["halo_plan"]
-    max_n_ghost = max(comm.allgather(halo_plan.n_ghost))
+    max_n_ghost = halo_plan.max_n_ghost
     local_row_indices = np.repeat(
         np.arange(A_bcsr.shape[0], dtype=np.int32),
-        np.diff(np.asarray(A_bcsr.indptr, dtype=np.int64)),
+        np.diff(indptr_host),
     )
 
     # Keep rank-local halo metadata inside the shard_map bodies. Making these

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -90,17 +90,14 @@ class ShardedMatrix:
     ) -> None:
         local_device = mesh.local_devices[0]
         local_nnz = int(local_bcsr.data.shape[0])
-        local_values = data.addressable_shards[0].data[:local_nnz]
-        # Keep only one local matrix-value buffer. In particular, an uneven
-        # partition must not retain both the original unpadded values and the
-        # padded shard used by ``data``.
-        self._local_bcsr = jsp.BCSR(
-            (
-                local_values,
-                jax.device_put(local_bcsr.indices, local_device),
-                jax.device_put(local_bcsr.indptr, local_device),
-            ),
-            shape=local_bcsr.shape,
+        # Keep only the rank-local CSR structure. The matrix values live solely
+        # in the padded shard of ``data``; ``local_matrix`` re-slices them on
+        # demand, so no second per-rank value buffer is retained.
+        self._structure = _CSRStructure(
+            jax.device_put(local_bcsr.indices, local_device),
+            jax.device_put(local_bcsr.indptr, local_device),
+            tuple(local_bcsr.shape),
+            local_nnz,
         )
         self._comm = comm
         self.mesh = mesh
@@ -122,8 +119,8 @@ class ShardedMatrix:
         _validate_operand(values, self.data, self.mesh, self.axis_name, "matrix data")
         local_values = values.addressable_shards[0].data[: self.local_nnz]
         return jsp.BCSR(
-            (local_values, self._local_bcsr.indices, self._local_bcsr.indptr),
-            shape=self._local_bcsr.shape,
+            (local_values, self._structure.indices, self._structure.indptr),
+            shape=self._structure.shape,
         )
 
 
@@ -181,7 +178,8 @@ def make_sharded_vector(
         comm: MPI communicator whose rank order matches ``mesh``. Defaults to
             ``MPI.COMM_WORLD``.
         mesh: One-dimensional JAX device mesh with one device per MPI rank.
-            Defaults to a mesh containing all JAX devices.
+            Defaults to a mesh over the first ``comm.size`` JAX devices (all
+            devices in a typical multi-process job).
         global_size: Optional true global length. When provided, it is checked
             against the sum of local lengths.
         axis_name: Mesh axis used to partition the vector.
@@ -192,7 +190,12 @@ def make_sharded_vector(
     """
     comm = _resolve_comm(comm)
     if mesh is None:
-        mesh = jax.make_mesh((jax.device_count(),), (axis_name,))
+        # One device per MPI rank. In a multi-process job this covers all JAX
+        # devices; a process with extra local devices uses the leading ones.
+        comm_size = comm.Get_size()
+        mesh = jax.make_mesh(
+            (comm_size,), (axis_name,), devices=jax.devices()[:comm_size]
+        )
     values: jax.Array | np.ndarray
     if isinstance(local_values, jax.Array):
         if not local_values.is_fully_addressable:
@@ -604,22 +607,21 @@ def make_sharded_solver(
     _validate_vector_layout(b, mesh, axis_name, comm.Get_size(), max_n_local)
 
     block_dim = int(block_dim)
-    local_rhs = b.addressable_shards[0].data[:n_local]
-    A_bcsr = A._local_bcsr
-    if get_preferred_dtype(A_bcsr, local_rhs) != A.data.dtype:
+    A_structure = A._structure
+    if get_preferred_dtype(A.data, b) != A.data.dtype:
         raise ValueError(
             "the sharded matrix dtype is incompatible with b; rebuild it "
             "with make_sharded_matrix(A_local, b)"
         )
 
-    _validate_matrix(A_bcsr, nglobal, partition_info, block_dim)
+    _validate_matrix(A_structure, nglobal, partition_info, block_dim)
     local_device = mesh.local_devices[0]
     local_hardware_id = getattr(local_device, "local_hardware_id", local_device.id)
 
     # MPI setup needs CSR structure on the host. Materialize it exactly once;
     # the halo and transpose plans below share these arrays.
-    indices_host = np.asarray(A_bcsr.indices, dtype=np.int64)
-    indptr_host = np.asarray(A_bcsr.indptr, dtype=np.int64)
+    indices_host = np.asarray(A_structure.indices, dtype=np.int64)
+    indptr_host = np.asarray(A_structure.indptr, dtype=np.int64)
     halo_plan = build_halo_plan(indices_host, A.row_counts, partition_info, comm)
 
     rhs_spec = P(axis_name)
@@ -627,12 +629,6 @@ def make_sharded_solver(
     max_nnz = A.max_local_nnz
     local_nnz = A.local_nnz
     A_data = A.data
-    A_structure = _CSRStructure(
-        A_bcsr.indices,
-        A_bcsr.indptr,
-        tuple(A_bcsr.shape),
-        local_nnz,
-    )
 
     if is_symmetric:
         nnz_out = None
@@ -684,6 +680,7 @@ def make_sharded_solver(
         halo_plan,
         block_dim=block_dim,
         lrank=int(local_hardware_id),
+        device=local_device,
     )
     if not is_symmetric:
         # The MPI solve's primal does not consume halo operands, and sharding's
@@ -691,8 +688,6 @@ def make_sharded_solver(
         # Therefore the nested A^T solve needs only placeholder halo operands.
         transpose_cache = {
             **mpi_cache,
-            "max_nnz": max_transpose_nnz,
-            "nnz_out": local_nnz,
             "halo_plan": _primal_halo_placeholder(n_local, len(A.row_counts)),
         }
 
@@ -802,7 +797,7 @@ def make_sharded_solver(
     halo_plan = mpi_cache["halo_plan"]
     max_n_ghost = halo_plan.max_n_ghost
     local_row_indices = np.repeat(
-        np.arange(A_bcsr.shape[0], dtype=np.int32),
+        np.arange(A_structure.shape[0], dtype=np.int32),
         np.diff(indptr_host),
     )
     # Keep rank-local halo metadata inside the shard_map bodies. Making these
@@ -961,7 +956,7 @@ def make_sharded_solver(
     ) -> tuple[jax.Array, ShardedInfo]:
         _validate_operand(rhs, b, mesh, axis_name, "b")
         if A_data_override is None:
-            if isinstance(rhs, jax.core.Tracer):
+            if isinstance(rhs, jax.core.Tracer) or isinstance(x0, jax.core.Tracer):
                 raise ValueError(
                     "A_data must be passed explicitly when a sharded solver is "
                     "used inside jax.jit, jax.grad, or another JAX transform"

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -79,11 +79,6 @@ def _resolve_comm(comm: Comm | None) -> Comm:
     return MPI.COMM_WORLD
 
 
-def _row_partition_spec(ndim: int, axis_name: str) -> P:
-    """Partition the leading row axis and replicate all trailing axes."""
-    return P(axis_name, *(None for _ in range(ndim - 1)))
-
-
 class ShardedMatrix:
     """Distributed CSR matrix with local structure and sharded values."""
 
@@ -167,7 +162,7 @@ class ShardedSolve:
         return self._solve_fn(b, x0, A_data=A_data)
 
     def local_vector(self, value: jax.Array) -> jax.Array:
-        """Return this rank's unpadded rows of a solver vector or RHS matrix."""
+        """Return this rank's unpadded rows of a solver vector."""
         return self._local_vector_fn(value)
 
 
@@ -179,7 +174,7 @@ def make_sharded_vector(
     global_size: int | None = None,
     axis_name: str = "rank",
 ) -> jax.Array:
-    """Create a row-sharded vector or RHS matrix, padding unequal partitions.
+    """Create a row-sharded vector, padding unequal partitions.
 
     The returned JAX array has equal physical shard sizes, as required by
     ``NamedSharding``. ``make_sharded_solver`` ignores each shard's padding and
@@ -187,8 +182,7 @@ def make_sharded_vector(
     assembled on device; other array-like inputs use a NumPy host staging path.
 
     Args:
-        local_values: This rank's unpadded values with shape ``(n_local,)`` or
-            ``(n_local, nrhs)``.
+        local_values: This rank's unpadded values with shape ``(n_local,)``.
         comm: MPI communicator whose rank order matches ``mesh``. Defaults to
             ``MPI.COMM_WORLD``.
         mesh: One-dimensional JAX device mesh with one device per MPI rank.
@@ -198,8 +192,7 @@ def make_sharded_vector(
         axis_name: Mesh axis used to partition the vector.
 
     Returns:
-        A global JAX array whose leading axis uses ``P(axis_name)`` and whose
-        optional RHS-column axis is replicated. Its physical leading-axis
+        A global JAX array whose axis uses ``P(axis_name)``. Its physical
         length is ``comm.size * max(local_sizes)``.
     """
     comm = _resolve_comm(comm)
@@ -215,12 +208,8 @@ def make_sharded_vector(
         values = local_values
     else:
         values = np.asarray(local_values)
-    if values.ndim not in (1, 2):
-        raise ValueError(
-            f"local_values must be one- or two-dimensional; got shape {values.shape}"
-        )
-    if values.ndim == 2 and values.shape[1] == 0:
-        raise ValueError("a batched RHS must contain at least one column")
+    if values.ndim != 1:
+        raise ValueError(f"local_values must be one-dimensional; got {values.shape}")
     if tuple(mesh.axis_names) != (axis_name,):
         raise ValueError(
             f"mesh must have the single axis {axis_name!r}; got {mesh.axis_names!r}"
@@ -234,11 +223,6 @@ def make_sharded_vector(
         )
 
     local_shapes = tuple(tuple(shape) for shape in comm.allgather(values.shape))
-    trailing_shape = values.shape[1:]
-    if any(shape[1:] != trailing_shape for shape in local_shapes):
-        raise ValueError(
-            f"all MPI ranks must use the same trailing RHS shape; got {local_shapes}"
-        )
     local_sizes = tuple(int(shape[0]) for shape in local_shapes)
     inferred_global_size = sum(local_sizes)
     if global_size is not None and int(global_size) != inferred_global_size:
@@ -248,18 +232,17 @@ def make_sharded_vector(
         )
 
     max_local_size = max(local_sizes)
-    padding = ((0, max_local_size - values.shape[0]),) + ((0, 0),) * (values.ndim - 1)
     if max_local_size == values.shape[0]:
         padded_values = values
     elif isinstance(values, jax.Array):
-        padded_values = jnp.pad(values, padding)
+        padded_values = jnp.pad(values, (0, max_local_size - values.shape[0]))
     else:
-        padded_values = np.pad(values, padding)
-    sharding = NamedSharding(mesh, _row_partition_spec(values.ndim, axis_name))
+        padded_values = np.pad(values, (0, max_local_size - values.shape[0]))
+    sharding = NamedSharding(mesh, P(axis_name))
     return jax.make_array_from_process_local_data(
         sharding,
         padded_values,
-        global_shape=(comm_size * max_local_size, *trailing_shape),
+        global_shape=(comm_size * max_local_size,),
     )
 
 
@@ -347,13 +330,11 @@ def _validate_vector_layout(
     comm_size: int,
     max_local_size: int,
 ) -> None:
-    if b.ndim not in (1, 2):
-        raise ValueError(f"b must be one- or two-dimensional; got shape {b.shape}")
-    if b.ndim == 2 and b.shape[1] == 0:
-        raise ValueError("a batched RHS must contain at least one column")
+    if b.ndim != 1:
+        raise ValueError(f"b must be one-dimensional; got shape {b.shape}")
 
     sharding = getattr(b, "sharding", None)
-    expected_spec = _row_partition_spec(b.ndim, axis_name)
+    expected_spec = P(axis_name)
     if not isinstance(sharding, NamedSharding):
         raise ValueError("b must use NamedSharding")
     if sharding.mesh != mesh or sharding.spec != expected_spec:
@@ -361,7 +342,7 @@ def _validate_vector_layout(
             f"b must use NamedSharding(mesh, P({axis_name!r})); got {sharding!r}"
         )
 
-    expected_shape = (comm_size * max_local_size, *b.shape[1:])
+    expected_shape = (comm_size * max_local_size,)
     if b.shape != expected_shape:
         raise ValueError(
             f"b must have padded sharded shape {expected_shape}; got {b.shape}. "
@@ -375,7 +356,7 @@ def _validate_vector_layout(
             f"{len(shards)}"
         )
     index = shards[0].index
-    if len(index) != b.ndim or not isinstance(index[0], slice):
+    if len(index) != 1 or not isinstance(index[0], slice):
         raise ValueError(f"b must have one contiguous local shard; got index {index!r}")
 
     row_slice = index[0]
@@ -448,8 +429,7 @@ def _normalize_local_matrix(
     _validate_matrix(A_local, nglobal, partition_info, block_dim=1)
 
     local_rhs = b.addressable_shards[0].data[:n_local]
-    matrix_probe_rhs = local_rhs[:, 0] if b.ndim == 2 else local_rhs
-    return to_bcsr_matrix(A_local, b=matrix_probe_rhs, use_int64_indices=True)
+    return to_bcsr_matrix(A_local, b=local_rhs, use_int64_indices=True)
 
 
 def _pack_sharded_matrix(
@@ -563,9 +543,7 @@ def _validate_operand(
         sharding = getattr(value, "sharding", None)
         if not isinstance(sharding, NamedSharding):
             raise ValueError(f"{name} must use NamedSharding")
-        if sharding.mesh != mesh or sharding.spec != _row_partition_spec(
-            value.ndim, axis_name
-        ):
+        if sharding.mesh != mesh or sharding.spec != P(axis_name):
             raise ValueError(f"{name} must use the same NamedSharding as its template")
 
 
@@ -723,11 +701,10 @@ def make_sharded_solver(
 
     Args:
         A: Distributed matrix created with :func:`make_sharded_matrix`.
-        b: Global JAX array with shape ``(n_global,)`` or
-            ``(n_global, nrhs)`` using row ``NamedSharding``. For unequal row
-            counts, construct it with :func:`make_sharded_vector`; physical
-            shards are padded to the largest local partition. Batched RHS
-            columns are replicated within each row shard.
+        b: Global JAX array with shape ``(n_global,)`` using row
+            ``NamedSharding``. For unequal row counts, construct it with
+            :func:`make_sharded_vector`; physical shards are padded to the
+            largest local partition.
         config: AmgX configuration. Defaults to the JAX-AMG MPI configuration.
         is_symmetric: Whether the global matrix is symmetric. When ``False``
             (the default), the distributed transpose is prepared once during
@@ -744,9 +721,7 @@ def make_sharded_solver(
         rank's unpadded BCSR structure. ``solver.local_vector(value)`` removes
         vector padding. ``A_data`` may be omitted for a direct call but must be
         explicit under ``jax.jit``, ``jax.grad``, or another JAX transform. For
-        a vector RHS, info values have one entry per rank. For a batched RHS
-        they have shape ``(nranks, nrhs)`` and ``residual_history`` has an
-        additional trailing ``max_iters + 1`` axis.
+        each solve, info values have one entry per rank.
     """
     _require_shard_map()
     if not isinstance(A, ShardedMatrix):
@@ -765,11 +740,9 @@ def make_sharded_solver(
     _validate_vector_layout(b, mesh, axis_name, comm.Get_size(), max_n_local)
 
     block_dim = int(block_dim)
-    is_batched = b.ndim == 2
     local_rhs = b.addressable_shards[0].data[:n_local]
-    matrix_probe_rhs = local_rhs[:, 0] if is_batched else local_rhs
     A_bcsr = A._local_bcsr
-    if get_preferred_dtype(A_bcsr, matrix_probe_rhs) != A.data.dtype:
+    if get_preferred_dtype(A_bcsr, local_rhs) != A.data.dtype:
         raise ValueError(
             "the sharded matrix dtype is incompatible with b; rebuild it "
             "with make_sharded_matrix(A_local, b)"
@@ -785,7 +758,7 @@ def make_sharded_solver(
     indptr_host = np.asarray(A_bcsr.indptr, dtype=np.int64)
     halo_plan = build_halo_plan(indices_host, A.row_counts, partition_info, comm)
 
-    rhs_spec = _row_partition_spec(b.ndim, axis_name)
+    rhs_spec = P(axis_name)
     A_data_spec = P(axis_name)
     max_nnz = A.max_local_nnz
     local_nnz = A.local_nnz
@@ -853,29 +826,14 @@ def make_sharded_solver(
             "halo_plan": _primal_halo_placeholder(n_local, len(A.row_counts)),
         }
 
-    if is_batched:
-        info_specs = {
-            "iterations": P(axis_name, None),
-            "residual": P(axis_name, None),
-            "status": P(axis_name, None),
-            "residual_history": P(axis_name, None, None),
-        }
-    else:
-        info_specs = {
-            "iterations": P(axis_name),
-            "residual": P(axis_name),
-            "status": P(axis_name),
-            "residual_history": P(axis_name, None),
-        }
+    info_specs = {
+        "iterations": P(axis_name),
+        "residual": P(axis_name),
+        "status": P(axis_name),
+        "residual_history": P(axis_name, None),
+    }
 
     def pack_info(info: ShardedInfo) -> ShardedInfo:
-        if is_batched:
-            return {
-                "iterations": jnp.asarray(info["iterations"], dtype=jnp.int32)[None, :],
-                "residual": jnp.asarray(info["residual"])[None, :],
-                "status": jnp.asarray(info["status"], dtype=jnp.int32)[None, :],
-                "residual_history": jnp.asarray(info["residual_history"])[None, :, :],
-            }
         return {
             "iterations": jnp.asarray(info["iterations"], dtype=jnp.int32)[None],
             "residual": jnp.asarray(info["residual"])[None],
@@ -900,76 +858,33 @@ def make_sharded_solver(
         return with_cache(matrix, mpi=cache, is_symmetric=symmetric)
 
     def pad_local_vector(value: jax.Array) -> jax.Array:
-        padding = ((0, max_n_local - n_local),) + ((0, 0),) * (value.ndim - 1)
-        return jnp.pad(value, padding)
+        return jnp.pad(value, (0, max_n_local - n_local))
 
     def solve_one_rhs(
         A_dynamic: jsp.BCSR,
         rhs_local: jax.Array,
         x0_local: jax.Array | None = None,
-        *,
-        reuse: bool = reuse_setup,
     ) -> tuple[jax.Array, ShardedInfo]:
         return solve(
             A_dynamic,
             rhs_local[:n_local],
             x0=None if x0_local is None else x0_local[:n_local],
             block_dim=block_dim,
-            reuse_setup=reuse,
-        )
-
-    def solve_local_rhs(
-        A_dynamic: jsp.BCSR,
-        rhs_local: jax.Array,
-        x0_local: jax.Array | None = None,
-    ) -> tuple[jax.Array, ShardedInfo]:
-        if not is_batched:
-            return solve_one_rhs(A_dynamic, rhs_local, x0_local)
-
-        solutions: list[jax.Array] = []
-        column_info: list[ShardedInfo] = []
-        for column in range(rhs_local.shape[1]):
-            rhs_column = rhs_local[:, column]
-            x0_column = None if x0_local is None else x0_local[:, column]
-            # XLA schedules each rank independently. Tie every column to the
-            # previous result so all ranks enter AmgX collectives in the same
-            # order.
-            if solutions:
-                if x0_column is None:
-                    rhs_column, _ = jax.lax.optimization_barrier(
-                        (rhs_column, solutions[-1])
-                    )
-                else:
-                    rhs_column, x0_column, _ = jax.lax.optimization_barrier(
-                        (rhs_column, x0_column, solutions[-1])
-                    )
-            solution, info = solve_one_rhs(
-                A_dynamic,
-                rhs_column,
-                x0_column,
-                # All columns use identical matrix values. Once the first
-                # column has prepared the hierarchy, resetting it again is
-                # unnecessary even when cross-call reuse was not requested.
-                reuse=reuse_setup or column > 0,
-            )
-            solutions.append(solution)
-            column_info.append(info)
-        return jnp.stack(solutions, axis=1), jax.tree.map(
-            lambda *values: jnp.stack(values), *column_info
+            reuse_setup=reuse_setup,
         )
 
     def local_solve(
         A_data_local: jax.Array, rhs_local: jax.Array
     ) -> tuple[jax.Array, ShardedInfo]:
         A_dynamic = matrix_with_data(A_data_local, A_structure, mpi_cache, is_symmetric)
-        x_local, info = solve_local_rhs(A_dynamic, rhs_local)
+        x_local, info = solve_one_rhs(A_dynamic, rhs_local)
         return pad_local_vector(x_local), pack_info(info)
 
     def local_solve_x0(
         A_data_local: jax.Array, rhs_local: jax.Array, x0_local: jax.Array
     ) -> tuple[jax.Array, ShardedInfo]:
         A_dynamic = matrix_with_data(A_data_local, A_structure, mpi_cache, is_symmetric)
-        x_local, info = solve_local_rhs(A_dynamic, rhs_local, x0_local)
+        x_local, info = solve_one_rhs(A_dynamic, rhs_local, x0_local)
         return pad_local_vector(x_local), pack_info(info)
 
     def local_transpose_values(A_data_local: jax.Array) -> jax.Array:
@@ -1001,25 +916,20 @@ def make_sharded_solver(
             (0, max_transpose_nnz - transpose_structure.nnz),
         )
 
-    def make_local_adjoint(reuse: bool):
-        def local_adjoint(
-            adjoint_data_local: jax.Array, g_local: jax.Array
-        ) -> jax.Array:
-            if is_symmetric:
-                structure = A_structure
-                cache = mpi_cache
-            else:
-                assert transpose_structure is not None
-                assert transpose_cache is not None
-                structure = transpose_structure
-                cache = transpose_cache
-            A_adjoint = matrix_with_data(
-                adjoint_data_local, structure, cache, symmetric=is_symmetric
-            )
-            adjoint_local, _ = solve_one_rhs(A_adjoint, g_local, reuse=reuse)
-            return pad_local_vector(adjoint_local)
-
-        return local_adjoint
+    def local_adjoint(adjoint_data_local: jax.Array, g_local: jax.Array) -> jax.Array:
+        if is_symmetric:
+            structure = A_structure
+            cache = mpi_cache
+        else:
+            assert transpose_structure is not None
+            assert transpose_cache is not None
+            structure = transpose_structure
+            cache = transpose_cache
+        A_adjoint = matrix_with_data(
+            adjoint_data_local, structure, cache, symmetric=is_symmetric
+        )
+        adjoint_local, _ = solve_one_rhs(A_adjoint, g_local)
+        return pad_local_vector(adjoint_local)
 
     halo_plan = mpi_cache["halo_plan"]
     max_n_ghost = halo_plan.max_n_ghost
@@ -1049,10 +959,9 @@ def make_sharded_solver(
             split_axis=0,
             concat_axis=0,
         )
-        trailing_shape = x_local.shape[1:]
-        x_ghost = jnp.zeros((max_n_ghost + 1, *trailing_shape), dtype=x_local.dtype)
+        x_ghost = jnp.zeros(max_n_ghost + 1, dtype=x_local.dtype)
         x_ghost = x_ghost.at[recv_ghost_slot_local.reshape(-1)].set(
-            recv_buffer.reshape((-1, *trailing_shape))
+            recv_buffer.reshape(-1)
         )
         return jnp.concatenate([x_local, x_ghost[:max_n_ghost]], axis=0)
 
@@ -1087,7 +996,6 @@ def make_sharded_solver(
             out_specs=(rhs_spec, info_specs),
         )
     )
-
     scalar_spec = P(axis_name)
     if is_symmetric:
         mapped_transpose_values = None
@@ -1102,22 +1010,10 @@ def make_sharded_solver(
         )
     mapped_adjoint = jax.jit(
         jax.shard_map(
-            make_local_adjoint(reuse_setup),
+            local_adjoint,
             mesh=mesh,
             in_specs=(A_data_spec, scalar_spec),
             out_specs=scalar_spec,
-        )
-    )
-    mapped_adjoint_reuse = (
-        mapped_adjoint
-        if reuse_setup or not is_batched
-        else jax.jit(
-            jax.shard_map(
-                make_local_adjoint(True),
-                mesh=mesh,
-                in_specs=(A_data_spec, scalar_spec),
-                out_specs=scalar_spec,
-            )
         )
     )
     mapped_matrix_gradient = jax.jit(
@@ -1128,6 +1024,21 @@ def make_sharded_solver(
             out_specs=A_data_spec,
         )
     )
+
+    def differentiated_solve_backward(
+        matrix_data: jax.Array, x: jax.Array, g_x: jax.Array
+    ) -> tuple[jax.Array, jax.Array]:
+        if is_symmetric:
+            adjoint_data = matrix_data
+        else:
+            assert mapped_transpose_values is not None
+            # Tie the transpose exchange to the completed forward solution so
+            # XLA cannot overlap it with AmgX's preceding MPI collectives.
+            matrix_data_ordered, _ = jax.lax.optimization_barrier((matrix_data, x))
+            adjoint_data = mapped_transpose_values(matrix_data_ordered)
+
+        adjoint = mapped_adjoint(adjoint_data, g_x)
+        return adjoint, mapped_matrix_gradient(x, adjoint)
 
     # Place the custom VJP outside shard_map. Its cotangent is then a global
     # sharded array, and the adjoint shard_map receives the correct local shard
@@ -1143,60 +1054,6 @@ def make_sharded_solver(
         result = mapped_solve(matrix_data, rhs)
         x, _ = result
         return result, (matrix_data, x)
-
-    def differentiated_solve_backward(
-        matrix_data: jax.Array, x: jax.Array, g_x: jax.Array
-    ) -> tuple[jax.Array, jax.Array]:
-        if is_symmetric:
-            adjoint_data = matrix_data
-        else:
-            assert mapped_transpose_values is not None
-            # Matrix values are identical for every RHS column, so prepare the
-            # distributed transpose exactly once per backward pass. Tie the
-            # exchange to the completed forward solution so XLA cannot overlap
-            # its JAX collective with AmgX's preceding MPI collectives.
-            matrix_data_ordered, _ = jax.lax.optimization_barrier((matrix_data, x))
-            adjoint_data = mapped_transpose_values(matrix_data_ordered)
-
-        if not is_batched:
-            adjoint = mapped_adjoint(adjoint_data, g_x)
-            return adjoint, mapped_matrix_gradient(x, adjoint)
-
-        adjoint_columns: list[jax.Array] = []
-        for column in range(x.shape[1]):
-            g_column = g_x[:, column]
-            # Preserve one cross-rank order for the sequential AmgX solves.
-            if adjoint_columns:
-                g_column, _ = jax.lax.optimization_barrier(
-                    (g_column, adjoint_columns[-1])
-                )
-            adjoint = (mapped_adjoint if column == 0 else mapped_adjoint_reuse)(
-                adjoint_data,
-                g_column,
-            )
-            adjoint_columns.append(adjoint)
-
-        # Run matrix-gradient halo exchanges only after all AmgX adjoint
-        # collectives have completed. Accumulating immediately avoids an
-        # ``(nrhs, nnz)`` stack of temporary matrix gradients.
-        matrix_gradient_sum = None
-        last_adjoint = adjoint_columns[-1]
-        for column, adjoint in enumerate(adjoint_columns):
-            x_column = x[:, column]
-            order_dependency = (
-                last_adjoint if matrix_gradient_sum is None else matrix_gradient_sum
-            )
-            x_column, adjoint, _ = jax.lax.optimization_barrier(
-                (x_column, adjoint, order_dependency)
-            )
-            matrix_gradient = mapped_matrix_gradient(x_column, adjoint)
-            matrix_gradient_sum = (
-                matrix_gradient
-                if matrix_gradient_sum is None
-                else matrix_gradient_sum + matrix_gradient
-            )
-        assert matrix_gradient_sum is not None
-        return jnp.stack(adjoint_columns, axis=1), matrix_gradient_sum
 
     def differentiated_solve_bwd(residuals, cotangents):
         matrix_data, x = residuals

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -438,7 +438,9 @@ def make_sharded_solver(
         is_symmetric: Whether the global matrix is symmetric. When ``False``
             (the default), the distributed transpose is prepared once during
             solver creation for the reverse-mode adjoint.
-        block_dim: AmgX block dimension.
+        block_dim: AmgX block dimension. The matrix retains its scalar CSR
+            representation, and every local row partition must be divisible by
+            this value.
         reuse_setup: Reuse the cached AmgX hierarchy across solves with the
             same sparsity pattern.
 

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -90,6 +90,7 @@ class ShardedMatrix:
         partition_info: tuple[int, int],
         row_counts: tuple[int, ...],
         max_local_size: int,
+        coloring: tuple | None = None,
     ) -> None:
         local_nnz = int(local_bcsr.data.shape[0])
         # Keep only the rank-local CSR structure. The matrix values live solely
@@ -116,6 +117,9 @@ class ShardedMatrix:
         self.max_local_nnz = int(data.addressable_shards[0].data.shape[0])
         self.shape = (self.global_size, self.global_size)
         self.local_shape = tuple(local_bcsr.shape)
+        # Coloring of the source operator, if any, for materializing
+        # operators with this sparsity.
+        self._coloring = coloring
 
     def local_matrix(self, data: jax.Array | None = None) -> jsp.BCSR:
         """Return this rank's unpadded BCSR matrix for ``data`` or cached values.
@@ -127,7 +131,10 @@ class ShardedMatrix:
         """
         values = self.data if data is None else data
         _validate_operand(values, self.data, self.mesh, self.axis_name, "matrix data")
-        local_values = values.addressable_shards[0].data[: self.local_nnz]
+        # The caller may be inside jax.set_mesh over the whole mesh, which
+        # rejects single-device slicing.
+        with jax.set_mesh(_local_mesh(self.mesh, self.axis_name)):
+            local_values = values.addressable_shards[0].data[: self.local_nnz]
         return jsp.BCSR(
             (local_values, self._structure.indices, self._structure.indptr),
             shape=self._structure.shape,
@@ -154,18 +161,21 @@ class ShardedSolve:
         b: jax.Array,
         x0: jax.Array | None = None,
         *,
-        A_data: jax.Array | None = None,
+        A: MatrixOrOperator | jax.Array | None = None,
         save_stats_file: str | os.PathLike | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
-        """Solve with cached values or an explicit differentiable ``A_data``.
+        """Solve with the cached values or an explicit ``A``.
 
-        ``A_data`` may be omitted for a direct call but is required inside a
-        JAX transformation so matrix values remain a dynamic operand.
-        ``save_stats_file`` writes formatted AmgX statistics after a direct
-        call (rank 0 writes the file); the solver must have been created with
-        ``save_stats=True`` for the file to contain solver statistics.
+        ``A`` is this rank's ``(n_local, n_global)`` operator or matrix with the
+        sparsity fixed at solver creation, as ``solve(A, b)`` takes it, or the
+        packed global values in the layout of ``ShardedMatrix.data``. Operator
+        parameters must be identical on every rank and receive the gradient of
+        the global loss; packed values receive their per-entry gradient. ``A``
+        is required inside a JAX transformation. ``save_stats_file`` writes
+        AmgX statistics after a direct call (rank 0 writes the file; requires
+        ``save_stats=True`` at creation).
         """
-        return self._solve_fn(b, x0, A_data=A_data, save_stats_file=save_stats_file)
+        return self._solve_fn(b, x0, A=A, save_stats_file=save_stats_file)
 
     def local_vector(self, value: jax.Array) -> jax.Array:
         """Return this rank's unpadded rows of a solver vector.
@@ -261,6 +271,11 @@ def make_sharded_vector(
         padded_values,
         global_shape=(comm_size * max_local_size,),
     )
+
+
+def _local_mesh(mesh: Mesh, axis_name: str) -> Mesh:
+    """This process's mesh device as a one-device mesh."""
+    return jax.make_mesh((1,), (axis_name,), devices=[mesh.local_devices[0]])
 
 
 def _require_shard_map() -> None:
@@ -477,6 +492,7 @@ def _pack_sharded_matrix(
     row_counts: tuple[int, ...],
     max_local_size: int,
     max_nnz: int | None = None,
+    coloring: tuple | None = None,
 ) -> ShardedMatrix:
     """Pack normalized local values into a global sharded array."""
     local_nnz = int(A_bcsr.data.shape[0])
@@ -502,6 +518,7 @@ def _pack_sharded_matrix(
         partition_info,
         row_counts,
         max_local_size,
+        coloring,
     )
 
 
@@ -558,6 +575,9 @@ def make_sharded_matrix(
         partition_info,
         row_counts,
         max_local_size,
+        coloring=(
+            getattr(A_local, "_coloring_info", None) if callable(A_local) else None
+        ),
     )
 
 
@@ -611,7 +631,7 @@ def make_sharded_solver(
     ``jax.distributed.initialize()`` must be called before this function in a
     multi-process job. The matrix owns the communicator, mesh, local CSR
     structure, and globally sharded packed values. Pass ``A.data`` through
-    ``solver(..., A_data=A_data)`` to differentiate matrix values. Use
+    ``solver(..., A=A.data)`` to differentiate matrix values. Use
     ``jax.set_mesh(A.mesh)`` around outer transforms such as ``jax.grad``.
 
     .. warning::
@@ -644,12 +664,13 @@ def make_sharded_solver(
             file.
 
     Returns:
-        A callable ``solver(b, x0=None, *, A_data=None, save_stats_file=None)``. Use
-        ``A.local_matrix(gradient)`` to convert packed matrix gradients to this
-        rank's unpadded BCSR structure. ``solver.local_vector(value)`` removes
-        vector padding. ``A_data`` may be omitted for a direct call but must be
-        explicit under ``jax.jit``, ``jax.grad``, or another JAX transform. For
-        each solve, info values have one entry per rank.
+        A callable ``solver(b, x0=None, *, A=None, save_stats_file=None)``.
+        ``A`` is this rank's operator or matrix with the sparsity fixed here
+        (its closed-over parameters must be identical on every rank) or the
+        packed global values ``A.data``; it may be omitted for a direct call
+        but is required under a JAX transform. ``A.local_matrix(gradient)``
+        unpacks a packed matrix gradient and ``solver.local_vector(value)``
+        removes vector padding. Info values have one entry per rank.
     """
     _require_shard_map()
     if not isinstance(A, ShardedMatrix):
@@ -934,7 +955,7 @@ def make_sharded_solver(
     # under it so that its single-device operations dispatch cleanly even when
     # the caller sits inside jax.set_mesh over the whole multi-process mesh
     # (as an eager outer transform requires for its own global-array ops).
-    local_mesh = jax.make_mesh((1,), (axis_name,), devices=[local_device])
+    local_mesh = _local_mesh(mesh, axis_name)
 
     def local_shard(value: jax.Array) -> jax.Array:
         return value.addressable_shards[0].data
@@ -1011,6 +1032,191 @@ def make_sharded_solver(
             out_specs=A_data_spec,
         ),
     )
+
+    coloring = A._coloring
+
+    def local_values_of(A_local: MatrixOrOperator) -> jax.Array:
+        """This rank's padded values of ``A_local`` in the packed layout."""
+        if callable(A_local):
+            info = getattr(A_local, "_coloring_info", None) or coloring
+            if info is None:
+                raise ValueError(
+                    "A is a matrix-free operator without coloring information; "
+                    "build the sharded matrix from the operator, or attach "
+                    "coloring with jaxamg.with_cache(op, coloring="
+                    "jaxamg.cache_coloring(op, shape=(n_local, n_global)))"
+                )
+            rows, cols, column_colors, n_colors, shape = info
+            if tuple(shape) != (n_local, nglobal):
+                raise ValueError(
+                    f"A must have local shape {(n_local, nglobal)}; its "
+                    f"coloring describes shape {tuple(shape)}"
+                )
+            from .sparsity import materialize_sparse_matrix
+
+            values = materialize_sparse_matrix(
+                A_local, shape, rows, cols, column_colors, n_colors
+            ).data
+        else:
+            values = to_bcsr_matrix(
+                A_local,
+                b=jnp.zeros(n_local, dtype=A_data.dtype),
+                use_int64_indices=True,
+            ).data
+        if values.shape[0] != local_nnz:
+            raise ValueError(
+                "A must have the sparsity structure fixed when the solver was "
+                f"created; got {values.shape[0]} local nonzeros, expected "
+                f"{local_nnz}"
+            )
+        return jnp.pad(values.astype(A_data.dtype), (0, max_nnz - local_nnz))
+
+    def lax_reduce(value: jax.Array) -> jax.Array:
+        return jax.lax.psum(value, axis_name)
+
+    if nranks == 1:
+
+        def mpi_reduce(value: jax.Array) -> jax.Array:
+            return value
+
+    else:
+
+        def mpi_reduce(value: jax.Array) -> jax.Array:
+            import mpi4jax
+            from mpi4py import MPI
+
+            return mpi4jax.allreduce(value, op=MPI.SUM, comm=comm)
+
+    def require_replicated(value: jax.Array) -> None:
+        sharding = getattr(getattr(value, "aval", None), "sharding", None)
+        spec = getattr(sharding, "spec", None)
+        if spec is not None and any(entry is not None for entry in spec):
+            raise ValueError(
+                "a differentiable value that A closes over is sharded across "
+                "ranks; such values must be identical on every rank. Pass "
+                "rank-local matrix values as the packed array A.data instead."
+            )
+
+    def check_replicated(value: Any) -> None:
+        if (
+            isinstance(value, jax.Array)
+            and not isinstance(value, jax.core.Tracer)
+            and not value.sharding.is_fully_replicated
+        ):
+            raise ValueError(
+                "a value that A closes over is sharded across ranks; such "
+                "values must be identical on every rank. Pass rank-local "
+                "matrix values as the packed array A.data instead."
+            )
+
+    def local_copy(value: Any) -> Any:
+        """This process's copy of a value: for an array spanning the mesh,
+        its addressable shard (the value is replicated)."""
+        if isinstance(value, jax.Array) and not isinstance(value, jax.core.Tracer):
+            return value.addressable_shards[0].data
+        return value
+
+    def replicated_over_mesh(local_value: jax.Array) -> jax.Array:
+        """This rank's value typed as replicated over the mesh; ranks may
+        differ, and only this rank's copy is read back."""
+        return jax.make_array_from_single_device_arrays(
+            local_value.shape,
+            NamedSharding(mesh, P()),
+            [jax.device_put(local_value, local_device)],
+        )
+
+    def typed_like(cotangent: jax.Array, primal: jax.Array) -> jax.Array:
+        if isinstance(getattr(primal, "sharding", None), NamedSharding):
+            return replicated_over_mesh(cotangent)
+        return cotangent
+
+    def in_mesh_context() -> bool:
+        return not jax.sharding.get_abstract_mesh().empty
+
+    # The materialization is ordinary JAX code evaluated outside shard_map
+    # (JAX assumes a shard_map body is identical on every device; per-process
+    # constants violate that). Traced, each process computes its own values
+    # typed replicated (P()); eagerly it runs in the caller's context, which
+    # its arrays' types are tied to. Two custom VJPs bracket it: local_to_global
+    # avoids the psum JAX would insert when transposing replicated to sharded,
+    # and reduce_cotangent sums parameter cotangents across ranks.
+    to_shards = jax.shard_map(
+        lambda values: values,
+        mesh=mesh,
+        in_specs=(P(),),
+        out_specs=A_data_spec,
+        check_vma=False,
+    )
+    from_shards = jax.shard_map(
+        lambda values: values,
+        mesh=mesh,
+        in_specs=(A_data_spec,),
+        out_specs=P(),
+        check_vma=False,
+    )
+    sum_across_ranks = jax.shard_map(
+        lax_reduce, mesh=mesh, in_specs=(P(),), out_specs=P(), check_vma=False
+    )
+
+    @jax.custom_vjp
+    def local_to_global(values: jax.Array) -> jax.Array:
+        if isinstance(values, jax.core.Tracer):
+            return to_shards(values)
+        return assemble_global(local_copy(values))
+
+    def local_to_global_fwd(values: jax.Array):
+        return local_to_global(values), values
+
+    def local_to_global_bwd(values: jax.Array, ct: jax.Array):
+        if isinstance(ct, jax.core.Tracer):
+            return (from_shards(ct),)
+        return (typed_like(local_shard(ct), values),)
+
+    local_to_global.defvjp(local_to_global_fwd, local_to_global_bwd)
+
+    @jax.custom_vjp
+    def reduce_cotangent(value: jax.Array) -> jax.Array:
+        return value
+
+    def reduce_cotangent_fwd(value: jax.Array):
+        return value, value
+
+    def reduce_cotangent_bwd(value: jax.Array, ct: jax.Array):
+        if isinstance(ct, jax.core.Tracer):
+            return (sum_across_ranks(ct),)
+        with jax.set_mesh(local_mesh):
+            reduced = mpi_reduce(local_copy(ct))
+        return (typed_like(reduced, value),)
+
+    reduce_cotangent.defvjp(reduce_cotangent_fwd, reduce_cotangent_bwd)
+
+    def pack_operator(A_local: MatrixOrOperator, traced: bool) -> jax.Array:
+        """Global packed values of a local operator or matrix, differentiable
+        with respect to the traced values it closes over."""
+        closed = jax.make_jaxpr(lambda: local_values_of(A_local))()
+        # Traced closed-over values become explicit inputs; the rest stay
+        # jaxpr constants.
+        hoisted = tuple(
+            const
+            for const in closed.consts
+            if isinstance(const, jax.core.Tracer)
+            and jnp.issubdtype(const.dtype, jnp.inexact)
+        )
+        if traced:
+            for value in hoisted:
+                require_replicated(value)
+        slots = {id(const): index for index, const in enumerate(hoisted)}
+        values = tuple(reduce_cotangent(value) for value in hoisted)
+        consts = []
+        for const in closed.consts:
+            if id(const) in slots:
+                consts.append(values[slots[id(const)]])
+                continue
+            check_replicated(const)
+            # A jit cannot close over an array spanning the mesh; eager
+            # evaluation needs it as is.
+            consts.append(local_copy(const) if traced else const)
+        return local_to_global(jax.core.eval_jaxpr(closed.jaxpr, consts)[0])
 
     def differentiated_solve_backward(
         matrix_data: jax.Array, x: jax.Array, g_x: jax.Array
@@ -1092,19 +1298,24 @@ def make_sharded_solver(
         rhs: jax.Array,
         x0: jax.Array | None = None,
         *,
-        A_data_override: jax.Array | None = None,
+        A_override: MatrixOrOperator | jax.Array | None = None,
         save_stats_file: str | os.PathLike | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
         _validate_operand(rhs, b, mesh, axis_name, "b")
-        if A_data_override is None:
-            if isinstance(rhs, jax.core.Tracer) or isinstance(x0, jax.core.Tracer):
+        traced = isinstance(rhs, jax.core.Tracer) or isinstance(x0, jax.core.Tracer)
+        if A_override is None:
+            if traced:
                 raise ValueError(
-                    "A_data must be passed explicitly when a sharded solver is "
-                    "used inside jax.jit, jax.grad, or another JAX transform"
+                    "A must be passed explicitly (this rank's operator or "
+                    "matrix, or the packed values A.data) when a sharded solver "
+                    "is used inside jax.jit, jax.grad, or another JAX transform"
                 )
             matrix_data = A_data
+        elif isinstance(A_override, jax.Array) and A_override.ndim == 1:
+            # The packed global values themselves.
+            matrix_data = A_override
         else:
-            matrix_data = A_data_override
+            matrix_data = pack_operator(A_override, traced)
         _validate_operand(matrix_data, A_data, mesh, axis_name, "A_data")
         if save_stats_file is not None:
             if any(
@@ -1137,18 +1348,17 @@ def make_sharded_solver(
 
     def unpad_local_vector(value: jax.Array) -> jax.Array:
         _validate_operand(value, b, mesh, axis_name, "solver vector")
-        return value.addressable_shards[0].data[:n_local]
+        with jax.set_mesh(local_mesh):
+            return value.addressable_shards[0].data[:n_local]
 
     def solve_fn(
         rhs: jax.Array,
         x0: jax.Array | None = None,
         *,
-        A_data: jax.Array | None = None,
+        A: MatrixOrOperator | jax.Array | None = None,
         save_stats_file: str | os.PathLike | None = None,
     ) -> tuple[jax.Array, ShardedInfo]:
-        return sharded_solver(
-            rhs, x0, A_data_override=A_data, save_stats_file=save_stats_file
-        )
+        return sharded_solver(rhs, x0, A_override=A, save_stats_file=save_stats_file)
 
     return ShardedSolve(
         solve_fn,

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -28,6 +28,13 @@ from .mpi_utils import (
     build_halo_plan,
     build_transpose_plan,
 )
+from .nullspace import (
+    _MISSING_NULLSPACE_MSG,
+    _MISSING_TRANSPOSE_MSG,
+    NullSpaceWarning,
+    as_nullspace_basis,
+    validate_basis,
+)
 from .utils import (
     MatrixOrOperator,
     get_preferred_dtype,
@@ -135,6 +142,8 @@ class ShardedMatrix:
         row_counts: tuple[int, ...],
         max_local_size: int,
         coloring: tuple | None = None,
+        nullspace: jax.Array | None = None,
+        transpose_nullspace: jax.Array | None = None,
     ) -> None:
         local_nnz = int(local_bcsr.data.shape[0])
         # Keep only the rank-local CSR structure. The matrix values live solely
@@ -164,6 +173,9 @@ class ShardedMatrix:
         # Coloring of the source operator, if any, for materializing
         # operators with this sparsity.
         self._coloring = coloring
+        # Null-space bases of the local rows, fixed like the sparsity.
+        self._nullspace = nullspace
+        self._transpose_nullspace = transpose_nullspace
 
     def local_matrix(self, data: jax.Array | None = None) -> jsp.BCSR:
         """Return this rank's unpadded BCSR matrix for ``data`` or cached values.
@@ -338,15 +350,15 @@ def _require_shard_map() -> None:
         )
 
 
-def _reject_nullspace(A_local: MatrixOrOperator) -> None:
-    if any(
-        getattr(A_local, attr, None) is not None
-        for attr in ("_nullspace", "_transpose_nullspace")
-    ):
-        raise ValueError(
-            "null spaces are not supported by the sharding interface yet; use "
-            "solve(..., comm=...) for singular systems"
-        )
+def _local_basis(
+    A_local: MatrixOrOperator, name: str, n_local: int, n_global: int, dtype: Any
+) -> jax.Array | None:
+    """Normalized ``(n_local, k)`` null-space basis attached to ``A_local``."""
+    basis = as_nullspace_basis(
+        getattr(A_local, f"_{name}", None), n_local, dtype, name, n_global
+    )
+    # Uncommitted, so a shard_map spanning the mesh can capture it.
+    return None if basis is None else jnp.asarray(np.asarray(basis))
 
 
 def _resolve_mesh(
@@ -560,6 +572,8 @@ def _pack_sharded_matrix(
     max_local_size: int,
     max_nnz: int | None = None,
     coloring: tuple | None = None,
+    nullspace: jax.Array | None = None,
+    transpose_nullspace: jax.Array | None = None,
 ) -> ShardedMatrix:
     """Pack normalized local values into a global sharded array."""
     local_nnz = int(A_bcsr.data.shape[0])
@@ -586,6 +600,8 @@ def _pack_sharded_matrix(
         row_counts,
         max_local_size,
         coloring,
+        nullspace,
+        transpose_nullspace,
     )
 
 
@@ -610,6 +626,9 @@ def make_sharded_matrix(
             operator is also accepted, provided it carries cached coloring
             information (``jaxamg.with_cache(op, coloring=...)``) so its shape
             and sparsity pattern are known; it is materialized once here.
+            Null-space bases attached with ``with_cache(A_local,
+            nullspace=..., transpose_nullspace=...)`` (local rows) are kept
+            and applied by every solve.
         b: Global row-sharded RHS used to validate the matrix partition, mesh,
             and numerical dtype.
         comm: MPI communicator spanning every JAX process, with rank order
@@ -629,12 +648,12 @@ def make_sharded_matrix(
     mesh = _resolve_mesh(b, mesh, axis_name)
     _validate_runtime(comm, mesh, axis_name)
 
-    _reject_nullspace(A_local)
     n_local, nglobal = _local_matrix_shape(A_local)
     partition_info, row_counts, max_local_size = _local_partition(
         b, mesh, axis_name, comm, n_local, nglobal
     )
     A_bcsr = _normalize_local_matrix(A_local, b, partition_info)
+    dtype = A_bcsr.data.dtype
     return _pack_sharded_matrix(
         A_bcsr,
         comm,
@@ -645,6 +664,10 @@ def make_sharded_matrix(
         max_local_size,
         coloring=(
             getattr(A_local, "_coloring_info", None) if callable(A_local) else None
+        ),
+        nullspace=_local_basis(A_local, "nullspace", n_local, nglobal, dtype),
+        transpose_nullspace=_local_basis(
+            A_local, "transpose_nullspace", n_local, nglobal, dtype
         ),
     )
 
@@ -761,6 +784,43 @@ def make_sharded_solver(
         )
 
     _validate_matrix(A_structure, nglobal, partition_info, block_dim)
+
+    # Null spaces as in solve(): a symmetric matrix shares one basis.
+    nullspace = A._nullspace
+    transpose_nullspace = A._transpose_nullspace
+    if transpose_nullspace is None and nullspace is not None:
+        if is_symmetric:
+            transpose_nullspace = nullspace
+        else:
+            warnings.warn(_MISSING_TRANSPOSE_MSG, NullSpaceWarning, stacklevel=2)
+    elif nullspace is None and transpose_nullspace is not None:
+        if is_symmetric:
+            nullspace = transpose_nullspace
+        else:
+            warnings.warn(_MISSING_NULLSPACE_MSG, NullSpaceWarning, stacklevel=2)
+    # Every rank must take the same basis-dependent branches and collectives.
+    schema = tuple(
+        None if basis is None else basis.shape[1]
+        for basis in (nullspace, transpose_nullspace)
+    )
+    schemas = comm.allgather(schema)
+    if any(other != schema for other in schemas):
+        raise ValueError(
+            "null-space bases must be declared on every rank with the same "
+            "column counts; (nullspace, transpose_nullspace) columns per rank: "
+            f"{schemas}"
+        )
+    # Validate here, collectively, on the schedule the schema check fixed;
+    # the nested solves are told to skip it (see ``nullspaces_validated``).
+    if nullspace is not None:
+        validate_basis(nullspace, "nullspace", comm)
+    if transpose_nullspace is not None:
+        validate_basis(transpose_nullspace, "transpose_nullspace", comm)
+    singular = nullspace is not None or transpose_nullspace is not None
+    primal_bases = (nullspace, transpose_nullspace)
+    # For Aᵀ the roles of the two null spaces swap.
+    adjoint_bases = primal_bases if is_symmetric else (transpose_nullspace, nullspace)
+
     local_device = mesh.local_devices[0]
     local_hardware_id = getattr(local_device, "local_hardware_id", local_device.id)
 
@@ -826,18 +886,26 @@ def make_sharded_solver(
         row_indices=local_row_indices,
         save_stats=save_stats,
         block_dim=block_dim,
+        singular=singular,
         lrank=int(local_hardware_id),
         device=local_device,
         commit=False,
     )
     if not is_symmetric:
-        # The MPI solve's primal does not consume halo operands, and sharding's
-        # outer VJP computes its matrix gradient from A's existing halo plan.
-        # Therefore the nested A^T solve needs only placeholder halo operands.
-        transpose_cache = {
-            **mpi_cache,
-            "halo_plan": _primal_halo_placeholder(n_local, len(A.row_counts)),
-        }
+        # The nested Aᵀ solve's primal ignores halo operands and the matrix
+        # gradient uses A's own plan; a real plan is needed only for the
+        # null-space check of Aᵀ.
+        transpose_halo = (
+            build_halo_plan(
+                np.asarray(transpose_plan.indices, dtype=np.int64),
+                A.row_counts,
+                partition_info,
+                comm,
+            )
+            if transpose_nullspace is not None
+            else _primal_halo_placeholder(n_local, len(A.row_counts))
+        )
+        transpose_cache = {**mpi_cache, "halo_plan": transpose_halo}
 
     info_specs = {
         "iterations": P(axis_name),
@@ -845,6 +913,8 @@ def make_sharded_solver(
         "status": P(axis_name),
         "residual_history": P(axis_name, None),
     }
+    if transpose_nullspace is not None:
+        info_specs["rhs_inconsistency"] = P(axis_name)
 
     res_history_len = amgx_config.outer_max_iters(mpi_cache["config_str"]) + 1
 
@@ -859,18 +929,24 @@ def make_sharded_solver(
                 (0, res_history_len - history.shape[0]),
                 constant_values=jnp.nan,
             )
-        return {
+        packed = {
             "iterations": jnp.asarray(info["iterations"], dtype=jnp.int32)[None],
             "residual": jnp.asarray(info["residual"])[None],
             "status": jnp.asarray(info["status"], dtype=jnp.int32)[None],
             "residual_history": history[None, :],
         }
+        if "rhs_inconsistency" in info:
+            packed["rhs_inconsistency"] = jnp.asarray(
+                info["rhs_inconsistency"], dtype=A_data.dtype
+            )[None]
+        return packed
 
     def matrix_with_data(
         data_local: jax.Array,
         structure: _CSRStructure,
         cache: dict[str, Any],
         symmetric: bool,
+        bases: tuple[jax.Array | None, jax.Array | None],
     ) -> jsp.BCSR:
         matrix = jsp.BCSR(
             (
@@ -880,7 +956,13 @@ def make_sharded_solver(
             ),
             shape=structure.shape,
         )
-        return with_cache(matrix, mpi=cache, is_symmetric=symmetric)
+        return with_cache(
+            matrix,
+            mpi=cache,
+            is_symmetric=symmetric,
+            nullspace=bases[0],
+            transpose_nullspace=bases[1],
+        )
 
     def pad_local_vector(value: jax.Array) -> jax.Array:
         return jnp.pad(value, (0, max_n_local - n_local))
@@ -903,19 +985,32 @@ def make_sharded_solver(
             save_stats_file=os.devnull if save_stats else None,
         )
 
-    def local_solve(
-        A_data_local: jax.Array, rhs_local: jax.Array
-    ) -> tuple[jax.Array, ShardedInfo]:
-        A_dynamic = matrix_with_data(A_data_local, A_structure, mpi_cache, is_symmetric)
-        x_local, info = solve_one_rhs(A_dynamic, rhs_local)
-        return pad_local_vector(x_local), pack_info(info)
+    def make_local_solves(
+        reduce: Callable[[jax.Array], jax.Array],
+    ) -> tuple[Callable[..., Any], Callable[..., Any]]:
+        # The nested solve reduces its null-space projections with ``reduce``:
+        # psum inside shard_map, mpi4jax for a direct call.
+        cache = {**mpi_cache, "reduce_sum": reduce, "nullspaces_validated": True}
 
-    def local_solve_x0(
-        A_data_local: jax.Array, rhs_local: jax.Array, x0_local: jax.Array
-    ) -> tuple[jax.Array, ShardedInfo]:
-        A_dynamic = matrix_with_data(A_data_local, A_structure, mpi_cache, is_symmetric)
-        x_local, info = solve_one_rhs(A_dynamic, rhs_local, x0_local)
-        return pad_local_vector(x_local), pack_info(info)
+        def local_solve(
+            A_data_local: jax.Array, rhs_local: jax.Array
+        ) -> tuple[jax.Array, ShardedInfo]:
+            A_dynamic = matrix_with_data(
+                A_data_local, A_structure, cache, is_symmetric, primal_bases
+            )
+            x_local, info = solve_one_rhs(A_dynamic, rhs_local)
+            return pad_local_vector(x_local), pack_info(info)
+
+        def local_solve_x0(
+            A_data_local: jax.Array, rhs_local: jax.Array, x0_local: jax.Array
+        ) -> tuple[jax.Array, ShardedInfo]:
+            A_dynamic = matrix_with_data(
+                A_data_local, A_structure, cache, is_symmetric, primal_bases
+            )
+            x_local, info = solve_one_rhs(A_dynamic, rhs_local, x0_local)
+            return pad_local_vector(x_local), pack_info(info)
+
+        return local_solve, local_solve_x0
 
     def make_local_transpose_values(
         exchange: Callable[[jax.Array], jax.Array],
@@ -944,20 +1039,29 @@ def make_sharded_solver(
 
         return local_transpose_values
 
-    def local_adjoint(adjoint_data_local: jax.Array, g_local: jax.Array) -> jax.Array:
+    def make_local_adjoint(
+        reduce: Callable[[jax.Array], jax.Array],
+    ) -> Callable[[jax.Array, jax.Array], jax.Array]:
         if is_symmetric:
             structure = A_structure
-            cache = mpi_cache
+            base_cache = mpi_cache
         else:
             assert transpose_structure is not None
             assert transpose_cache is not None
             structure = transpose_structure
-            cache = transpose_cache
-        A_adjoint = matrix_with_data(
-            adjoint_data_local, structure, cache, symmetric=is_symmetric
-        )
-        adjoint_local, _ = solve_one_rhs(A_adjoint, g_local)
-        return pad_local_vector(adjoint_local)
+            base_cache = transpose_cache
+        cache = {**base_cache, "reduce_sum": reduce, "nullspaces_validated": True}
+
+        def local_adjoint(
+            adjoint_data_local: jax.Array, g_local: jax.Array
+        ) -> jax.Array:
+            A_adjoint = matrix_with_data(
+                adjoint_data_local, structure, cache, is_symmetric, adjoint_bases
+            )
+            adjoint_local, _ = solve_one_rhs(A_adjoint, g_local)
+            return pad_local_vector(adjoint_local)
+
+        return local_adjoint
 
     halo_plan = mpi_cache["halo_plan"]
     max_n_ghost = halo_plan.max_n_ghost
@@ -1015,6 +1119,22 @@ def make_sharded_solver(
 
             return mpi4jax.alltoall(values, comm=comm)
 
+    def lax_reduce(value: jax.Array) -> jax.Array:
+        return jax.lax.psum(value, axis_name)
+
+    if nranks == 1:
+
+        def mpi_reduce(value: jax.Array) -> jax.Array:
+            return value
+
+    else:
+
+        def mpi_reduce(value: jax.Array) -> jax.Array:
+            import mpi4jax
+            from mpi4py import MPI
+
+            return mpi4jax.allreduce(value, op=MPI.SUM, comm=comm)
+
     # The mesh-local device as a one-device mesh. The eager local branch runs
     # under it so that its single-device operations dispatch cleanly even when
     # the caller sits inside jax.set_mesh over the whole multi-process mesh
@@ -1047,19 +1167,21 @@ def make_sharded_solver(
 
         return invoke
 
+    eager_solve, eager_solve_x0 = make_local_solves(mpi_reduce)
+    traced_solve, traced_solve_x0 = make_local_solves(lax_reduce)
     mapped_solve = dispatch(
-        local_solve,
+        eager_solve,
         jax.shard_map(
-            local_solve,
+            traced_solve,
             mesh=mesh,
             in_specs=(A_data_spec, rhs_spec),
             out_specs=(rhs_spec, info_specs),
         ),
     )
     mapped_solve_x0 = dispatch(
-        local_solve_x0,
+        eager_solve_x0,
         jax.shard_map(
-            local_solve_x0,
+            traced_solve_x0,
             mesh=mesh,
             in_specs=(A_data_spec, rhs_spec, rhs_spec),
             out_specs=(rhs_spec, info_specs),
@@ -1079,9 +1201,9 @@ def make_sharded_solver(
             ),
         )
     mapped_adjoint = dispatch(
-        local_adjoint,
+        make_local_adjoint(mpi_reduce),
         jax.shard_map(
-            local_adjoint,
+            make_local_adjoint(lax_reduce),
             mesh=mesh,
             in_specs=(A_data_spec, scalar_spec),
             out_specs=scalar_spec,
@@ -1162,22 +1284,6 @@ def make_sharded_solver(
                 f"{local_nnz}"
             )
         return jnp.pad(values.astype(A_data.dtype), (0, max_nnz - local_nnz))
-
-    def lax_reduce(value: jax.Array) -> jax.Array:
-        return jax.lax.psum(value, axis_name)
-
-    if nranks == 1:
-
-        def mpi_reduce(value: jax.Array) -> jax.Array:
-            return value
-
-    else:
-
-        def mpi_reduce(value: jax.Array) -> jax.Array:
-            import mpi4jax
-            from mpi4py import MPI
-
-            return mpi4jax.allreduce(value, op=MPI.SUM, comm=comm)
 
     def require_replicated(value: jax.Array) -> None:
         sharding = getattr(getattr(value, "aval", None), "sharding", None)
@@ -1285,7 +1391,6 @@ def make_sharded_solver(
     def pack_operator(A_local: MatrixOrOperator, traced: bool) -> jax.Array:
         """Global packed values of a local operator or matrix, differentiable
         with respect to the traced values it closes over."""
-        _reject_nullspace(A_local)
         closed = jax.make_jaxpr(lambda: local_values_of(A_local))()
         # Traced closed-over values become explicit inputs; the rest stay
         # jaxpr constants.

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -19,6 +19,7 @@ import numpy as np
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
+from . import config as amgx_config
 from .cache import _build_mpi_cache, with_cache
 from .jaxamg import _capture_and_save_stats, solve
 from .mpi_utils import (
@@ -90,14 +91,15 @@ class ShardedMatrix:
         row_counts: tuple[int, ...],
         max_local_size: int,
     ) -> None:
-        local_device = mesh.local_devices[0]
         local_nnz = int(local_bcsr.data.shape[0])
         # Keep only the rank-local CSR structure. The matrix values live solely
         # in the padded shard of ``data``; ``local_matrix`` re-slices them on
-        # demand, so no second per-rank value buffer is retained.
+        # demand, so no second per-rank value buffer is retained. These arrays
+        # stay uncommitted: an array pinned to this process's single device
+        # cannot be captured by a shard_map spanning the whole mesh.
         self._structure = _CSRStructure(
-            jax.device_put(local_bcsr.indices, local_device),
-            jax.device_put(local_bcsr.indptr, local_device),
+            jnp.asarray(local_bcsr.indices),
+            jnp.asarray(local_bcsr.indptr),
             tuple(local_bcsr.shape),
             local_nnz,
         )
@@ -408,15 +410,34 @@ def _local_partition(
     return (row_start, row_start + n_local), local_sizes, max_local_size
 
 
+def _local_matrix_shape(A_local: MatrixOrOperator) -> tuple[int, int]:
+    """Resolve the ``(n_local, n_global)`` shape of a local matrix or operator.
+
+    A matrix-free operator is a plain callable with no ``shape``, so its shape
+    comes from the coloring cache that the distributed solve needs anyway.
+    """
+    shape = getattr(A_local, "shape", None)
+    if shape is None and callable(A_local):
+        coloring = getattr(A_local, "_coloring_info", None)
+        if coloring is None:
+            raise ValueError(
+                "a callable A_local must carry cached coloring information so "
+                "its shape is known; attach it with jaxamg.with_cache(op, "
+                "coloring=jaxamg.cache_coloring(op, shape=(n_local, n_global)))"
+            )
+        shape = coloring[4]
+    if shape is None or len(shape) != 2:
+        raise ValueError("A_local must have a two-dimensional shape")
+    return int(shape[0]), int(shape[1])
+
+
 def _validate_matrix(
     A_local: MatrixOrOperator,
     nglobal: int,
     partition_info: tuple[int, int],
     block_dim: int,
 ) -> None:
-    shape = getattr(A_local, "shape", None)
-    if shape is None or len(shape) != 2:
-        raise ValueError("A_local must have a two-dimensional shape")
+    shape = _local_matrix_shape(A_local)
 
     n_local = partition_info[1] - partition_info[0]
     if tuple(shape) != (n_local, nglobal):
@@ -440,7 +461,7 @@ def _normalize_local_matrix(
 ) -> jsp.BCSR:
     """Normalize a validated local matrix partition."""
     n_local = partition_info[1] - partition_info[0]
-    nglobal = int(getattr(A_local, "shape")[1])
+    nglobal = _local_matrix_shape(A_local)[1]
     _validate_matrix(A_local, nglobal, partition_info, block_dim=1)
 
     local_rhs = b.addressable_shards[0].data[:n_local]
@@ -501,7 +522,10 @@ def make_sharded_matrix(
 
     Args:
         A_local: This process's CSR row partition with shape
-            ``(n_local, n_global)`` and global column indices.
+            ``(n_local, n_global)`` and global column indices. A matrix-free
+            operator is also accepted, provided it carries cached coloring
+            information (``jaxamg.with_cache(op, coloring=...)``) so its shape
+            and sparsity pattern are known; it is materialized once here.
         b: Global row-sharded RHS used to validate the matrix partition, mesh,
             and numerical dtype.
         comm: MPI communicator whose rank order matches the JAX process order.
@@ -521,11 +545,7 @@ def make_sharded_matrix(
     mesh = _resolve_mesh(b, mesh, axis_name)
     _validate_runtime(comm, mesh, axis_name)
 
-    matrix_shape = getattr(A_local, "shape", None)
-    if matrix_shape is None or len(matrix_shape) != 2:
-        raise ValueError("A_local must have a two-dimensional shape")
-    n_local = int(matrix_shape[0])
-    nglobal = int(matrix_shape[1])
+    n_local, nglobal = _local_matrix_shape(A_local)
     partition_info, row_counts, max_local_size = _local_partition(
         b, mesh, axis_name, comm, n_local, nglobal
     )
@@ -572,7 +592,15 @@ def make_sharded_solver(
     reuse_setup: bool = False,
     save_stats: bool = False,
 ) -> ShardedSolve:
-    """Create a JIT-compiled solver for a globally sharded RHS.
+    """Create a solver for a globally sharded RHS.
+
+    Whether the solve is compiled is entirely the caller's choice: this function
+    adds no ``jax.jit`` of its own. A caller that wraps its own function in
+    ``jax.jit`` gets the whole pipeline compiled as part of that single program
+    (through ``jax.shard_map``). A direct, untransformed call instead executes
+    the rank-local pipeline on this process's shard -- the same code path as
+    ``solve(..., comm=...)``, with mpi4jax for the gradient exchanges -- and
+    reassembles global arrays, so it matches the MPI interface's eager speed.
 
     This interface complements, rather than replaces, ``solve(..., comm=...)``.
     JAX manages the global input and output arrays through ``shard_map`` while
@@ -585,6 +613,17 @@ def make_sharded_solver(
     structure, and globally sharded packed values. Pass ``A.data`` through
     ``solver(..., A_data=A_data)`` to differentiate matrix values. Use
     ``jax.set_mesh(A.mesh)`` around outer transforms such as ``jax.grad``.
+
+    .. warning::
+        The rank-local CSR structure and communication plans are compiled into
+        each process's program as constants, so the processes compile programs
+        that differ. XLA's cross-process sharded autotuning assumes identical
+        programs and deadlocks during compilation when such a program also
+        contains an automatically partitioned collective -- which is what
+        ``jnp.sum(x)`` over a sharded solution inside ``jax.jit`` produces. Run
+        multi-process sharded jobs with ``XLA_FLAGS=--xla_gpu_shard_autotuning=false``
+        (set before JAX initializes its backend) to disable that autotuning;
+        see :doc:`sharding` for details.
 
     Args:
         A: Distributed matrix created with :func:`make_sharded_matrix`.
@@ -671,26 +710,25 @@ def make_sharded_solver(
         )
         with temp_enable_x64():
             transpose_structure = _CSRStructure(
-                jax.device_put(transpose_plan.indices, local_device),
-                jax.device_put(transpose_plan.indptr, local_device),
+                jnp.asarray(transpose_plan.indices),
+                jnp.asarray(transpose_plan.indptr),
                 (n_local, nglobal),
                 transpose_plan.nnz,
             )
         nnz_out = transpose_plan.nnz
         max_transpose_nnz = transpose_plan.max_nnz
-        # Explicit single-device placement keeps rank-local constants local even
-        # when solver construction happens inside a global ``jax.set_mesh``
-        # context.
-        transpose_local_source_ids = jax.device_put(
-            transpose_plan.local_source_ids, local_device
-        )
-        transpose_local_target_ids = jax.device_put(
-            transpose_plan.local_target_ids, local_device
-        )
-        transpose_send_ids = jax.device_put(transpose_plan.send_ids_2d, local_device)
-        transpose_recv_target_ids = jax.device_put(
-            transpose_plan.recv_target_ids_2d, local_device
-        )
+        # Uncommitted for the same reason as the CSR structure above.
+        transpose_local_source_ids = jnp.asarray(transpose_plan.local_source_ids)
+        transpose_local_target_ids = jnp.asarray(transpose_plan.local_target_ids)
+        transpose_send_ids = jnp.asarray(transpose_plan.send_ids_2d)
+        transpose_recv_target_ids = jnp.asarray(transpose_plan.recv_target_ids_2d)
+
+    # The local CSR row index of every nonzero, used by both the nested MPI
+    # solve and this module's matrix-gradient body.
+    local_row_indices = np.repeat(
+        np.arange(A_structure.shape[0], dtype=np.int32),
+        np.diff(indptr_host),
+    ).astype(np.int32)
 
     mpi_cache = _build_mpi_cache(
         config or {},
@@ -700,10 +738,12 @@ def make_sharded_solver(
         max_nnz,
         nnz_out,
         halo_plan,
+        row_indices=local_row_indices,
         save_stats=save_stats,
         block_dim=block_dim,
         lrank=int(local_hardware_id),
         device=local_device,
+        commit=False,
     )
     if not is_symmetric:
         # The MPI solve's primal does not consume halo operands, and sharding's
@@ -721,12 +761,24 @@ def make_sharded_solver(
         "residual_history": P(axis_name, None),
     }
 
+    res_history_len = amgx_config.outer_max_iters(mpi_cache["config_str"]) + 1
+
     def pack_info(info: ShardedInfo) -> ShardedInfo:
+        history = jnp.asarray(info["residual_history"])
+        if history.shape[0] < res_history_len:
+            # A direct (untraced) solve trims the history to its own iteration
+            # count, which differs per rank; restore the static traced length
+            # (NaN-padded) so every rank's info shard has one common shape.
+            history = jnp.pad(
+                history,
+                (0, res_history_len - history.shape[0]),
+                constant_values=jnp.nan,
+            )
         return {
             "iterations": jnp.asarray(info["iterations"], dtype=jnp.int32)[None],
             "residual": jnp.asarray(info["residual"])[None],
             "status": jnp.asarray(info["status"], dtype=jnp.int32)[None],
-            "residual_history": jnp.asarray(info["residual_history"])[None, :],
+            "residual_history": history[None, :],
         }
 
     def matrix_with_data(
@@ -759,9 +811,10 @@ def make_sharded_solver(
             x0=None if x0_local is None else x0_local[:n_local],
             block_dim=block_dim,
             reuse_setup=reuse_setup,
-            # Under the shard_map trace this only enables stats capture in the
-            # FFI call; solve() never writes a file for traced results. The
-            # actual file is written by ``sharded_solver`` after execution.
+            # os.devnull enables stats capture in the FFI call without writing
+            # anything: solve() never writes a file for traced results and
+            # skips the write for os.devnull on direct local calls. The actual
+            # file is written by ``sharded_solver`` after execution.
             save_stats_file=os.devnull if save_stats else None,
         )
 
@@ -779,32 +832,32 @@ def make_sharded_solver(
         x_local, info = solve_one_rhs(A_dynamic, rhs_local, x0_local)
         return pad_local_vector(x_local), pack_info(info)
 
-    def local_transpose_values(A_data_local: jax.Array) -> jax.Array:
-        assert transpose_structure is not None
-        assert max_transpose_nnz is not None
-        assert transpose_local_source_ids is not None
-        assert transpose_local_target_ids is not None
-        assert transpose_send_ids is not None
-        assert transpose_recv_target_ids is not None
+    def make_local_transpose_values(
+        exchange: Callable[[jax.Array], jax.Array],
+    ) -> Callable[[jax.Array], jax.Array]:
+        def local_transpose_values(A_data_local: jax.Array) -> jax.Array:
+            assert transpose_structure is not None
+            assert max_transpose_nnz is not None
+            assert transpose_local_source_ids is not None
+            assert transpose_local_target_ids is not None
+            assert transpose_send_ids is not None
+            assert transpose_recv_target_ids is not None
 
-        transpose_values = _apply_transpose_plan(
-            A_data_local,
-            transpose_local_source_ids,
-            transpose_local_target_ids,
-            transpose_send_ids,
-            transpose_recv_target_ids,
-            transpose_structure.nnz,
-            lambda values: jax.lax.all_to_all(
-                values,
-                axis_name,
-                split_axis=0,
-                concat_axis=0,
-            ),
-        )
-        return jnp.pad(
-            transpose_values,
-            (0, max_transpose_nnz - transpose_structure.nnz),
-        )
+            transpose_values = _apply_transpose_plan(
+                A_data_local,
+                transpose_local_source_ids,
+                transpose_local_target_ids,
+                transpose_send_ids,
+                transpose_recv_target_ids,
+                transpose_structure.nnz,
+                exchange,
+            )
+            return jnp.pad(
+                transpose_values,
+                (0, max_transpose_nnz - transpose_structure.nnz),
+            )
+
+        return local_transpose_values
 
     def local_adjoint(adjoint_data_local: jax.Array, g_local: jax.Array) -> jax.Array:
         if is_symmetric:
@@ -823,95 +876,140 @@ def make_sharded_solver(
 
     halo_plan = mpi_cache["halo_plan"]
     max_n_ghost = halo_plan.max_n_ghost
-    local_row_indices = np.repeat(
-        np.arange(A_structure.shape[0], dtype=np.int32),
-        np.diff(indptr_host),
-    )
     # Keep rank-local halo metadata inside the shard_map bodies. Making these
     # arrays global and closing over them in the custom VJP prevents an outer
     # multi-process jax.jit from lowering because their remote shards are not
     # addressable by the current process.
-    row_indices = jax.device_put(local_row_indices, local_device)
-    col_to_combined = jax.device_put(halo_plan.col_to_combined, local_device)
-    send_ids = jax.device_put(halo_plan.send_ids_2d, local_device)
-    recv_ghost_slot = jax.device_put(halo_plan.recv_ghost_slot_2d, local_device)
+    row_indices = mpi_cache["row_indices"]
+    col_to_combined = halo_plan.col_to_combined
+    send_ids = halo_plan.send_ids_2d
+    recv_ghost_slot = halo_plan.recv_ghost_slot_2d
 
     def gather_solution_halo(
         x_local: jax.Array,
-        send_ids_local: jax.Array,
-        recv_ghost_slot_local: jax.Array,
+        exchange: Callable[[jax.Array], jax.Array],
     ) -> jax.Array:
-        send_buffer = x_local[send_ids_local]
-        recv_buffer = jax.lax.all_to_all(
-            send_buffer,
-            axis_name,
-            split_axis=0,
-            concat_axis=0,
-        )
+        send_buffer = x_local[send_ids]
+        recv_buffer = exchange(send_buffer)
         x_ghost = jnp.zeros(max_n_ghost + 1, dtype=x_local.dtype)
-        x_ghost = x_ghost.at[recv_ghost_slot_local.reshape(-1)].set(
-            recv_buffer.reshape(-1)
-        )
+        x_ghost = x_ghost.at[recv_ghost_slot.reshape(-1)].set(recv_buffer.reshape(-1))
         return jnp.concatenate([x_local, x_ghost[:max_n_ghost]], axis=0)
 
-    def local_matrix_gradient(
-        x_local: jax.Array, adjoint_local: jax.Array
-    ) -> jax.Array:
-        # Order the JAX halo exchange after the preceding AmgX adjoint solve.
-        x_ordered, adjoint_ordered = jax.lax.optimization_barrier(
-            (x_local, adjoint_local)
-        )
-        x_combined = gather_solution_halo(
-            x_ordered[:n_local], send_ids, recv_ghost_slot
-        )
-        grad_values = (
-            -adjoint_ordered[:n_local][row_indices] * x_combined[col_to_combined]
-        )
-        return jnp.pad(grad_values, (0, max_nnz - local_nnz))
+    def make_local_matrix_gradient(
+        exchange: Callable[[jax.Array], jax.Array],
+    ) -> Callable[[jax.Array, jax.Array], jax.Array]:
+        def local_matrix_gradient(
+            x_local: jax.Array, adjoint_local: jax.Array
+        ) -> jax.Array:
+            # Order the halo exchange after the preceding AmgX adjoint solve.
+            x_ordered, adjoint_ordered = jax.lax.optimization_barrier(
+                (x_local, adjoint_local)
+            )
+            x_combined = gather_solution_halo(x_ordered[:n_local], exchange)
+            grad_values = (
+                -adjoint_ordered[:n_local][row_indices] * x_combined[col_to_combined]
+            )
+            return jnp.pad(grad_values, (0, max_nnz - local_nnz))
 
-    mapped_solve = jax.jit(
+        return local_matrix_gradient
+
+    nranks = comm.Get_size()
+
+    def lax_exchange(values: jax.Array) -> jax.Array:
+        return jax.lax.all_to_all(values, axis_name, split_axis=0, concat_axis=0)
+
+    if nranks == 1:
+        # A single-rank all-to-all is the identity.
+        def mpi_exchange(values: jax.Array) -> jax.Array:
+            return values
+
+    else:
+
+        def mpi_exchange(values: jax.Array) -> jax.Array:
+            import mpi4jax
+
+            return mpi4jax.alltoall(values, comm=comm)
+
+    # The mesh-local device as a one-device mesh. The eager local branch runs
+    # under it so that its single-device operations dispatch cleanly even when
+    # the caller sits inside jax.set_mesh over the whole multi-process mesh
+    # (as an eager outer transform requires for its own global-array ops).
+    local_mesh = jax.make_mesh((1,), (axis_name,), devices=[local_device])
+
+    def local_shard(value: jax.Array) -> jax.Array:
+        return value.addressable_shards[0].data
+
+    def assemble_global(local_value: jax.Array) -> jax.Array:
+        spec = P(axis_name, *(None,) * (local_value.ndim - 1))
+        return jax.make_array_from_single_device_arrays(
+            (nranks * local_value.shape[0], *local_value.shape[1:]),
+            NamedSharding(mesh, spec),
+            [jax.device_put(local_value, local_device)],
+        )
+
+    def dispatch(
+        local_fn: Callable[..., Any], shard_mapped: Callable[..., Any]
+    ) -> Callable[..., Any]:
+        # Concrete operands bypass shard_map: outside a trace, JAX executes a
+        # shard_map body primitive by primitive across the mesh, an order of
+        # magnitude slower than running the body on the local shard directly.
+        def invoke(*args: Any) -> Any:
+            if any(isinstance(leaf, jax.core.Tracer) for leaf in jax.tree.leaves(args)):
+                return shard_mapped(*args)
+            with jax.set_mesh(local_mesh):
+                outputs = local_fn(*(local_shard(arg) for arg in args))
+                return jax.tree.map(assemble_global, outputs)
+
+        return invoke
+
+    mapped_solve = dispatch(
+        local_solve,
         jax.shard_map(
             local_solve,
             mesh=mesh,
             in_specs=(A_data_spec, rhs_spec),
             out_specs=(rhs_spec, info_specs),
-        )
+        ),
     )
-    mapped_solve_x0 = jax.jit(
+    mapped_solve_x0 = dispatch(
+        local_solve_x0,
         jax.shard_map(
             local_solve_x0,
             mesh=mesh,
             in_specs=(A_data_spec, rhs_spec, rhs_spec),
             out_specs=(rhs_spec, info_specs),
-        )
+        ),
     )
     scalar_spec = P(axis_name)
     if is_symmetric:
         mapped_transpose_values = None
     else:
-        mapped_transpose_values = jax.jit(
+        mapped_transpose_values = dispatch(
+            make_local_transpose_values(mpi_exchange),
             jax.shard_map(
-                local_transpose_values,
+                make_local_transpose_values(lax_exchange),
                 mesh=mesh,
                 in_specs=(A_data_spec,),
                 out_specs=A_data_spec,
-            )
+            ),
         )
-    mapped_adjoint = jax.jit(
+    mapped_adjoint = dispatch(
+        local_adjoint,
         jax.shard_map(
             local_adjoint,
             mesh=mesh,
             in_specs=(A_data_spec, scalar_spec),
             out_specs=scalar_spec,
-        )
+        ),
     )
-    mapped_matrix_gradient = jax.jit(
+    mapped_matrix_gradient = dispatch(
+        make_local_matrix_gradient(mpi_exchange),
         jax.shard_map(
-            local_matrix_gradient,
+            make_local_matrix_gradient(lax_exchange),
             mesh=mesh,
             in_specs=(scalar_spec, scalar_spec),
             out_specs=A_data_spec,
-        )
+        ),
     )
 
     def differentiated_solve_backward(
@@ -921,10 +1019,17 @@ def make_sharded_solver(
             adjoint_data = matrix_data
         else:
             assert mapped_transpose_values is not None
-            # Tie the transpose exchange to the completed forward solution so
-            # XLA cannot overlap it with AmgX's preceding MPI collectives.
-            matrix_data_ordered, _ = jax.lax.optimization_barrier((matrix_data, x))
-            adjoint_data = mapped_transpose_values(matrix_data_ordered)
+            if isinstance(matrix_data, jax.core.Tracer) or isinstance(
+                x, jax.core.Tracer
+            ):
+                # Within one compiled program, tie the transpose exchange to the
+                # completed forward solution so XLA cannot overlap it with
+                # AmgX's preceding MPI collectives. Concrete calls dispatch each
+                # step in program order, so they need no barrier -- and a
+                # barrier over a multi-process global array could not be
+                # dispatched eagerly anyway.
+                matrix_data, _ = jax.lax.optimization_barrier((matrix_data, x))
+            adjoint_data = mapped_transpose_values(matrix_data)
 
         adjoint = mapped_adjoint(adjoint_data, g_x)
         return adjoint, mapped_matrix_gradient(x, adjoint)
@@ -969,7 +1074,15 @@ def make_sharded_solver(
         matrix_data, x = residuals
         g_x, _ = cotangents
         adjoint, grad_A_data = differentiated_solve_backward(matrix_data, x, g_x)
-        return grad_A_data, adjoint, jnp.zeros_like(adjoint)
+        # The x0 cotangent is zero (the converged solution ignores the initial
+        # guess). Build it shard-locally for a concrete adjoint: zeros_like on
+        # a multi-process global array cannot be dispatched eagerly.
+        if isinstance(adjoint, jax.core.Tracer):
+            grad_x0 = jnp.zeros_like(adjoint)
+        else:
+            with jax.set_mesh(local_mesh):
+                grad_x0 = assemble_global(jnp.zeros_like(local_shard(adjoint)))
+        return grad_A_data, adjoint, grad_x0
 
     differentiated_solve_x0.defvjp(
         differentiated_solve_x0_fwd, differentiated_solve_x0_bwd

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -88,7 +88,7 @@ def make_sharded_vector(
     local_values: Any,
     *,
     comm: Comm | None = None,
-    mesh: Mesh,
+    mesh: Mesh | None = None,
     global_size: int | None = None,
     axis_name: str = "rank",
 ) -> jax.Array:
@@ -104,6 +104,7 @@ def make_sharded_vector(
         comm: MPI communicator whose rank order matches ``mesh``. Defaults to
             ``MPI.COMM_WORLD``.
         mesh: One-dimensional JAX device mesh with one device per MPI rank.
+            Defaults to a mesh containing all JAX devices.
         global_size: Optional true global length. When provided, it is checked
             against the sum of local lengths.
         axis_name: Mesh axis used to partition the vector.
@@ -114,6 +115,8 @@ def make_sharded_vector(
         length is ``comm.size * max(local_sizes)``.
     """
     comm = _resolve_comm(comm)
+    if mesh is None:
+        mesh = jax.make_mesh((jax.device_count(),), (axis_name,))
     values = np.asarray(local_values)
     if values.ndim not in (1, 2):
         raise ValueError(

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -1074,6 +1074,27 @@ def make_sharded_solver(
 
     coloring = A._coloring
 
+    def check_structure(matrix: jsp.BCSR) -> None:
+        """Reject a matrix whose CSR structure differs from the fixed one."""
+        for given, fixed in (
+            (matrix.indices, A_structure.indices),
+            (matrix.indptr, A_structure.indptr),
+        ):
+            if given is fixed:
+                continue
+            if isinstance(given, jax.core.Tracer):
+                raise ValueError(
+                    "A's sparsity structure must be concrete; pass traced matrix "
+                    "values in the packed A.data layout instead"
+                )
+            if given.shape != fixed.shape or not np.array_equal(
+                np.asarray(given), np.asarray(fixed)
+            ):
+                raise ValueError(
+                    "A must have the sparsity structure fixed when the solver "
+                    "was created"
+                )
+
     def local_values_of(A_local: MatrixOrOperator) -> jax.Array:
         """This rank's padded values of ``A_local`` in the packed layout."""
         if callable(A_local):
@@ -1097,11 +1118,13 @@ def make_sharded_solver(
                 A_local, shape, rows, cols, column_colors, n_colors
             ).data
         else:
-            values = to_bcsr_matrix(
+            matrix = to_bcsr_matrix(
                 A_local,
                 b=jnp.zeros(n_local, dtype=A_data.dtype),
                 use_int64_indices=True,
-            ).data
+            )
+            check_structure(matrix)
+            values = matrix.data
         if values.shape[0] != local_nnz:
             raise ValueError(
                 "A must have the sparsity structure fixed when the solver was "

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -27,6 +27,20 @@ if TYPE_CHECKING:
 ShardedInfo = dict[str, jax.Array]
 
 
+def _resolve_comm(comm: Comm | None) -> Comm:
+    """Use MPI.COMM_WORLD when the caller does not supply a communicator."""
+    if comm is not None:
+        return comm
+
+    try:
+        from mpi4py import MPI
+    except ImportError as exc:
+        raise RuntimeError(
+            "mpi4py is required when comm is omitted from the sharding API"
+        ) from exc
+    return MPI.COMM_WORLD
+
+
 def _row_partition_spec(ndim: int, axis_name: str) -> P:
     """Partition the leading row axis and replicate all trailing axes."""
     return P(axis_name, *(None for _ in range(ndim - 1)))
@@ -73,7 +87,7 @@ class ShardedSolve:
 def make_sharded_vector(
     local_values: Any,
     *,
-    comm: Comm,
+    comm: Comm | None = None,
     mesh: Mesh,
     global_size: int | None = None,
     axis_name: str = "rank",
@@ -87,7 +101,8 @@ def make_sharded_vector(
     Args:
         local_values: This rank's unpadded values with shape ``(n_local,)`` or
             ``(n_local, nrhs)``.
-        comm: MPI communicator whose rank order matches ``mesh``.
+        comm: MPI communicator whose rank order matches ``mesh``. Defaults to
+            ``MPI.COMM_WORLD``.
         mesh: One-dimensional JAX device mesh with one device per MPI rank.
         global_size: Optional true global length. When provided, it is checked
             against the sum of local lengths.
@@ -98,6 +113,7 @@ def make_sharded_vector(
         optional RHS-column axis is replicated. Its physical leading-axis
         length is ``comm.size * max(local_sizes)``.
     """
+    comm = _resolve_comm(comm)
     values = np.asarray(local_values)
     if values.ndim not in (1, 2):
         raise ValueError(
@@ -421,7 +437,7 @@ def make_sharded_solver(
     A_local: MatrixOrOperator,
     b: jax.Array,
     *,
-    comm: Comm,
+    comm: Comm | None = None,
     mesh: Mesh | None = None,
     axis_name: str = "rank",
     config: dict[str, Any] | None = None,
@@ -453,6 +469,7 @@ def make_sharded_solver(
             shards are padded to the largest local partition. Batched RHS
             columns are replicated within each row shard.
         comm: MPI communicator whose rank order matches the JAX process order.
+            Defaults to ``MPI.COMM_WORLD``.
         mesh: One-dimensional JAX device mesh. If omitted, use the mesh from
             ``b.sharding``.
         axis_name: Name of the mesh axis that partitions rows.
@@ -480,6 +497,7 @@ def make_sharded_solver(
     _require_shard_map()
     if not isinstance(b, jax.Array):
         raise TypeError("b must be a global jax.Array")
+    comm = _resolve_comm(comm)
     mesh = _resolve_mesh(b, mesh, axis_name)
     _validate_runtime(comm, mesh, axis_name)
 
@@ -915,7 +933,7 @@ def solve_sharded(
     b: jax.Array,
     x0: jax.Array | None = None,
     *,
-    comm: Comm,
+    comm: Comm | None = None,
     mesh: Mesh | None = None,
     axis_name: str = "rank",
     config: dict[str, Any] | None = None,

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -19,7 +19,7 @@ from jax.sharding import PartitionSpec as P
 
 from .cache import _build_mpi_cache, with_cache
 from .jaxamg import solve
-from .mpi_utils import build_halo_plan
+from .mpi_utils import HaloPlan, build_halo_plan
 from .utils import (
     MatrixOrOperator,
     get_preferred_dtype,
@@ -49,9 +49,20 @@ class _TransposePlan(NamedTuple):
     local_target_ids: np.ndarray
     send_ids_2d: np.ndarray
     recv_target_ids_2d: np.ndarray
-    indices_host: np.ndarray
-    indptr_host: np.ndarray
     max_nnz: int
+
+
+def _primal_halo_placeholder(n_local: int, nranks: int) -> HaloPlan:
+    """Minimal halo operands for an MPI solve whose primal does not use them."""
+    return HaloPlan(
+        n_local=n_local,
+        n_ghost=0,
+        max_n_ghost=0,
+        max_per_rank=1,
+        col_to_combined=np.empty(0, dtype=np.int32),
+        send_ids_2d=np.zeros((nranks, 1), dtype=np.int32),
+        recv_ghost_slot_2d=np.zeros((nranks, 1), dtype=np.int32),
+    )
 
 
 def _resolve_comm(comm: Comm | None) -> Comm:
@@ -683,8 +694,6 @@ def _transpose_distributed_matrix(
         local_target_ids,
         send_ids_2d,
         recv_target_ids_2d,
-        recv_cols,
-        transpose_indptr,
         max_nnz,
     )
 
@@ -808,12 +817,6 @@ def make_sharded_solver(
         )
         nnz_out = transpose_structure.nnz
         max_transpose_nnz = transpose_plan.max_nnz
-        transpose_halo_plan = build_halo_plan(
-            transpose_plan.indices_host,
-            A.row_counts,
-            partition_info,
-            comm,
-        )
         # Explicit single-device placement keeps rank-local constants local even
         # when solver construction happens inside a global ``jax.set_mesh``
         # context.
@@ -840,14 +843,14 @@ def make_sharded_solver(
         lrank=int(local_hardware_id),
     )
     if not is_symmetric:
-        # A and A^T share the communicator, row partition, configuration, and
-        # device. Only structure-dependent buffer and halo metadata differ.
-        assert transpose_halo_plan is not None
+        # The MPI solve's primal does not consume halo operands, and sharding's
+        # outer VJP computes its matrix gradient from A's existing halo plan.
+        # Therefore the nested A^T solve needs only placeholder halo operands.
         transpose_cache = {
             **mpi_cache,
             "max_nnz": max_transpose_nnz,
             "nnz_out": local_nnz,
-            "halo_plan": transpose_halo_plan,
+            "halo_plan": _primal_halo_placeholder(n_local, len(A.row_counts)),
         }
 
     if is_batched:

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -35,10 +35,16 @@ class ShardedSolve:
         solve_fn: Callable[..., tuple[jax.Array, ShardedInfo]],
         A_data: jax.Array,
         local_matrix_gradient_fn: Callable[[jax.Array], jsp.BCSR],
+        local_vector_fn: Callable[[jax.Array], jax.Array],
+        global_size: int,
+        local_size: int,
     ) -> None:
         self._solve_fn = solve_fn
         self.A_data = A_data
         self._local_matrix_gradient_fn = local_matrix_gradient_fn
+        self._local_vector_fn = local_vector_fn
+        self.global_size = global_size
+        self.local_size = local_size
 
     def __call__(
         self,
@@ -53,6 +59,70 @@ class ShardedSolve:
     def local_matrix_gradient(self, gradient: jax.Array) -> jsp.BCSR:
         """Convert a packed global value gradient to this rank's local BCSR."""
         return self._local_matrix_gradient_fn(gradient)
+
+    def local_vector(self, value: jax.Array) -> jax.Array:
+        """Return this rank's unpadded portion of a solver vector."""
+        return self._local_vector_fn(value)
+
+
+def make_sharded_vector(
+    local_values: Any,
+    *,
+    comm: Comm,
+    mesh: Mesh,
+    global_size: int | None = None,
+    axis_name: str = "rank",
+) -> jax.Array:
+    """Create a row-sharded vector, padding unequal local partitions.
+
+    The returned JAX array has equal physical shard sizes, as required by
+    ``NamedSharding``. ``make_sharded_solver`` ignores each shard's padding and
+    uses the true row counts from ``A_local``.
+
+    Args:
+        local_values: This rank's unpadded one-dimensional values.
+        comm: MPI communicator whose rank order matches ``mesh``.
+        mesh: One-dimensional JAX device mesh with one device per MPI rank.
+        global_size: Optional true global length. When provided, it is checked
+            against the sum of local lengths.
+        axis_name: Mesh axis used to partition the vector.
+
+    Returns:
+        A global JAX array with ``NamedSharding(mesh, P(axis_name))``. Its
+        physical length is ``comm.size * max(local_sizes)``.
+    """
+    values = np.asarray(local_values)
+    if values.ndim != 1:
+        raise ValueError(f"local_values must be one-dimensional; got {values.shape}")
+    if tuple(mesh.axis_names) != (axis_name,):
+        raise ValueError(
+            f"mesh must have the single axis {axis_name!r}; got {mesh.axis_names!r}"
+        )
+
+    comm_size = comm.Get_size()
+    if mesh.size != comm_size or mesh.shape[axis_name] != comm_size:
+        raise ValueError(
+            "the mesh axis must contain exactly one device per MPI rank; got "
+            f"mesh size {mesh.size} and communicator size {comm_size}"
+        )
+
+    local_sizes = tuple(int(size) for size in comm.allgather(values.shape[0]))
+    inferred_global_size = sum(local_sizes)
+    if global_size is not None and int(global_size) != inferred_global_size:
+        raise ValueError(
+            f"global_size is {global_size}, but local sizes sum to "
+            f"{inferred_global_size}"
+        )
+
+    max_local_size = max(local_sizes)
+    padded_values = np.zeros(max_local_size, dtype=values.dtype)
+    padded_values[: values.shape[0]] = values
+    sharding = NamedSharding(mesh, P(axis_name))
+    return jax.make_array_from_process_local_data(
+        sharding,
+        padded_values,
+        global_shape=(comm_size * max_local_size,),
+    )
 
 
 def _require_shard_map() -> None:
@@ -136,7 +206,10 @@ def _local_partition(
     b: jax.Array,
     mesh: Mesh,
     axis_name: str,
-) -> tuple[int, int]:
+    comm: Comm,
+    n_local: int,
+    n_global: int,
+) -> tuple[tuple[int, int], int]:
     if b.ndim != 1:
         raise ValueError(f"b must be one-dimensional; got shape {b.shape}")
 
@@ -147,6 +220,20 @@ def _local_partition(
     if sharding.mesh != mesh or sharding.spec != expected_spec:
         raise ValueError(
             f"b must use NamedSharding(mesh, P({axis_name!r})); got {sharding!r}"
+        )
+
+    local_sizes = tuple(int(size) for size in comm.allgather(n_local))
+    if sum(local_sizes) != n_global:
+        raise ValueError(
+            "the distributed matrix row counts must sum to its global column "
+            f"count; got row counts {local_sizes} and {n_global} columns"
+        )
+    max_local_size = max(local_sizes)
+    expected_shape = (comm.Get_size() * max_local_size,)
+    if b.shape != expected_shape:
+        raise ValueError(
+            f"b must have padded sharded shape {expected_shape}; got {b.shape}. "
+            "Use jaxamg.make_sharded_vector for uneven row partitions."
         )
 
     shards = b.addressable_shards
@@ -162,9 +249,17 @@ def _local_partition(
     row_slice = index[0]
     if row_slice.step not in (None, 1):
         raise ValueError(f"b shard must be contiguous; got slice {row_slice!r}")
-    row_start = 0 if row_slice.start is None else int(row_slice.start)
-    row_end = b.shape[0] if row_slice.stop is None else int(row_slice.stop)
-    return row_start, row_end
+    physical_start = 0 if row_slice.start is None else int(row_slice.start)
+    physical_end = b.shape[0] if row_slice.stop is None else int(row_slice.stop)
+    if physical_end - physical_start != max_local_size:
+        raise ValueError(
+            "each physical RHS shard must have the maximum local row count; "
+            f"expected {max_local_size}, got {physical_end - physical_start}"
+        )
+
+    comm_rank = comm.Get_rank()
+    row_start = sum(local_sizes[:comm_rank])
+    return (row_start, row_start + n_local), max_local_size
 
 
 def _validate_matrix(
@@ -332,8 +427,9 @@ def make_sharded_solver(
         A_local: Local row partition with shape ``(n_local, n_global)`` and
             global column indices.
         b: Global one-dimensional JAX array using
-            ``NamedSharding(mesh, PartitionSpec(axis_name))``. It is also the
-            shape, dtype, and sharding template for later calls.
+            ``NamedSharding(mesh, PartitionSpec(axis_name))``. For unequal row
+            counts, construct it with :func:`make_sharded_vector`; physical
+            shards are padded to the largest local partition.
         comm: MPI communicator whose rank order matches the JAX process order.
         mesh: One-dimensional JAX device mesh. If omitted, use the mesh from
             ``b.sharding``.
@@ -350,7 +446,8 @@ def make_sharded_solver(
         A callable ``solver(b, x0=None, *, A_data=None)``. ``solver.A_data`` is the
         global sharded array of packed CSR values, padded to the largest local
         nonzero count. ``solver.local_matrix_gradient(gradient)`` converts its
-        gradient back to this rank's unpadded BCSR structure. The solve returns
+        gradient back to this rank's unpadded BCSR structure, while
+        ``solver.local_vector(value)`` removes vector padding. The solve returns
         a global sharded solution and an info dictionary. Info values are global
         arrays with one entry per rank; ``residual_history`` has shape
         ``(nranks, max_iters + 1)``.
@@ -360,13 +457,20 @@ def make_sharded_solver(
         raise TypeError("b must be a global jax.Array")
     mesh = _resolve_mesh(b, mesh, axis_name)
     _validate_runtime(comm, mesh, axis_name)
-    partition_info = _local_partition(b, mesh, axis_name)
+
+    matrix_shape = getattr(A_local, "shape", None)
+    if matrix_shape is None or len(matrix_shape) != 2:
+        raise ValueError("A_local must have a two-dimensional shape")
+    n_local = int(matrix_shape[0])
+    nglobal = int(matrix_shape[1])
+    partition_info, max_n_local = _local_partition(
+        b, mesh, axis_name, comm, n_local, nglobal
+    )
 
     block_dim = int(block_dim)
-    nglobal = int(b.shape[0])
     _validate_matrix(A_local, nglobal, partition_info, block_dim)
 
-    local_rhs = b.addressable_shards[0].data
+    local_rhs = b.addressable_shards[0].data[:n_local]
     A_bcsr = to_bcsr_matrix(A_local, b=local_rhs, use_int64_indices=True)
     mpi_cache = cache_mpi_metadata(
         config or {},
@@ -447,17 +551,20 @@ def make_sharded_solver(
         )
         return with_cache(matrix, mpi=cache, is_symmetric=symmetric)
 
+    def pad_local_vector(value: jax.Array) -> jax.Array:
+        return jnp.pad(value, (0, max_n_local - n_local))
+
     def local_solve(
         A_data_local: jax.Array, rhs_local: jax.Array
     ) -> tuple[jax.Array, ShardedInfo]:
         A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
         x_local, info = solve(
             A_dynamic,
-            rhs_local,
+            rhs_local[:n_local],
             block_dim=block_dim,
             reuse_setup=reuse_setup,
         )
-        return x_local, pack_info(info)
+        return pad_local_vector(x_local), pack_info(info)
 
     def local_solve_x0(
         A_data_local: jax.Array, rhs_local: jax.Array, x0_local: jax.Array
@@ -465,12 +572,12 @@ def make_sharded_solver(
         A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
         x_local, info = solve(
             A_dynamic,
-            rhs_local,
-            x0=x0_local,
+            rhs_local[:n_local],
+            x0=x0_local[:n_local],
             block_dim=block_dim,
             reuse_setup=reuse_setup,
         )
-        return x_local, pack_info(info)
+        return pad_local_vector(x_local), pack_info(info)
 
     def local_adjoint(A_data_local: jax.Array, g_local: jax.Array) -> jax.Array:
         if is_symmetric:
@@ -488,7 +595,7 @@ def make_sharded_solver(
             )
         adjoint_local, _ = solve(
             A_adjoint,
-            g_local,
+            g_local[:n_local],
             block_dim=block_dim,
             reuse_setup=reuse_setup,
         )
@@ -544,7 +651,7 @@ def make_sharded_solver(
         return jnp.where(valid_values, grad_values, 0)
 
     def local_gather_matrix_columns(x_local: jax.Array) -> jax.Array:
-        x_combined = gather_solution_halo(x_local, send_ids, recv_ghost_slot)
+        x_combined = gather_solution_halo(x_local[:n_local], send_ids, recv_ghost_slot)
         return jnp.where(valid_values, x_combined[col_to_combined], 0)
 
     def local_backward(
@@ -561,7 +668,7 @@ def make_sharded_solver(
             x_at_columns,
             adjoint_local,
         )
-        return adjoint_local, grad_A_data_local
+        return pad_local_vector(adjoint_local), grad_A_data_local
 
     mapped_solve = jax.jit(
         jax.shard_map(
@@ -688,6 +795,10 @@ def make_sharded_solver(
             (local_gradient, A_bcsr.indices, A_bcsr.indptr), shape=A_bcsr.shape
         )
 
+    def unpad_local_vector(value: jax.Array) -> jax.Array:
+        _validate_operand(value, b, mesh, axis_name, "solver vector")
+        return value.addressable_shards[0].data[:n_local]
+
     def solve_fn(
         rhs: jax.Array,
         x0: jax.Array | None = None,
@@ -696,7 +807,14 @@ def make_sharded_solver(
     ) -> tuple[jax.Array, ShardedInfo]:
         return sharded_solver(rhs, x0, A_data_override=A_data)
 
-    return ShardedSolve(solve_fn, A_data, unpad_matrix_gradient)
+    return ShardedSolve(
+        solve_fn,
+        A_data,
+        unpad_matrix_gradient,
+        unpad_local_vector,
+        nglobal,
+        n_local,
+    )
 
 
 def solve_sharded(

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -1,0 +1,750 @@
+"""JAX sharding integration for distributed AmgX solves.
+
+This module provides an additive interface on top of JAX-AMG's MPI backend.
+JAX owns the global arrays and ``shard_map`` execution, while AmgX continues
+to use one MPI rank per GPU for the distributed solve.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import jax
+import jax.experimental.sparse as jsp
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from .cache import cache_mpi_metadata, with_cache
+from .jaxamg import solve
+from .utils import MatrixOrOperator, temp_enable_x64, to_bcsr_matrix
+
+if TYPE_CHECKING:
+    from mpi4py.MPI import Comm
+
+ShardedInfo = dict[str, jax.Array]
+
+
+class ShardedSolve:
+    """Callable sharded solver with differentiable packed matrix values."""
+
+    def __init__(
+        self,
+        solve_fn: Callable[..., tuple[jax.Array, ShardedInfo]],
+        A_data: jax.Array,
+        local_matrix_gradient_fn: Callable[[jax.Array], jsp.BCSR],
+    ) -> None:
+        self._solve_fn = solve_fn
+        self.A_data = A_data
+        self._local_matrix_gradient_fn = local_matrix_gradient_fn
+
+    def __call__(
+        self,
+        b: jax.Array,
+        x0: jax.Array | None = None,
+        *,
+        A_data: jax.Array | None = None,
+    ) -> tuple[jax.Array, ShardedInfo]:
+        """Solve with the cached values or a differentiable ``A_data`` operand."""
+        return self._solve_fn(b, x0, A_data=A_data)
+
+    def local_matrix_gradient(self, gradient: jax.Array) -> jsp.BCSR:
+        """Convert a packed global value gradient to this rank's local BCSR."""
+        return self._local_matrix_gradient_fn(gradient)
+
+
+def _require_shard_map() -> None:
+    if not hasattr(jax, "shard_map"):
+        raise RuntimeError(
+            "JAX-AMG's sharding interface requires a JAX version that exposes "
+            "jax.shard_map. Upgrade JAX or use solve(..., comm=...) instead."
+        )
+
+
+def _resolve_mesh(
+    b: jax.Array,
+    mesh: Mesh | None,
+    axis_name: str,
+) -> Mesh:
+    if mesh is None:
+        sharding = getattr(b, "sharding", None)
+        if not isinstance(sharding, NamedSharding):
+            raise ValueError(
+                "mesh was not provided and b does not have NamedSharding; "
+                "pass mesh=... or place b with NamedSharding first"
+            )
+        inferred_mesh = sharding.mesh
+        if not isinstance(inferred_mesh, Mesh):
+            raise TypeError("b must use a concrete JAX Mesh")
+        mesh = inferred_mesh
+
+    if tuple(mesh.axis_names) != (axis_name,):
+        raise ValueError(
+            "the initial sharding interface requires a one-dimensional mesh "
+            f"with axis name {axis_name!r}; got axes {tuple(mesh.axis_names)!r}"
+        )
+    return mesh
+
+
+def _validate_runtime(comm: Comm, mesh: Mesh, axis_name: str) -> None:
+    comm_size = comm.Get_size()
+    comm_rank = comm.Get_rank()
+
+    if comm_size > 1 and not jax.distributed.is_initialized():
+        raise RuntimeError(
+            "jax.distributed.initialize() must be called before creating a "
+            "multi-process sharded solver"
+        )
+    if jax.process_count() != comm_size:
+        raise ValueError(
+            "the JAX process count and MPI communicator size must match; got "
+            f"{jax.process_count()} and {comm_size}"
+        )
+    if jax.process_index() != comm_rank:
+        raise ValueError(
+            "the JAX process index must match the MPI rank; got "
+            f"{jax.process_index()} and {comm_rank}"
+        )
+    if mesh.size != comm_size or mesh.shape[axis_name] != comm_size:
+        raise ValueError(
+            "the mesh axis must contain exactly one device per MPI rank; got "
+            f"mesh size {mesh.size} and communicator size {comm_size}"
+        )
+
+    local_devices = tuple(mesh.local_devices)
+    if len(local_devices) != 1:
+        raise ValueError(
+            "the initial sharding interface requires exactly one mesh-local "
+            f"device per MPI process; got {len(local_devices)}"
+        )
+    mesh_position = tuple(mesh.devices.flat).index(local_devices[0])
+    if mesh_position != comm_rank:
+        raise ValueError(
+            "mesh device order must match MPI rank order; this process owns "
+            f"MPI rank {comm_rank} but mesh position {mesh_position}"
+        )
+    if local_devices[0].platform != "gpu":
+        raise RuntimeError(
+            "AMGX requires GPU mesh devices; the local mesh device uses "
+            f"platform {local_devices[0].platform!r}"
+        )
+
+
+def _local_partition(
+    b: jax.Array,
+    mesh: Mesh,
+    axis_name: str,
+) -> tuple[int, int]:
+    if b.ndim != 1:
+        raise ValueError(f"b must be one-dimensional; got shape {b.shape}")
+
+    sharding = getattr(b, "sharding", None)
+    expected_spec = P(axis_name)
+    if not isinstance(sharding, NamedSharding):
+        raise ValueError("b must use NamedSharding")
+    if sharding.mesh != mesh or sharding.spec != expected_spec:
+        raise ValueError(
+            f"b must use NamedSharding(mesh, P({axis_name!r})); got {sharding!r}"
+        )
+
+    shards = b.addressable_shards
+    if len(shards) != 1:
+        raise ValueError(
+            "each MPI process must own exactly one addressable RHS shard; got "
+            f"{len(shards)}"
+        )
+    index = shards[0].index
+    if len(index) != 1 or not isinstance(index[0], slice):
+        raise ValueError(f"b must have one contiguous local shard; got index {index!r}")
+
+    row_slice = index[0]
+    if row_slice.step not in (None, 1):
+        raise ValueError(f"b shard must be contiguous; got slice {row_slice!r}")
+    row_start = 0 if row_slice.start is None else int(row_slice.start)
+    row_end = b.shape[0] if row_slice.stop is None else int(row_slice.stop)
+    return row_start, row_end
+
+
+def _validate_matrix(
+    A_local: MatrixOrOperator,
+    nglobal: int,
+    partition_info: tuple[int, int],
+    block_dim: int,
+) -> None:
+    shape = getattr(A_local, "shape", None)
+    if shape is None or len(shape) != 2:
+        raise ValueError("A_local must have a two-dimensional shape")
+
+    n_local = partition_info[1] - partition_info[0]
+    if tuple(shape) != (n_local, nglobal):
+        raise ValueError(
+            "A_local must contain this process's rows and all global columns; "
+            f"expected shape {(n_local, nglobal)}, got {tuple(shape)}"
+        )
+    if block_dim < 1:
+        raise ValueError("block_dim must be a positive integer")
+    if n_local % block_dim != 0 or nglobal % block_dim != 0:
+        raise ValueError(
+            f"local partition ({n_local} rows) and global size ({nglobal}) "
+            f"must be divisible by block_dim {block_dim}"
+        )
+
+
+def _validate_operand(
+    value: jax.Array,
+    template: jax.Array,
+    mesh: Mesh,
+    axis_name: str,
+    name: str,
+) -> None:
+    if value.shape != template.shape:
+        raise ValueError(f"{name} must have shape {template.shape}; got {value.shape}")
+    if value.dtype != template.dtype:
+        raise ValueError(f"{name} must have dtype {template.dtype}; got {value.dtype}")
+    # During an outer JAX transform ``value`` is a tracer and its concrete
+    # sharding is supplied by shard_map. Validate eager calls here.
+    if not isinstance(value, jax.core.Tracer):
+        sharding = getattr(value, "sharding", None)
+        if not isinstance(sharding, NamedSharding):
+            raise ValueError(f"{name} must use NamedSharding")
+        if sharding.mesh != mesh or sharding.spec != P(axis_name):
+            raise ValueError(
+                f"{name} must use the same NamedSharding as the template RHS"
+            )
+
+
+def _transpose_distributed_matrix(
+    A: jsp.BCSR,
+    recvcounts: tuple[int, ...],
+    partition_info: tuple[int, int],
+    max_nnz: int,
+    comm: Comm,
+) -> tuple[jsp.BCSR, np.ndarray]:
+    """Transpose fixed CSR structure and return its packed value-source map."""
+    from mpi4py import MPI
+
+    row_start, row_end = partition_info
+    n_local = row_end - row_start
+    n_global = sum(recvcounts)
+    nranks = len(recvcounts)
+
+    data = np.asarray(A.data)
+    indices = np.asarray(A.indices, dtype=np.int64)
+    indptr = np.asarray(A.indptr, dtype=np.int64)
+    source_rows = np.repeat(
+        np.arange(row_start, row_end, dtype=np.int64), np.diff(indptr)
+    )
+
+    invalid_columns = bool(np.any(indices < 0) or np.any(indices >= n_global))
+    if comm.allreduce(invalid_columns, op=MPI.LOR):
+        raise ValueError("A_local contains a global column index outside the matrix")
+
+    row_bounds = np.cumsum(np.array([0, *recvcounts], dtype=np.int64))
+    owners = np.searchsorted(row_bounds, indices, side="right") - 1
+    send_order = np.argsort(owners, kind="stable")
+    send_counts = np.bincount(owners, minlength=nranks).astype(np.int32)
+    recv_counts = np.empty(nranks, dtype=np.int32)
+    comm.Alltoall(send_counts, recv_counts)
+    send_displs = np.insert(np.cumsum(send_counts[:-1]), 0, 0).astype(np.int32)
+    recv_displs = np.insert(np.cumsum(recv_counts[:-1]), 0, 0).astype(np.int32)
+
+    send_data = np.ascontiguousarray(data[send_order])
+    send_rows = np.ascontiguousarray(indices[send_order])
+    send_cols = np.ascontiguousarray(source_rows[send_order])
+    packed_ids = comm.Get_rank() * max_nnz + np.arange(len(data), dtype=np.int64)
+    send_ids = np.ascontiguousarray(packed_ids[send_order])
+    recv_nnz = int(recv_counts.sum())
+    recv_data = np.empty(recv_nnz, dtype=data.dtype)
+    recv_rows = np.empty(recv_nnz, dtype=np.int64)
+    recv_cols = np.empty(recv_nnz, dtype=np.int64)
+    recv_ids = np.empty(recv_nnz, dtype=np.int64)
+    value_mpi_type = MPI.FLOAT if data.dtype == np.float32 else MPI.DOUBLE
+
+    comm.Alltoallv(
+        [send_data, send_counts, send_displs, value_mpi_type],
+        [recv_data, recv_counts, recv_displs, value_mpi_type],
+    )
+    comm.Alltoallv(
+        [send_rows, send_counts, send_displs, MPI.INT64_T],
+        [recv_rows, recv_counts, recv_displs, MPI.INT64_T],
+    )
+    comm.Alltoallv(
+        [send_cols, send_counts, send_displs, MPI.INT64_T],
+        [recv_cols, recv_counts, recv_displs, MPI.INT64_T],
+    )
+    comm.Alltoallv(
+        [send_ids, send_counts, send_displs, MPI.INT64_T],
+        [recv_ids, recv_counts, recv_displs, MPI.INT64_T],
+    )
+
+    local_rows = recv_rows - row_start
+    order = np.lexsort((recv_cols, local_rows))
+    local_rows = local_rows[order]
+    recv_cols = recv_cols[order]
+    recv_data = recv_data[order]
+    recv_ids = recv_ids[order]
+    row_counts = np.bincount(local_rows, minlength=n_local)
+    transpose_indptr = np.concatenate(([0], np.cumsum(row_counts))).astype(np.int32)
+
+    with temp_enable_x64():
+        transpose_indices = jnp.asarray(recv_cols, dtype=jnp.int64)
+        transpose = jsp.BCSR(
+            (
+                jnp.asarray(recv_data),
+                transpose_indices,
+                jnp.asarray(transpose_indptr),
+            ),
+            shape=(n_local, n_global),
+        )
+    return transpose, recv_ids
+
+
+def make_sharded_solver(
+    A_local: MatrixOrOperator,
+    b: jax.Array,
+    *,
+    comm: Comm,
+    mesh: Mesh | None = None,
+    axis_name: str = "rank",
+    config: dict[str, Any] | None = None,
+    is_symmetric: bool = False,
+    block_dim: int = 1,
+    reuse_setup: bool = False,
+) -> ShardedSolve:
+    """Create a JIT-compiled solver for a globally sharded RHS.
+
+    This interface complements, rather than replaces, ``solve(..., comm=...)``.
+    JAX manages the global input and output arrays through ``shard_map`` while
+    the AmgX solve itself uses the supplied MPI communicator. Version one uses
+    a one-dimensional mesh and requires one MPI process with one mesh-local GPU
+    per rank.
+
+    ``jax.distributed.initialize()`` must be called before this function in a
+    multi-process job. The CSR structure is captured as static per-process state,
+    while the packed values are available as ``solver.A_data``. Pass that array
+    back through ``solver(..., A_data=A_data)`` to differentiate matrix values.
+    Use ``jax.set_mesh(mesh)`` around outer transforms such as ``jax.grad`` that
+    consume the solver's global output.
+
+    Args:
+        A_local: Local row partition with shape ``(n_local, n_global)`` and
+            global column indices.
+        b: Global one-dimensional JAX array using
+            ``NamedSharding(mesh, PartitionSpec(axis_name))``. It is also the
+            shape, dtype, and sharding template for later calls.
+        comm: MPI communicator whose rank order matches the JAX process order.
+        mesh: One-dimensional JAX device mesh. If omitted, use the mesh from
+            ``b.sharding``.
+        axis_name: Name of the mesh axis that partitions rows.
+        config: AmgX configuration. Defaults to the JAX-AMG MPI configuration.
+        is_symmetric: Whether the global matrix is symmetric. When ``False``
+            (the default), the distributed transpose is prepared once during
+            solver creation for the reverse-mode adjoint.
+        block_dim: AmgX block dimension.
+        reuse_setup: Reuse the cached AmgX hierarchy across solves with the
+            same sparsity pattern.
+
+    Returns:
+        A callable ``solver(b, x0=None, *, A_data=None)``. ``solver.A_data`` is the
+        global sharded array of packed CSR values, padded to the largest local
+        nonzero count. ``solver.local_matrix_gradient(gradient)`` converts its
+        gradient back to this rank's unpadded BCSR structure. The solve returns
+        a global sharded solution and an info dictionary. Info values are global
+        arrays with one entry per rank; ``residual_history`` has shape
+        ``(nranks, max_iters + 1)``.
+    """
+    _require_shard_map()
+    if not isinstance(b, jax.Array):
+        raise TypeError("b must be a global jax.Array")
+    mesh = _resolve_mesh(b, mesh, axis_name)
+    _validate_runtime(comm, mesh, axis_name)
+    partition_info = _local_partition(b, mesh, axis_name)
+
+    block_dim = int(block_dim)
+    nglobal = int(b.shape[0])
+    _validate_matrix(A_local, nglobal, partition_info, block_dim)
+
+    local_rhs = b.addressable_shards[0].data
+    A_bcsr = to_bcsr_matrix(A_local, b=local_rhs, use_int64_indices=True)
+    mpi_cache = cache_mpi_metadata(
+        config or {},
+        comm,
+        nglobal,
+        partition_info,
+        A_bcsr,
+        is_symmetric=is_symmetric,
+        block_dim=block_dim,
+    )
+    # cache_mpi_metadata's lrank preserves the existing MPI API's device
+    # selection. In sharded mode JAX has already selected this process's one
+    # mesh-local GPU, so pass its CUDA-local hardware ordinal to AmgX.
+    local_device = mesh.local_devices[0]
+    local_hardware_id = getattr(local_device, "local_hardware_id", local_device.id)
+    mpi_cache["lrank"] = int(local_hardware_id)
+
+    row_spec = P(axis_name)
+    A_data_sharding = NamedSharding(mesh, row_spec)
+    local_nnz = int(A_bcsr.data.shape[0])
+    max_nnz = int(mpi_cache["max_nnz"])
+    local_packed_data = np.zeros(max_nnz, dtype=np.asarray(A_bcsr.data).dtype)
+    local_packed_data[:local_nnz] = np.asarray(A_bcsr.data)
+    A_data = jax.make_array_from_process_local_data(
+        A_data_sharding,
+        local_packed_data,
+        global_shape=(comm.Get_size() * max_nnz,),
+    )
+
+    if is_symmetric:
+        A_transpose = None
+        transpose_cache = None
+        transpose_source_ids = None
+    else:
+        A_transpose, source_ids = _transpose_distributed_matrix(
+            A_bcsr,
+            mpi_cache["recvcounts_tuple"],
+            partition_info,
+            max_nnz,
+            comm,
+        )
+        transpose_cache = cache_mpi_metadata(
+            config or {},
+            comm,
+            nglobal,
+            partition_info,
+            A_transpose,
+            is_symmetric=False,
+            block_dim=block_dim,
+        )
+        transpose_cache["lrank"] = int(local_hardware_id)
+        transpose_source_ids = jnp.asarray(source_ids, dtype=jnp.int32)
+
+    info_specs = {
+        "iterations": row_spec,
+        "residual": row_spec,
+        "status": row_spec,
+        "residual_history": P(axis_name, None),
+    }
+
+    def pack_info(info: ShardedInfo) -> ShardedInfo:
+        return {
+            "iterations": jnp.asarray(info["iterations"], dtype=jnp.int32)[None],
+            "residual": jnp.asarray(info["residual"])[None],
+            "status": jnp.asarray(info["status"], dtype=jnp.int32)[None],
+            "residual_history": jnp.asarray(info["residual_history"])[None, :],
+        }
+
+    def matrix_with_data(
+        data_local: jax.Array,
+        template: jsp.BCSR,
+        cache: dict[str, Any],
+        symmetric: bool,
+    ) -> jsp.BCSR:
+        matrix = jsp.BCSR(
+            (data_local[: template.data.shape[0]], template.indices, template.indptr),
+            shape=template.shape,
+        )
+        return with_cache(matrix, mpi=cache, is_symmetric=symmetric)
+
+    def local_solve(
+        A_data_local: jax.Array, rhs_local: jax.Array
+    ) -> tuple[jax.Array, ShardedInfo]:
+        A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
+        x_local, info = solve(
+            A_dynamic,
+            rhs_local,
+            block_dim=block_dim,
+            reuse_setup=reuse_setup,
+        )
+        return x_local, pack_info(info)
+
+    def local_solve_x0(
+        A_data_local: jax.Array, rhs_local: jax.Array, x0_local: jax.Array
+    ) -> tuple[jax.Array, ShardedInfo]:
+        A_dynamic = matrix_with_data(A_data_local, A_bcsr, mpi_cache, is_symmetric)
+        x_local, info = solve(
+            A_dynamic,
+            rhs_local,
+            x0=x0_local,
+            block_dim=block_dim,
+            reuse_setup=reuse_setup,
+        )
+        return x_local, pack_info(info)
+
+    def local_adjoint(A_data_local: jax.Array, g_local: jax.Array) -> jax.Array:
+        if is_symmetric:
+            A_adjoint = matrix_with_data(
+                A_data_local, A_bcsr, mpi_cache, symmetric=True
+            )
+        else:
+            assert A_transpose is not None
+            assert transpose_cache is not None
+            assert transpose_source_ids is not None
+            all_A_data = jax.lax.all_gather(A_data_local, axis_name, axis=0, tiled=True)
+            transpose_data = all_A_data[transpose_source_ids]
+            A_adjoint = matrix_with_data(
+                transpose_data, A_transpose, transpose_cache, symmetric=False
+            )
+        adjoint_local, _ = solve(
+            A_adjoint,
+            g_local,
+            block_dim=block_dim,
+            reuse_setup=reuse_setup,
+        )
+        return adjoint_local
+
+    halo_plan = mpi_cache["halo_plan"]
+    max_n_ghost = max(comm.allgather(halo_plan.n_ghost))
+    local_row_indices = np.repeat(
+        np.arange(A_bcsr.shape[0], dtype=np.int32),
+        np.diff(np.asarray(A_bcsr.indptr, dtype=np.int64)),
+    )
+    padded_row_indices = np.zeros(max_nnz, dtype=np.int32)
+    padded_row_indices[:local_nnz] = local_row_indices
+    padded_col_to_combined = np.zeros(max_nnz, dtype=np.int32)
+    padded_col_to_combined[:local_nnz] = halo_plan.col_to_combined
+    local_valid_values = np.arange(max_nnz) < local_nnz
+
+    plan_vector_sharding = NamedSharding(mesh, row_spec)
+    plan_matrix_sharding = NamedSharding(mesh, P(axis_name, None))
+
+    def global_plan_vector(local_value: np.ndarray) -> jax.Array:
+        return jax.make_array_from_process_local_data(
+            plan_vector_sharding,
+            local_value,
+            global_shape=(comm.Get_size() * local_value.shape[0],),
+        )
+
+    row_indices = global_plan_vector(padded_row_indices)
+    col_to_combined = global_plan_vector(padded_col_to_combined)
+    valid_values = global_plan_vector(local_valid_values)
+    send_ids = jax.make_array_from_process_local_data(
+        plan_matrix_sharding,
+        halo_plan.send_ids_2d,
+        global_shape=(
+            comm.Get_size() * halo_plan.send_ids_2d.shape[0],
+            halo_plan.send_ids_2d.shape[1],
+        ),
+    )
+    recv_ghost_slot = jax.make_array_from_process_local_data(
+        plan_matrix_sharding,
+        halo_plan.recv_ghost_slot_2d,
+        global_shape=(
+            comm.Get_size() * halo_plan.recv_ghost_slot_2d.shape[0],
+            halo_plan.recv_ghost_slot_2d.shape[1],
+        ),
+    )
+
+    def gather_solution_halo(
+        x_local: jax.Array,
+        send_ids_local: jax.Array,
+        recv_ghost_slot_local: jax.Array,
+    ) -> jax.Array:
+        send_buffer = x_local[send_ids_local]
+        recv_buffer = jax.lax.all_to_all(
+            send_buffer,
+            axis_name,
+            split_axis=0,
+            concat_axis=0,
+        )
+        x_ghost = jnp.zeros(max_n_ghost + 1, dtype=x_local.dtype)
+        x_ghost = x_ghost.at[recv_ghost_slot_local.reshape(-1)].set(
+            recv_buffer.reshape(-1)
+        )
+        return jnp.concatenate([x_local, x_ghost[:max_n_ghost]])
+
+    def local_matrix_gradient(
+        A_data_local: jax.Array,
+        x_at_columns: jax.Array,
+        adjoint_local: jax.Array,
+        row_indices_local: jax.Array,
+        valid_values_local: jax.Array,
+    ) -> jax.Array:
+        grad_values = -adjoint_local[row_indices_local] * x_at_columns
+        return jnp.where(valid_values_local, grad_values, 0)
+
+    def local_gather_matrix_columns(
+        x_local: jax.Array,
+        send_ids_local: jax.Array,
+        recv_ghost_slot_local: jax.Array,
+        col_to_combined_local: jax.Array,
+        valid_values_local: jax.Array,
+    ) -> jax.Array:
+        x_combined = gather_solution_halo(
+            x_local, send_ids_local, recv_ghost_slot_local
+        )
+        return jnp.where(valid_values_local, x_combined[col_to_combined_local], 0)
+
+    def local_backward(
+        A_data_local: jax.Array,
+        x_at_columns: jax.Array,
+        g_local: jax.Array,
+        row_indices_local: jax.Array,
+        valid_values_local: jax.Array,
+    ) -> tuple[jax.Array, jax.Array]:
+        A_data_ordered, g_ordered, x_at_columns = jax.lax.optimization_barrier(
+            (A_data_local, g_local, x_at_columns)
+        )
+        adjoint_local = local_adjoint(A_data_ordered, g_ordered)
+        grad_A_data_local = local_matrix_gradient(
+            A_data_ordered,
+            x_at_columns,
+            adjoint_local,
+            row_indices_local,
+            valid_values_local,
+        )
+        return adjoint_local, grad_A_data_local
+
+    mapped_solve = jax.jit(
+        jax.shard_map(
+            local_solve,
+            mesh=mesh,
+            in_specs=(row_spec, row_spec),
+            out_specs=(row_spec, info_specs),
+        )
+    )
+    mapped_solve_x0 = jax.jit(
+        jax.shard_map(
+            local_solve_x0,
+            mesh=mesh,
+            in_specs=(row_spec, row_spec, row_spec),
+            out_specs=(row_spec, info_specs),
+        )
+    )
+    mapped_gather_matrix_columns = jax.jit(
+        jax.shard_map(
+            local_gather_matrix_columns,
+            mesh=mesh,
+            in_specs=(row_spec, row_spec, row_spec, row_spec, row_spec),
+            out_specs=row_spec,
+        )
+    )
+    mapped_backward = jax.jit(
+        jax.shard_map(
+            local_backward,
+            mesh=mesh,
+            in_specs=(row_spec, row_spec, row_spec, row_spec, row_spec),
+            out_specs=(row_spec, row_spec),
+        )
+    )
+
+    # Place the custom VJP outside shard_map. Its cotangent is then a global
+    # sharded array, and the adjoint shard_map receives the correct local shard
+    # on every rank. Keeping the custom rule inside shard_map would make the
+    # FFI result appear rank-invariant to JAX's varying-manual-axis analysis.
+    @jax.custom_vjp
+    def differentiated_solve(
+        matrix_data: jax.Array, rhs: jax.Array
+    ) -> tuple[jax.Array, ShardedInfo]:
+        return mapped_solve(matrix_data, rhs)
+
+    def differentiated_solve_fwd(matrix_data: jax.Array, rhs: jax.Array):
+        result = mapped_solve(matrix_data, rhs)
+        x, _ = result
+        return result, (matrix_data, x)
+
+    def differentiated_solve_bwd(residuals, cotangents):
+        matrix_data, x = residuals
+        g_x, _ = cotangents
+        x_at_columns = mapped_gather_matrix_columns(
+            x, send_ids, recv_ghost_slot, col_to_combined, valid_values
+        )
+        adjoint, grad_A_data = mapped_backward(
+            matrix_data, x_at_columns, g_x, row_indices, valid_values
+        )
+        return grad_A_data, adjoint
+
+    differentiated_solve.defvjp(differentiated_solve_fwd, differentiated_solve_bwd)
+
+    @jax.custom_vjp
+    def differentiated_solve_x0(
+        matrix_data: jax.Array, rhs: jax.Array, x0: jax.Array
+    ) -> tuple[jax.Array, ShardedInfo]:
+        return mapped_solve_x0(matrix_data, rhs, x0)
+
+    def differentiated_solve_x0_fwd(
+        matrix_data: jax.Array, rhs: jax.Array, x0: jax.Array
+    ):
+        result = mapped_solve_x0(matrix_data, rhs, x0)
+        x, _ = result
+        return result, (matrix_data, x)
+
+    def differentiated_solve_x0_bwd(residuals, cotangents):
+        matrix_data, x = residuals
+        g_x, _ = cotangents
+        x_at_columns = mapped_gather_matrix_columns(
+            x, send_ids, recv_ghost_slot, col_to_combined, valid_values
+        )
+        adjoint, grad_A_data = mapped_backward(
+            matrix_data, x_at_columns, g_x, row_indices, valid_values
+        )
+        return grad_A_data, adjoint, jnp.zeros_like(adjoint)
+
+    differentiated_solve_x0.defvjp(
+        differentiated_solve_x0_fwd, differentiated_solve_x0_bwd
+    )
+
+    def sharded_solver(
+        rhs: jax.Array,
+        x0: jax.Array | None = None,
+        *,
+        A_data_override: jax.Array | None = None,
+    ) -> tuple[jax.Array, ShardedInfo]:
+        _validate_operand(rhs, b, mesh, axis_name, "b")
+        matrix_data = A_data if A_data_override is None else A_data_override
+        _validate_operand(matrix_data, A_data, mesh, axis_name, "A_data")
+        if x0 is None:
+            return differentiated_solve(matrix_data, rhs)
+        _validate_operand(x0, b, mesh, axis_name, "x0")
+        return differentiated_solve_x0(matrix_data, rhs, x0)
+
+    def unpad_matrix_gradient(gradient: jax.Array) -> jsp.BCSR:
+        _validate_operand(gradient, A_data, mesh, axis_name, "A_data gradient")
+        local_gradient = gradient.addressable_shards[0].data[:local_nnz]
+        return jsp.BCSR(
+            (local_gradient, A_bcsr.indices, A_bcsr.indptr), shape=A_bcsr.shape
+        )
+
+    def solve_fn(
+        rhs: jax.Array,
+        x0: jax.Array | None = None,
+        *,
+        A_data: jax.Array | None = None,
+    ) -> tuple[jax.Array, ShardedInfo]:
+        return sharded_solver(rhs, x0, A_data_override=A_data)
+
+    return ShardedSolve(solve_fn, A_data, unpad_matrix_gradient)
+
+
+def solve_sharded(
+    A_local: MatrixOrOperator,
+    b: jax.Array,
+    x0: jax.Array | None = None,
+    *,
+    comm: Comm,
+    mesh: Mesh | None = None,
+    axis_name: str = "rank",
+    config: dict[str, Any] | None = None,
+    is_symmetric: bool = False,
+    block_dim: int = 1,
+    reuse_setup: bool = False,
+) -> tuple[jax.Array, ShardedInfo]:
+    """Solve ``Ax=b`` while preserving JAX global-array sharding.
+
+    This convenience function creates a sharded solver and calls it once. For
+    repeated solves, use :func:`make_sharded_solver` so MPI metadata and the
+    compiled ``shard_map`` are reused.
+    """
+    solver = make_sharded_solver(
+        A_local,
+        b,
+        comm=comm,
+        mesh=mesh,
+        axis_name=axis_name,
+        config=config,
+        is_symmetric=is_symmetric,
+        block_dim=block_dim,
+        reuse_setup=reuse_setup,
+    )
+    return solver(b, x0)

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -19,7 +19,12 @@ from jax.sharding import PartitionSpec as P
 
 from .cache import _build_mpi_cache, with_cache
 from .jaxamg import solve
-from .mpi_utils import HaloPlan, build_halo_plan
+from .mpi_utils import (
+    HaloPlan,
+    _apply_transpose_plan,
+    build_halo_plan,
+    build_transpose_plan,
+)
 from .utils import (
     MatrixOrOperator,
     get_preferred_dtype,
@@ -40,16 +45,6 @@ class _CSRStructure(NamedTuple):
     indptr: jax.Array
     shape: tuple[int, int]
     nnz: int
-
-
-class _TransposePlan(NamedTuple):
-    """Static structure and sparse value-exchange plan for a transpose."""
-
-    local_source_ids: np.ndarray
-    local_target_ids: np.ndarray
-    send_ids_2d: np.ndarray
-    recv_target_ids_2d: np.ndarray
-    max_nnz: int
 
 
 def _primal_halo_placeholder(n_local: int, nranks: int) -> HaloPlan:
@@ -547,135 +542,6 @@ def _validate_operand(
             raise ValueError(f"{name} must use the same NamedSharding as its template")
 
 
-def _transpose_distributed_matrix(
-    indices: np.ndarray,
-    indptr: np.ndarray,
-    recvcounts: tuple[int, ...],
-    partition_info: tuple[int, int],
-    comm: Comm,
-    local_device: jax.Device,
-) -> tuple[_CSRStructure, _TransposePlan]:
-    """Transpose fixed CSR structure and build a sparse value-exchange plan."""
-    from mpi4py import MPI
-
-    row_start, row_end = partition_info
-    n_local = row_end - row_start
-    n_global = sum(recvcounts)
-    nranks = len(recvcounts)
-
-    source_rows = np.repeat(
-        np.arange(row_start, row_end, dtype=np.int64), np.diff(indptr)
-    )
-
-    invalid_columns = bool(np.any(indices < 0) or np.any(indices >= n_global))
-    if comm.allreduce(invalid_columns, op=MPI.LOR):
-        raise ValueError("A_local contains a global column index outside the matrix")
-
-    row_bounds = np.cumsum(np.array([0, *recvcounts], dtype=np.int64))
-    owners = np.searchsorted(row_bounds, indices, side="right") - 1
-    send_order = np.argsort(owners, kind="stable")
-    send_counts = np.bincount(owners, minlength=nranks).astype(np.int32)
-    recv_counts = np.empty(nranks, dtype=np.int32)
-    comm.Alltoall(send_counts, recv_counts)
-    send_displs = np.insert(np.cumsum(send_counts[:-1]), 0, 0).astype(np.int32)
-    recv_displs = np.insert(np.cumsum(recv_counts[:-1]), 0, 0).astype(np.int32)
-
-    send_coordinates = np.ascontiguousarray(
-        np.column_stack((indices[send_order], source_rows[send_order]))
-    )
-    send_ids = np.ascontiguousarray(np.arange(len(indices), dtype=np.int64)[send_order])
-    recv_nnz = int(recv_counts.sum())
-    recv_coordinates = np.empty((recv_nnz, 2), dtype=np.int64)
-    coordinate_send_counts = 2 * send_counts
-    coordinate_recv_counts = 2 * recv_counts
-    coordinate_send_displs = 2 * send_displs
-    coordinate_recv_displs = 2 * recv_displs
-    comm.Alltoallv(
-        [
-            send_coordinates,
-            coordinate_send_counts,
-            coordinate_send_displs,
-            MPI.INT64_T,
-        ],
-        [
-            recv_coordinates,
-            coordinate_recv_counts,
-            coordinate_recv_displs,
-            MPI.INT64_T,
-        ],
-    )
-    recv_rows = recv_coordinates[:, 0]
-    recv_cols = recv_coordinates[:, 1]
-    local_rows = recv_rows - row_start
-    order = np.lexsort((recv_cols, local_rows))
-    local_rows = local_rows[order]
-    recv_cols = recv_cols[order]
-    row_counts = np.bincount(local_rows, minlength=n_local)
-    transpose_indptr = np.concatenate(([0], np.cumsum(row_counts))).astype(np.int32)
-
-    # The dynamic transpose communicates only off-rank values. Entries whose
-    # transpose rows remain on this rank are gathered locally, so the padded
-    # all-to-all chunk is governed by the largest remote rank pair rather than
-    # by the (usually much larger) on-rank diagonal block.
-    rank = comm.Get_rank()
-    remote_send_counts = send_counts.copy()
-    remote_recv_counts = recv_counts.copy()
-    remote_send_counts[rank] = 0
-    remote_recv_counts[rank] = 0
-    local_maxima = np.array(
-        [max(remote_send_counts.max(), remote_recv_counts.max()), recv_nnz],
-        dtype=np.int64,
-    )
-    global_maxima = np.empty_like(local_maxima)
-    comm.Allreduce(local_maxima, global_maxima, op=MPI.MAX)
-    max_per_rank = max(int(global_maxima[0]), 1)
-    max_nnz = int(global_maxima[1])
-
-    send_ids_2d = np.zeros((nranks, max_per_rank), dtype=np.int32)
-    recv_target_ids_2d = np.full((nranks, max_per_rank), recv_nnz, dtype=np.int32)
-    inverse_order = np.empty(recv_nnz, dtype=np.int32)
-    inverse_order[order] = np.arange(recv_nnz, dtype=np.int32)
-    for peer in range(nranks):
-        if peer == rank:
-            continue
-        send_count = int(send_counts[peer])
-        if send_count:
-            start = int(send_displs[peer])
-            send_ids_2d[peer, :send_count] = send_ids[start : start + send_count]
-        recv_count = int(recv_counts[peer])
-        if recv_count:
-            start = int(recv_displs[peer])
-            recv_target_ids_2d[peer, :recv_count] = inverse_order[
-                start : start + recv_count
-            ]
-
-    local_send_start = int(send_displs[rank])
-    local_recv_start = int(recv_displs[rank])
-    local_count = int(send_counts[rank])
-    local_source_ids = send_ids[
-        local_send_start : local_send_start + local_count
-    ].astype(np.int32)
-    local_target_ids = inverse_order[local_recv_start : local_recv_start + local_count]
-
-    with temp_enable_x64():
-        transpose_indices = jax.device_put(
-            np.asarray(recv_cols, dtype=np.int64), local_device
-        )
-        transpose_structure = _CSRStructure(
-            transpose_indices,
-            jax.device_put(transpose_indptr, local_device),
-            (n_local, n_global),
-            recv_nnz,
-        )
-    return transpose_structure, _TransposePlan(
-        local_source_ids,
-        local_target_ids,
-        send_ids_2d,
-        recv_target_ids_2d,
-        max_nnz,
-    )
-
-
 def make_sharded_solver(
     A: ShardedMatrix,
     b: jax.Array,
@@ -780,15 +646,21 @@ def make_sharded_solver(
         transpose_send_ids = None
         transpose_recv_target_ids = None
     else:
-        transpose_structure, transpose_plan = _transpose_distributed_matrix(
+        transpose_plan = build_transpose_plan(
             indices_host,
             indptr_host,
             A.row_counts,
             partition_info,
             comm,
-            local_device,
         )
-        nnz_out = transpose_structure.nnz
+        with temp_enable_x64():
+            transpose_structure = _CSRStructure(
+                jax.device_put(transpose_plan.indices, local_device),
+                jax.device_put(transpose_plan.indptr, local_device),
+                (n_local, nglobal),
+                transpose_plan.nnz,
+            )
+        nnz_out = transpose_plan.nnz
         max_transpose_nnz = transpose_plan.max_nnz
         # Explicit single-device placement keeps rank-local constants local even
         # when solver construction happens inside a global ``jax.set_mesh``
@@ -895,24 +767,22 @@ def make_sharded_solver(
         assert transpose_send_ids is not None
         assert transpose_recv_target_ids is not None
 
-        transpose_values = jnp.zeros(
-            transpose_structure.nnz + 1, dtype=A_data_local.dtype
+        transpose_values = _apply_transpose_plan(
+            A_data_local,
+            transpose_local_source_ids,
+            transpose_local_target_ids,
+            transpose_send_ids,
+            transpose_recv_target_ids,
+            transpose_structure.nnz,
+            lambda values: jax.lax.all_to_all(
+                values,
+                axis_name,
+                split_axis=0,
+                concat_axis=0,
+            ),
         )
-        transpose_values = transpose_values.at[transpose_local_target_ids].set(
-            A_data_local[transpose_local_source_ids]
-        )
-        send_buffer = A_data_local[transpose_send_ids]
-        recv_buffer = jax.lax.all_to_all(
-            send_buffer,
-            axis_name,
-            split_axis=0,
-            concat_axis=0,
-        )
-        transpose_values = transpose_values.at[
-            transpose_recv_target_ids.reshape(-1)
-        ].set(recv_buffer.reshape(-1))
         return jnp.pad(
-            transpose_values[:-1],
+            transpose_values,
             (0, max_transpose_nnz - transpose_structure.nnz),
         )
 
@@ -937,7 +807,6 @@ def make_sharded_solver(
         np.arange(A_bcsr.shape[0], dtype=np.int32),
         np.diff(indptr_host),
     )
-
     # Keep rank-local halo metadata inside the shard_map bodies. Making these
     # arrays global and closing over them in the custom VJP prevents an outer
     # multi-process jax.jit from lowering because their remote shards are not

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -1101,6 +1101,11 @@ def make_sharded_solver(
 
     def check_structure(matrix: jsp.BCSR) -> None:
         """Reject a matrix whose CSR structure differs from the fixed one."""
+        if tuple(matrix.shape) != tuple(A_structure.shape):
+            raise ValueError(
+                f"A must have local shape {tuple(A_structure.shape)}; got "
+                f"{tuple(matrix.shape)}"
+            )
         for given, fixed in (
             (matrix.indices, A_structure.indices),
             (matrix.indptr, A_structure.indptr),

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -92,15 +92,11 @@ class ShardedSolve:
     def __init__(
         self,
         solve_fn: Callable[..., tuple[jax.Array, ShardedInfo]],
-        matrix: ShardedMatrix,
         local_vector_fn: Callable[[jax.Array], jax.Array],
         global_size: int,
         local_size: int,
     ) -> None:
         self._solve_fn = solve_fn
-        self.matrix = matrix
-        # Backward-compatible alias for the matrix container's sharded values.
-        self.A_data = matrix.data
         self._local_vector_fn = local_vector_fn
         self.global_size = global_size
         self.local_size = local_size
@@ -114,10 +110,6 @@ class ShardedSolve:
     ) -> tuple[jax.Array, ShardedInfo]:
         """Solve with the cached values or a differentiable ``A_data`` operand."""
         return self._solve_fn(b, x0, A_data=A_data)
-
-    def local_matrix_gradient(self, gradient: jax.Array) -> jsp.BCSR:
-        """Convert a packed global value gradient to this rank's local BCSR."""
-        return self.matrix.local_matrix(gradient)
 
     def local_vector(self, value: jax.Array) -> jax.Array:
         """Return this rank's unpadded rows of a solver vector or RHS matrix."""
@@ -293,14 +285,13 @@ def _validate_runtime(comm: Comm, mesh: Mesh, axis_name: str) -> None:
         )
 
 
-def _local_partition(
+def _validate_vector_layout(
     b: jax.Array,
     mesh: Mesh,
     axis_name: str,
-    comm: Comm,
-    n_local: int,
-    n_global: int,
-) -> tuple[tuple[int, int], int]:
+    comm_size: int,
+    max_local_size: int,
+) -> None:
     if b.ndim not in (1, 2):
         raise ValueError(f"b must be one- or two-dimensional; got shape {b.shape}")
     if b.ndim == 2 and b.shape[1] == 0:
@@ -315,14 +306,7 @@ def _local_partition(
             f"b must use NamedSharding(mesh, P({axis_name!r})); got {sharding!r}"
         )
 
-    local_sizes = tuple(int(size) for size in comm.allgather(n_local))
-    if sum(local_sizes) != n_global:
-        raise ValueError(
-            "the distributed matrix row counts must sum to its global column "
-            f"count; got row counts {local_sizes} and {n_global} columns"
-        )
-    max_local_size = max(local_sizes)
-    expected_shape = (comm.Get_size() * max_local_size, *b.shape[1:])
+    expected_shape = (comm_size * max_local_size, *b.shape[1:])
     if b.shape != expected_shape:
         raise ValueError(
             f"b must have padded sharded shape {expected_shape}; got {b.shape}. "
@@ -349,6 +333,24 @@ def _local_partition(
             "each physical RHS shard must have the maximum local row count; "
             f"expected {max_local_size}, got {physical_end - physical_start}"
         )
+
+
+def _local_partition(
+    b: jax.Array,
+    mesh: Mesh,
+    axis_name: str,
+    comm: Comm,
+    n_local: int,
+    n_global: int,
+) -> tuple[tuple[int, int], int]:
+    local_sizes = tuple(int(size) for size in comm.allgather(n_local))
+    if sum(local_sizes) != n_global:
+        raise ValueError(
+            "the distributed matrix row counts must sum to its global column "
+            f"count; got row counts {local_sizes} and {n_global} columns"
+        )
+    max_local_size = max(local_sizes)
+    _validate_vector_layout(b, mesh, axis_name, comm.Get_size(), max_local_size)
 
     comm_rank = comm.Get_rank()
     row_start = sum(local_sizes[:comm_rank])
@@ -588,12 +590,9 @@ def _transpose_distributed_matrix(
 
 
 def make_sharded_solver(
-    A_local: MatrixOrOperator | ShardedMatrix,
+    A: ShardedMatrix,
     b: jax.Array,
     *,
-    comm: Comm | None = None,
-    mesh: Mesh | None = None,
-    axis_name: str = "rank",
     config: dict[str, Any] | None = None,
     is_symmetric: bool = False,
     block_dim: int = 1,
@@ -608,26 +607,18 @@ def make_sharded_solver(
     per rank.
 
     ``jax.distributed.initialize()`` must be called before this function in a
-    multi-process job. The CSR structure is captured as static per-process state,
-    while the packed values are available as ``solver.A_data``. Pass that array
-    back through ``solver(..., A_data=A_data)`` to differentiate matrix values.
-    Use ``jax.set_mesh(mesh)`` around outer transforms such as ``jax.grad`` that
-    consume the solver's global output.
+    multi-process job. The matrix owns the communicator, mesh, local CSR
+    structure, and globally sharded packed values. Pass ``A.data`` through
+    ``solver(..., A_data=A_data)`` to differentiate matrix values. Use
+    ``jax.set_mesh(A.mesh)`` around outer transforms such as ``jax.grad``.
 
     Args:
-        A_local: Local row partition with shape ``(n_local, n_global)`` and
-            global column indices, or a :class:`ShardedMatrix` created with
-            :func:`make_sharded_matrix`.
+        A: Distributed matrix created with :func:`make_sharded_matrix`.
         b: Global JAX array with shape ``(n_global,)`` or
             ``(n_global, nrhs)`` using row ``NamedSharding``. For unequal row
             counts, construct it with :func:`make_sharded_vector`; physical
             shards are padded to the largest local partition. Batched RHS
             columns are replicated within each row shard.
-        comm: MPI communicator whose rank order matches the JAX process order.
-            Defaults to ``MPI.COMM_WORLD``.
-        mesh: One-dimensional JAX device mesh. If omitted, use the mesh from
-            ``b.sharding``.
-        axis_name: Name of the mesh axis that partitions rows.
         config: AmgX configuration. Defaults to the JAX-AMG MPI configuration.
         is_symmetric: Whether the global matrix is symmetric. When ``False``
             (the default), the distributed transpose is prepared once during
@@ -639,70 +630,44 @@ def make_sharded_solver(
             same sparsity pattern.
 
     Returns:
-        A callable ``solver(b, x0=None, *, A_data=None)``. ``solver.A_data`` is the
-        global sharded array of packed CSR values, padded to the largest local
-        nonzero count. ``solver.local_matrix_gradient(gradient)`` converts its
-        gradient back to this rank's unpadded BCSR structure, while
-        ``solver.local_vector(value)`` removes vector padding. The solve returns
-        a global sharded solution and an info dictionary. For a vector RHS,
-        info values have one entry per rank. For a batched RHS they have shape
-        ``(nranks, nrhs)`` and ``residual_history`` has an additional trailing
-        ``max_iters + 1`` axis.
+        A callable ``solver(b, x0=None, *, A_data=None)``. Use
+        ``A.local_matrix(gradient)`` to convert packed matrix gradients to this
+        rank's unpadded BCSR structure. ``solver.local_vector(value)`` removes
+        vector padding. For a vector RHS, info values have one entry per rank.
+        For a batched RHS they have shape ``(nranks, nrhs)`` and
+        ``residual_history`` has an additional trailing ``max_iters + 1`` axis.
     """
     _require_shard_map()
+    if not isinstance(A, ShardedMatrix):
+        raise TypeError("A must be created with jaxamg.make_sharded_matrix")
     if not isinstance(b, jax.Array):
         raise TypeError("b must be a global jax.Array")
-    if isinstance(A_local, ShardedMatrix) and comm is None:
-        comm = A_local._comm
-    comm = _resolve_comm(comm)
-    mesh = _resolve_mesh(b, mesh, axis_name)
+    comm = A._comm
+    mesh = A.mesh
+    axis_name = A.axis_name
     _validate_runtime(comm, mesh, axis_name)
 
-    matrix_shape = (
-        A_local.local_shape
-        if isinstance(A_local, ShardedMatrix)
-        else getattr(A_local, "shape", None)
-    )
-    if matrix_shape is None or len(matrix_shape) != 2:
-        raise ValueError("A_local must have a two-dimensional shape")
-    n_local = int(matrix_shape[0])
-    nglobal = int(matrix_shape[1])
-    partition_info, max_n_local = _local_partition(
-        b, mesh, axis_name, comm, n_local, nglobal
-    )
+    n_local = A.local_size
+    nglobal = A.global_size
+    partition_info = A.partition_info
+    max_n_local = A.max_local_size
+    _validate_vector_layout(b, mesh, axis_name, comm.Get_size(), max_n_local)
 
     block_dim = int(block_dim)
     is_batched = b.ndim == 2
     local_rhs = b.addressable_shards[0].data[:n_local]
     matrix_probe_rhs = local_rhs[:, 0] if is_batched else local_rhs
-    sharded_matrix: ShardedMatrix | None
-    if isinstance(A_local, ShardedMatrix):
-        sharded_matrix = A_local
-        if sharded_matrix.mesh != mesh or sharded_matrix.axis_name != axis_name:
-            raise ValueError(
-                "the sharded matrix and RHS must use the same mesh and axis name"
-            )
-        if (
-            sharded_matrix.partition_info != partition_info
-            or sharded_matrix.max_local_size != max_n_local
-        ):
-            raise ValueError(
-                "the sharded matrix partition does not match the current RHS"
-            )
-        normalized_matrix = to_bcsr_matrix(
-            sharded_matrix._local_bcsr,
-            b=matrix_probe_rhs,
-            use_int64_indices=True,
+    normalized_matrix = to_bcsr_matrix(
+        A._local_bcsr,
+        b=matrix_probe_rhs,
+        use_int64_indices=True,
+    )
+    if normalized_matrix.data.dtype != A.data.dtype:
+        raise ValueError(
+            "the sharded matrix dtype is incompatible with b; rebuild it "
+            "with make_sharded_matrix(A_local, b)"
         )
-        if normalized_matrix.data.dtype != sharded_matrix.data.dtype:
-            raise ValueError(
-                "the sharded matrix dtype is incompatible with b; rebuild it "
-                "with make_sharded_matrix(A_local, b)"
-            )
-        A_bcsr = sharded_matrix._local_bcsr
-    else:
-        sharded_matrix = None
-        A_bcsr = _normalize_local_matrix(A_local, b, partition_info)
+    A_bcsr = A._local_bcsr
 
     _validate_matrix(A_bcsr, nglobal, partition_info, block_dim)
     mpi_cache = cache_mpi_metadata(
@@ -724,23 +689,13 @@ def make_sharded_solver(
     rhs_spec = _row_partition_spec(b.ndim, axis_name)
     A_data_spec = P(axis_name)
     max_nnz = int(mpi_cache["max_nnz"])
-    if sharded_matrix is None:
-        sharded_matrix = _pack_sharded_matrix(
-            A_bcsr,
-            comm,
-            mesh,
-            axis_name,
-            partition_info,
-            max_n_local,
-            max_nnz=max_nnz,
-        )
-    elif max_nnz != sharded_matrix.max_local_nnz:
+    if max_nnz != A.max_local_nnz:
         raise RuntimeError(
             "matrix packing and MPI cache disagree about the maximum local nnz"
         )
-    local_nnz = sharded_matrix.local_nnz
-    local_packed_data = sharded_matrix._local_packed_data
-    A_data = sharded_matrix.data
+    local_nnz = A.local_nnz
+    local_packed_data = A._local_packed_data
+    A_data = A.data
 
     if is_symmetric:
         A_transpose = None
@@ -1109,41 +1064,7 @@ def make_sharded_solver(
 
     return ShardedSolve(
         solve_fn,
-        sharded_matrix,
         unpad_local_vector,
         nglobal,
         n_local,
     )
-
-
-def solve_sharded(
-    A_local: MatrixOrOperator | ShardedMatrix,
-    b: jax.Array,
-    x0: jax.Array | None = None,
-    *,
-    comm: Comm | None = None,
-    mesh: Mesh | None = None,
-    axis_name: str = "rank",
-    config: dict[str, Any] | None = None,
-    is_symmetric: bool = False,
-    block_dim: int = 1,
-    reuse_setup: bool = False,
-) -> tuple[jax.Array, ShardedInfo]:
-    """Solve ``Ax=b`` while preserving JAX global-array sharding.
-
-    This convenience function creates a sharded solver and calls it once. For
-    repeated solves, use :func:`make_sharded_solver` so MPI metadata and the
-    compiled ``shard_map`` are reused.
-    """
-    solver = make_sharded_solver(
-        A_local,
-        b,
-        comm=comm,
-        mesh=mesh,
-        axis_name=axis_name,
-        config=config,
-        is_symmetric=is_symmetric,
-        block_dim=block_dim,
-        reuse_setup=reuse_setup,
-    )
-    return solver(b, x0)

--- a/jaxamg/sharding.py
+++ b/jaxamg/sharding.py
@@ -8,6 +8,7 @@ to use one MPI rank per GPU for the distributed solve.
 from __future__ import annotations
 
 import os
+import re
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -274,6 +275,7 @@ def make_sharded_vector(
         length is ``comm.size * max(local_sizes)``; values are cast to
         ``float32`` unless already ``float32`` or ``float64``.
     """
+    _require_supported_jax()
     comm = _resolve_comm(comm)
     if mesh is None:
         # One device per MPI rank. In a multi-process job this covers all JAX
@@ -342,11 +344,23 @@ def _local_mesh(mesh: Mesh, axis_name: str) -> Mesh:
     return jax.make_mesh((1,), (axis_name,), devices=[mesh.local_devices[0]])
 
 
-def _require_shard_map() -> None:
-    if not hasattr(jax, "shard_map"):
+# Older releases default meshes to Auto axes, which drop the sharding spec of
+# derived arrays; the interface relies on explicit sharding throughout.
+_MIN_JAX = (0, 9)
+
+
+def has_supported_jax() -> bool:
+    """Whether the installed JAX release supports the sharding interface."""
+    major, minor = (int(part) for part in re.findall(r"\d+", jax.__version__)[:2])
+    return (major, minor) >= _MIN_JAX
+
+
+def _require_supported_jax() -> None:
+    if not has_supported_jax():
         raise RuntimeError(
-            "JAX-AMG's sharding interface requires a JAX version that exposes "
-            "jax.shard_map. Upgrade JAX or use solve(..., comm=...) instead."
+            "JAX-AMG's sharding interface requires JAX "
+            f"{'.'.join(map(str, _MIN_JAX))} or newer (found {jax.__version__}); "
+            "upgrade JAX or use solve(..., comm=...) instead."
         )
 
 
@@ -641,7 +655,7 @@ def make_sharded_matrix(
         A :class:`ShardedMatrix` whose ``data`` attribute contains the global
         sharded values. The original global matrix is never materialized.
     """
-    _require_shard_map()
+    _require_supported_jax()
     if not isinstance(b, jax.Array):
         raise TypeError("b must be a global jax.Array")
     comm = _resolve_comm(comm)
@@ -758,7 +772,7 @@ def make_sharded_solver(
         unpacks a packed matrix gradient and ``solver.local_vector(value)``
         removes vector padding. Info values have one entry per rank.
     """
-    _require_shard_map()
+    _require_supported_jax()
     if not isinstance(A, ShardedMatrix):
         raise TypeError("A must be created with jaxamg.make_sharded_matrix")
     if not isinstance(b, jax.Array):

--- a/jaxamg/sparsity.py
+++ b/jaxamg/sparsity.py
@@ -27,15 +27,34 @@ from jax.typing import ArrayLike
 
 from .sparsity_tracing import trace_sparsity_pattern
 
-
 # --- Probing-based detection: exhaustive one-hot basis-vector probing ---
+# Device-memory budget for one batch of one-hot probes. The batch is sized from
+# a per-probe footprint estimate (``_probe_batch_size``) so probing never forms
+# an n_global x n_global buffer; the OOM-halving loop stays as the safety net.
+_PROBE_BATCH_BYTES = 256 * 2**20
+
+
+def _probe_batch_size(m: int, n: int, out_itemsize: int) -> int:
+    """Initial batch size for one-hot probing from the device-memory budget.
+
+    Per-probe footprint estimate: the float32 one-hot input, the output, and up to
+    two full-input-size intermediates at the output precision -- an operator
+    partitioned from a global one (``global_op(x)[row_start:row_end]``) applies
+    the global operator to the whole vector before slicing its rows. The batch
+    size only sets the work per step: the (rows, cols) result is independent of it.
+    """
+    per_probe = 4 * m + out_itemsize * (2 * m + n)
+    return max(1, min(m, _PROBE_BATCH_BYTES // per_probe))
+
+
 def _probe_columns(
     A_callable: Callable, shape: tuple[int, int], tol: float
 ) -> tuple[np.ndarray, np.ndarray]:
     """Exhaustive probing with one-hot basis vectors (correct for any operator).
 
     Probes columns in batches and extracts the non-zeros per block (the full
-    (m, n) matrix is never assembled), halving the batch on OOM. O(m) probes.
+    (m, n) matrix is never assembled). Batches are sized to a device-memory
+    budget, then halved on OOM. O(m) probes.
     """
     n, m = shape
 
@@ -50,6 +69,13 @@ def _probe_columns(
 
         def batched_A(basis):
             return jax.lax.map(A_callable, basis)
+
+    # Output precision, for sizing the probe batches (worst case if unknown).
+    try:
+        out_sds = jax.eval_shape(A_callable, jax.ShapeDtypeStruct((m,), jnp.float32))
+        out_itemsize = int(np.dtype(out_sds.dtype).itemsize)
+    except Exception:
+        out_itemsize = 8
 
     def _eval_batch(start: int, size: int) -> tuple[np.ndarray, np.ndarray]:
         indices = jnp.arange(start, start + size)
@@ -76,7 +102,7 @@ def _probe_columns(
         s = str(e).lower()
         return "resource exhausted" in s or "out of memory" in s or "oom" in s
 
-    batch_size = m
+    batch_size = _probe_batch_size(m, n, out_itemsize)
     result: tuple[np.ndarray, np.ndarray] | None = None
     while result is None and batch_size >= 1:
         try:
@@ -105,9 +131,11 @@ def probe_sparsity_pattern(
     """Determine the sparsity pattern of a linear operator by one-hot probing.
 
     Probes the operator with batches of one-hot basis vectors and extracts the
-    nonzeros per block (the full (m, n) matrix is never assembled), halving the
-    batch on OOM. Correct for any operator; this is the fallback used when
-    jaxpr tracing is unavailable (opaque or data-dependent operators).
+    nonzeros per block (the full (m, n) matrix is never assembled). Batches are
+    sized to a device-memory budget -- so an operator partitioned from a global
+    one never forms an n_global x n_global buffer -- and halved on OOM. Correct
+    for any operator; this is the fallback used when jaxpr tracing is unavailable
+    (opaque or data-dependent operators).
 
     Must be run outside of JIT compilation. Returns (rows, cols).
     """

--- a/jaxamg/sparsity_tracing.py
+++ b/jaxamg/sparsity_tracing.py
@@ -158,16 +158,33 @@ _MOVEMENT_PRIMS = {
     "gather",
 }
 
-_CPU = jax.devices("cpu")[0]
-
 _UNKNOWN = object()  # sentinel: a value that depends on the operator input
+
+_HOST_DEVICE: Any = None  # this process's CPU device, resolved on first use
+
+
+def _host_device() -> Any:
+    """This process's (addressable) CPU device, resolved lazily and cached.
+
+    Under ``jax.distributed`` every process sees every process's CPU devices, so
+    ``jax.devices("cpu")[0]`` is process 0's -- not addressable elsewhere. Binding
+    on it raises, which silently turned every constant fold into ``_UNKNOWN`` and
+    bailed the whole trace on every rank but 0 (e.g. "conv with non-constant
+    kernel"), down to the probing fallback. Resolving lazily also keeps importing
+    this module from initializing the backends, which must not happen before
+    ``jax.distributed.initialize``.
+    """
+    global _HOST_DEVICE
+    if _HOST_DEVICE is None:
+        _HOST_DEVICE = jax.local_devices(backend="cpu")[0]
+    return _HOST_DEVICE
 
 
 @contextlib.contextmanager
 def _host_exact() -> Iterator[None]:
-    """Run host-side index/position binds on CPU with x64 enabled, so position
-    arithmetic stays exact regardless of the global precision config."""
-    with temp_enable_x64(), jax.default_device(_CPU):
+    """Run host-side index/position binds on this process's CPU with x64 enabled,
+    so position arithmetic stays exact regardless of the global precision config."""
+    with temp_enable_x64(), jax.default_device(_host_device()):
         yield
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Solver Configuration: config.md
   - MPI: mpi.md
   - Caching: caching.md
+  - JAX Sharding: sharding.md
   - Environment Variables: environ.md
   - Development: development.md
   - API Reference: api.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ testpaths = ["tests"]
 markers = [
     "gpu: tests that run the native AmgX solver (skipped without a GPU JAX backend)",
     "mpi: distributed tests; run under mpirun with pytest-mpi's --only-mpi flag",
+    "sharding: multi-process JAX sharding tests",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ select = ["E", "F", "W", "I", "UP"]
 ignore = ["E501", "F403", "F405", "E731", "E741"]
 
 [tool.ruff.lint.per-file-ignores]
-"demo/*" = ["F841"]
+"demo/*" = ["E402", "F841"]
 "tests/*" = ["F841"]
 
 [tool.black]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration and fixtures for jaxamg tests."""
 
 import os
+import sys
 
 # Under mpirun, pin each rank to a single distinct GPU before JAX initializes
 # its CUDA backend (test collection already allocates on device). Otherwise
@@ -8,7 +9,8 @@ import os
 # once a few ranks preallocate on it.
 _local_rank = os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK")
 _visible_gpus = os.environ.get("CUDA_VISIBLE_DEVICES")
-if _local_rank is not None and _visible_gpus:
+_sharding_test = any("test_sharding_mpi.py" in arg for arg in sys.argv[1:])
+if _local_rank is not None and _visible_gpus and not _sharding_test:
     _gpus = _visible_gpus.split(",")
     os.environ["CUDA_VISIBLE_DEVICES"] = _gpus[int(_local_rank) % len(_gpus)]
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -231,11 +231,9 @@ def test_mpi_allgatherv(mpi_context):
 def test_mpi_transpose(mpi_context):
     """Test distributed transpose on a non-symmetric matri."""
     comm, rank, nranks = mpi_context
-    from mpi4py import MPI
-
     from jaxamg.mpi_utils import (
-        _mpi4jax_alltoallv_transpose,
-        local_transpose_nnz,
+        _mpi4jax_transpose_values,
+        build_transpose_plan,
     )
 
     grid_size = 4
@@ -269,30 +267,42 @@ def test_mpi_transpose(mpi_context):
     row_counts_global = comm.allgather(n_local)
     recvcounts_tuple = tuple(row_counts_global)
 
-    # Calculate max_nnz across ranks (send buffers) and this rank's local
-    # nnz(A^T) (output). For this structurally symmetric graph the latter equals
-    # the local nnz of A, so both transpose directions use the same value.
-    max_nnz = comm.allreduce(nnz_local, op=MPI.MAX)
-    nnz_out = local_transpose_nnz(A_local.indices, recvcounts_tuple, comm)
-
-    # 3. Compute A^T
-    data_T, indices_T, indptr_T = _mpi4jax_alltoallv_transpose(
-        new_data,
+    plan = build_transpose_plan(
         A_local.indices,
         A_local.indptr,
         recvcounts_tuple,
+        (row_start, row_end),
         comm,
-        max_nnz,
-        nnz_out,
     )
+
+    # 3. Compute A^T
+    data_T = _mpi4jax_transpose_values(
+        new_data,
+        jnp.asarray(plan.local_source_ids),
+        jnp.asarray(plan.local_target_ids),
+        jnp.asarray(plan.send_ids_2d),
+        jnp.asarray(plan.recv_target_ids_2d),
+        plan.nnz,
+        comm,
+    )
+    indices_T = plan.indices
+    indptr_T = plan.indptr
 
     # Verify A^T is different from A (sanity check)
     assert not np.allclose(data_T, new_data)
 
     # 4. Compute (A^T)^T -> should be A
-    data_TT, indices_TT, indptr_TT = _mpi4jax_alltoallv_transpose(
-        data_T, indices_T, indptr_T, recvcounts_tuple, comm, max_nnz, nnz_out
+    data_TT = _mpi4jax_transpose_values(
+        data_T,
+        jnp.asarray(plan.local_target_ids),
+        jnp.asarray(plan.local_source_ids),
+        jnp.asarray(plan.recv_target_ids_2d),
+        jnp.asarray(plan.send_ids_2d),
+        len(A_local.data),
+        comm,
     )
+    indices_TT = A_local.indices
+    indptr_TT = A_local.indptr
 
     # 5. Verify (A^T)^T == A
     np.testing.assert_array_equal(indptr_TT, A_local.indptr)
@@ -301,19 +311,21 @@ def test_mpi_transpose(mpi_context):
 
     # 6. Verify JIT compatibility
     @jax.jit
-    def transpose_jit_fn(data, indices, indptr):
-        return _mpi4jax_alltoallv_transpose(
-            data, indices, indptr, recvcounts_tuple, comm, max_nnz, nnz_out
+    def transpose_jit_fn(data):
+        return _mpi4jax_transpose_values(
+            data,
+            jnp.asarray(plan.local_source_ids),
+            jnp.asarray(plan.local_target_ids),
+            jnp.asarray(plan.send_ids_2d),
+            jnp.asarray(plan.recv_target_ids_2d),
+            plan.nnz,
+            comm,
         )
 
     # Run JIT-compiled transpose
-    data_T_jit, indices_T_jit, indptr_T_jit = transpose_jit_fn(
-        new_data, A_local.indices, A_local.indptr
-    )
+    data_T_jit = transpose_jit_fn(new_data)
 
     # Verify JIT output matches non-JIT output
-    np.testing.assert_array_equal(indptr_T_jit, indptr_T)
-    np.testing.assert_array_equal(indices_T_jit, indices_T)
     np.testing.assert_allclose(data_T_jit, data_T)
 
 
@@ -332,7 +344,7 @@ def test_mpi_transpose_nonsymmetric_nnz(mpi_context):
     import scipy.sparse as sp
     from mpi4py import MPI
 
-    from jaxamg.mpi_utils import _mpi4jax_alltoallv_transpose, local_transpose_nnz
+    from jaxamg.mpi_utils import _mpi4jax_transpose_values, build_transpose_plan
 
     n = 4 * nranks
     rows, cols, vals = [], [], []
@@ -350,21 +362,25 @@ def test_mpi_transpose_nonsymmetric_nnz(mpi_context):
     A_local, row_start, row_end = partition_csr_matrix(A, rank, nranks)
     n_local = row_end - row_start
     recvcounts_tuple = tuple(comm.allgather(n_local))
-    max_nnz = comm.allreduce(int(A_local.data.shape[0]), op=MPI.MAX)
-    nnz_out = local_transpose_nnz(A_local.indices, recvcounts_tuple, comm)
-
-    data_T, indices_T, indptr_T = _mpi4jax_alltoallv_transpose(
-        A_local.data,
+    plan = build_transpose_plan(
         A_local.indices,
         A_local.indptr,
         recvcounts_tuple,
+        (row_start, row_end),
         comm,
-        max_nnz,
-        nnz_out,
+    )
+    data_T = _mpi4jax_transpose_values(
+        A_local.data,
+        jnp.asarray(plan.local_source_ids),
+        jnp.asarray(plan.local_target_ids),
+        jnp.asarray(plan.send_ids_2d),
+        jnp.asarray(plan.recv_target_ids_2d),
+        plan.nnz,
+        comm,
     )
     data_T = np.asarray(data_T)
-    indices_T = np.asarray(indices_T)
-    indptr_T = np.asarray(indptr_T)
+    indices_T = plan.indices
+    indptr_T = plan.indptr
 
     # Ground truth: this rank's rows of the true global transpose.
     at_true = A.T.tocsr()[row_start:row_end].toarray()
@@ -378,7 +394,7 @@ def test_mpi_transpose_nonsymmetric_nnz(mpi_context):
 
     # The scenario must actually exercise unequal local counts on some rank
     # (otherwise it would not distinguish the fix from the old nnz(A) sizing).
-    grew = comm.allreduce(int(nnz_out != int(A_local.data.shape[0])), op=MPI.SUM)
+    grew = comm.allreduce(int(plan.nnz != int(A_local.data.shape[0])), op=MPI.SUM)
     assert grew > 0, "test matrix should give unequal local nnz across transpose"
 
 

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -375,3 +375,14 @@ def test_sharded_matrix_rejects_nullspace():
     )
     with pytest.raises(ValueError, match="null spaces"):
         jaxamg.make_sharded_matrix(A_local, b)
+
+
+def test_distributed_basis_allows_more_columns_than_local_rows():
+    from jaxamg.nullspace import as_nullspace_basis
+
+    basis = np.ones((1, 2), dtype=np.float32)
+    assert as_nullspace_basis(basis, 1, jnp.float32, "nullspace", 4).shape == (1, 2)
+    with pytest.raises(ValueError, match="k ≤ 1"):
+        as_nullspace_basis(basis, 1, jnp.float32, "nullspace")
+    with pytest.raises(ValueError, match="k ≤ 1"):
+        as_nullspace_basis(basis, 1, jnp.float32, "nullspace", 1)

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,4 +1,6 @@
+import os
 import sys
+import warnings
 from types import ModuleType, SimpleNamespace
 
 import jax
@@ -308,3 +310,35 @@ def test_sharded_solver_requires_sharded_matrix():
 
     with pytest.raises(TypeError, match="make_sharded_matrix"):
         jaxamg.make_sharded_solver(jnp.eye(4), b)  # type: ignore[arg-type]
+
+
+def test_shard_autotuning_flag(monkeypatch):
+    monkeypatch.setattr(sharding_module, "_backends_are_initialized", lambda: False)
+
+    monkeypatch.setenv("XLA_FLAGS", "--xla_gpu_autotune_level=2")
+    assert sharding_module._disable_shard_autotuning()
+    assert os.environ["XLA_FLAGS"] == (
+        "--xla_gpu_autotune_level=2 --xla_gpu_shard_autotuning=false"
+    )
+
+    monkeypatch.setenv("XLA_FLAGS", "--xla_gpu_shard_autotuning=true")
+    assert not sharding_module._disable_shard_autotuning()
+    assert os.environ["XLA_FLAGS"] == "--xla_gpu_shard_autotuning=true"
+
+    monkeypatch.setattr(sharding_module, "_backends_are_initialized", lambda: True)
+    monkeypatch.delenv("XLA_FLAGS")
+    assert not sharding_module._disable_shard_autotuning()
+    assert "XLA_FLAGS" not in os.environ
+
+
+def test_shard_autotuning_warning(monkeypatch):
+    monkeypatch.setattr(jax, "process_count", lambda: 2)
+
+    monkeypatch.setattr(sharding_module, "_SHARD_AUTOTUNING_DISABLED", False)
+    with pytest.warns(UserWarning, match="sharded autotuning"):
+        sharding_module._check_shard_autotuning()
+
+    monkeypatch.setattr(sharding_module, "_SHARD_AUTOTUNING_DISABLED", True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sharding_module._check_shard_autotuning()

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -267,6 +267,11 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     # Same nnz, different column indices.
     with pytest.raises(ValueError, match="sparsity structure"):
         solver(b, A=jsp.BCSR.fromdense(jnp.fliplr(jnp.eye(4, dtype=jnp.float32))))
+    # Same CSR arrays, different declared shape.
+    with pytest.raises(ValueError, match="local shape"):
+        solver(
+            b, A=jsp.BCSR((A_local.data, A_local.indices, A_local.indptr), shape=(4, 8))
+        )
     with pytest.raises(ValueError, match="concrete"):
         jax.jit(
             lambda idx, rhs: solver(

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -64,6 +64,19 @@ def test_make_sharded_vector_constructs_default_mesh():
     np.testing.assert_array_equal(np.asarray(b), values)
 
 
+def test_make_sharded_vector_rejects_batched_rhs():
+    mesh = jax.make_mesh((1,), ("rank",), devices=[jax.devices()[0]])
+    comm = SimpleNamespace(
+        Get_size=lambda: 1,
+        allgather=lambda value: [value],
+    )
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        jaxamg.make_sharded_vector(
+            np.ones((4, 2), dtype=np.float32), comm=comm, mesh=mesh
+        )
+
+
 def test_sharded_inputs_preserve_device_arrays(monkeypatch):
     mesh, local_values = _single_device_array(np.arange(4, dtype=np.float32))
     A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
@@ -187,6 +200,12 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     )
     np.testing.assert_array_equal(np.asarray(x_jit), np.asarray(b))
 
+    # Multiple RHS use the same public batching path as the ordinary solver:
+    # vmap a solver that accepts one vector at a time.
+    batched_b = jnp.stack((b, 2 * b))
+    batched_x = jax.vmap(lambda rhs: solver(rhs, A_data=matrix.data)[0])(batched_b)
+    np.testing.assert_array_equal(np.asarray(batched_x), np.asarray(batched_b))
+
     with pytest.raises(ValueError, match="A_data must be passed explicitly"):
         jax.jit(solver).lower(b)
 
@@ -217,98 +236,6 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(np.asarray(b)))
 
     assert len(transpose_calls) == 1
-
-
-def test_sharded_solver_supports_batched_rhs(monkeypatch):
-    values = np.arange(1, 9, dtype=np.float32).reshape(4, 2)
-    mesh = jax.make_mesh((1,), ("rank",), devices=[jax.devices()[0]])
-    comm = SimpleNamespace(
-        Get_size=lambda: 1,
-        Get_rank=lambda: 0,
-        allgather=lambda value: [value],
-    )
-    b = jaxamg.make_sharded_vector(values, comm=comm, mesh=mesh, global_size=4)
-    A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
-    halo_plan = SimpleNamespace(
-        n_ghost=0,
-        max_n_ghost=0,
-        col_to_combined=np.arange(4, dtype=np.int32),
-        send_ids_2d=np.zeros((1, 1), dtype=np.int32),
-        recv_ghost_slot_2d=np.zeros((1, 1), dtype=np.int32),
-    )
-
-    monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
-    monkeypatch.setattr(
-        sharding_module,
-        "build_halo_plan",
-        lambda *args, **kwargs: halo_plan,
-    )
-    monkeypatch.setattr(
-        sharding_module,
-        "_build_mpi_cache",
-        lambda config, comm, nglobal, row_counts, max_nnz, nnz_out, plan, **kwargs: {
-            "lrank": 0,
-            "recvcounts_tuple": row_counts,
-            "max_nnz": max_nnz,
-            "nnz_out": nnz_out,
-            "halo_plan": plan,
-        },
-    )
-    monkeypatch.setattr(sharding_module, "with_cache", lambda A, **kwargs: A)
-    monkeypatch.setattr(sharding_module, "to_bcsr_matrix", lambda A, **kwargs: A)
-    monkeypatch.setattr(
-        sharding_module,
-        "_transpose_distributed_matrix",
-        lambda *args: (
-            _single_rank_transpose_structure(A_local),
-            _single_rank_transpose_plan(A_local),
-        ),
-    )
-
-    def fake_solve(A, rhs, x0=None, **kwargs):
-        x = A.data * rhs
-        if x0 is not None:
-            x = x + x0
-        return x, {
-            "iterations": jnp.asarray(2.0),
-            "residual": jnp.asarray(1e-6, dtype=rhs.dtype),
-            "status": jnp.asarray(0.0),
-            "residual_history": jnp.asarray([1.0, 0.1, 1e-6], dtype=rhs.dtype),
-        }
-
-    monkeypatch.setattr(sharding_module, "solve", fake_solve)
-    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
-    solver = jaxamg.make_sharded_solver(matrix, b)
-
-    with jax.set_mesh(mesh):
-        x, info = jax.jit(lambda matrix_data, rhs: solver(rhs, A_data=matrix_data))(
-            matrix.data, b
-        )
-        grad_A_data, grad_b = jax.jit(
-            jax.grad(
-                lambda matrix_data, rhs: jnp.sum(
-                    solver(rhs, A_data=matrix_data)[0] ** 2
-                ),
-                argnums=(0, 1),
-            )
-        )(matrix.data, b)
-        grad_b_warm, grad_x0 = jax.grad(
-            lambda data, rhs, x0: jnp.sum(solver(rhs, x0, A_data=data)[0] ** 2),
-            argnums=(1, 2),
-        )(matrix.data, b, b)
-
-    np.testing.assert_array_equal(np.asarray(x), values)
-    np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), values)
-    assert info["iterations"].shape == (1, 2)
-    assert info["residual_history"].shape == (1, 2, 3)
-    np.testing.assert_array_equal(np.asarray(grad_b), 2 * values)
-    np.testing.assert_array_equal(np.asarray(grad_b_warm), 4 * values)
-    np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(values))
-
-    grad_A_local = matrix.local_matrix(grad_A_data)
-    np.testing.assert_array_equal(
-        np.asarray(grad_A_local.data), -2 * np.sum(values**2, axis=1)
-    )
 
 
 def test_sharded_matrix_validates_partition(monkeypatch):

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -185,7 +185,8 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm)
     # Omit mesh to exercise inference from b.sharding.
     solver = jaxamg.make_sharded_solver(matrix, b)
-    assert len(allgather_calls) == 2
+    # Row counts, nonzero counts, and the null-space schema.
+    assert len(allgather_calls) == 3
     assert len(normalization_calls) == 1
     assert len(halo_plan_calls) == 1
     x, info = solver(b)
@@ -368,13 +369,21 @@ def test_make_sharded_vector_normalizes_dtype_and_rejects_empty_ranks():
         jaxamg.make_sharded_vector(np.zeros(0, dtype=np.float32), comm=comm)
 
 
-def test_sharded_matrix_rejects_nullspace():
-    _, b = _single_device_array(np.ones(4, dtype=np.float32))
+def test_sharded_matrix_keeps_nullspace_bases(monkeypatch):
+    mesh, b = _single_device_array(np.ones(4, dtype=np.float32))
+    monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
+    comm = SimpleNamespace(
+        Get_size=lambda: 1, Get_rank=lambda: 0, allgather=lambda value: [value]
+    )
     A_local = jaxamg.with_cache(
         jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32)), nullspace="constant"
     )
-    with pytest.raises(ValueError, match="null spaces"):
-        jaxamg.make_sharded_matrix(A_local, b)
+
+    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
+
+    np.testing.assert_array_equal(np.asarray(matrix._nullspace), np.ones((4, 1)))
+    assert matrix._nullspace.dtype == jnp.float32
+    assert matrix._transpose_nullspace is None
 
 
 def test_distributed_basis_allows_more_columns_than_local_rows():

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -32,6 +32,21 @@ def _single_device_array(values):
     return mesh, jax.device_put(jnp.asarray(values), sharding)
 
 
+def test_make_sharded_vector_constructs_default_mesh():
+    comm = SimpleNamespace(
+        Get_size=lambda: 1,
+        allgather=lambda value: [value],
+    )
+    values = np.arange(4, dtype=np.float32)
+
+    b = jaxamg.make_sharded_vector(values, comm=comm, global_size=4)
+
+    assert isinstance(b.sharding, jax.NamedSharding)
+    assert b.sharding.mesh.size == jax.device_count()
+    assert b.sharding.spec == jax.P("rank")
+    np.testing.assert_array_equal(np.asarray(b), values)
+
+
 def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     mesh, b = _single_device_array(np.arange(4, dtype=np.float32))
     A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -9,6 +9,7 @@ import pytest
 
 import jaxamg
 import jaxamg.sharding as sharding_module
+from jaxamg.mpi_utils import TransposePlan
 
 pytestmark = pytest.mark.skipif(
     not hasattr(jax, "shard_map"), reason="jax.shard_map is unavailable"
@@ -34,18 +35,14 @@ def _single_device_array(values):
 
 def _single_rank_transpose_plan(A):
     nnz = len(A.data)
-    return sharding_module._TransposePlan(
+    return TransposePlan(
+        np.asarray(A.indices),
+        np.asarray(A.indptr),
         np.arange(nnz, dtype=np.int32),
         np.arange(nnz, dtype=np.int32),
-        np.zeros((1, 1), dtype=np.int32),
+        np.full((1, 1), nnz, dtype=np.int32),
         np.full((1, 1), nnz, dtype=np.int32),
         nnz,
-    )
-
-
-def _single_rank_transpose_structure(A):
-    return sharding_module._CSRStructure(
-        A.indices, A.indptr, tuple(A.shape), len(A.data)
     )
 
 
@@ -159,13 +156,9 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     def fake_transpose(*args):
         transpose_calls.append(A_local)
-        return _single_rank_transpose_structure(A_local), _single_rank_transpose_plan(
-            A_local
-        )
+        return _single_rank_transpose_plan(A_local)
 
-    monkeypatch.setattr(
-        sharding_module, "_transpose_distributed_matrix", fake_transpose
-    )
+    monkeypatch.setattr(sharding_module, "build_transpose_plan", fake_transpose)
 
     def fake_solve(A, rhs, x0=None, **kwargs):
         x = A.data * rhs

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+import jax
+import jax.experimental.sparse as jsp
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import jaxamg
+import jaxamg.sharding as sharding_module
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(jax, "shard_map"), reason="jax.shard_map is unavailable"
+)
+
+
+def _single_device_array(values):
+    mesh = jax.make_mesh((1,), ("rank",), devices=[jax.devices()[0]])
+    sharding = jax.NamedSharding(mesh, jax.P("rank"))
+    return mesh, jax.device_put(jnp.asarray(values), sharding)
+
+
+def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
+    mesh, b = _single_device_array(np.arange(4, dtype=np.float32))
+    A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
+    comm = SimpleNamespace(Get_size=lambda: 1, allgather=lambda value: [value])
+    halo_plan = SimpleNamespace(
+        n_ghost=0,
+        col_to_combined=np.arange(4, dtype=np.int32),
+        send_ids_2d=np.zeros((1, 1), dtype=np.int32),
+        recv_ghost_slot_2d=np.zeros((1, 1), dtype=np.int32),
+    )
+
+    monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
+    monkeypatch.setattr(
+        sharding_module,
+        "cache_mpi_metadata",
+        lambda *args, **kwargs: {
+            "lrank": 99,
+            "recvcounts_tuple": (4,),
+            "max_nnz": 4,
+            "halo_plan": halo_plan,
+        },
+    )
+    monkeypatch.setattr(
+        sharding_module,
+        "with_cache",
+        lambda A, **kwargs: A,
+    )
+    monkeypatch.setattr(
+        sharding_module,
+        "to_bcsr_matrix",
+        lambda A, **kwargs: A,
+    )
+    transpose_calls = []
+
+    def fake_transpose(A, *args):
+        transpose_calls.append(A)
+        return A, np.arange(len(A.data), dtype=np.int32)
+
+    monkeypatch.setattr(
+        sharding_module, "_transpose_distributed_matrix", fake_transpose
+    )
+
+    def fake_solve(A, rhs, x0=None, **kwargs):
+        x = A.data * rhs
+        if x0 is not None:
+            x = x + x0
+        info = {
+            "iterations": jnp.asarray(2.0),
+            "residual": jnp.asarray(1e-6, dtype=rhs.dtype),
+            "status": jnp.asarray(0.0),
+            "residual_history": jnp.asarray([1.0, 0.1, 1e-6], dtype=rhs.dtype),
+        }
+        return x, info
+
+    monkeypatch.setattr(sharding_module, "solve", fake_solve)
+
+    # Omit mesh to exercise inference from b.sharding.
+    solver = jaxamg.make_sharded_solver(A_local, b, comm=comm)
+    x, info = solver(b)
+    np.testing.assert_array_equal(np.asarray(x), np.asarray(b))
+    np.testing.assert_array_equal(np.asarray(info["iterations"]), [2])
+    assert info["residual_history"].shape == (1, 3)
+
+    x_jit, _ = jax.jit(solver)(b)
+    np.testing.assert_array_equal(np.asarray(x_jit), np.asarray(b))
+
+    x_updated, _ = solver(b, A_data=2 * solver.A_data)
+    np.testing.assert_array_equal(np.asarray(x_updated), 2 * np.asarray(b))
+
+    x_warm, _ = solver(b, b)
+    np.testing.assert_array_equal(np.asarray(x_warm), 2 * np.asarray(b))
+
+    with jax.set_mesh(mesh):
+        grad_b = jax.grad(lambda rhs: jnp.sum(solver(rhs)[0] ** 2))(b)
+        grad_A_data = jax.grad(lambda data: jnp.sum(solver(b, A_data=data)[0] ** 2))(
+            solver.A_data
+        )
+        grad_b_warm, grad_x0 = jax.grad(
+            lambda rhs, x0: jnp.sum(solver(rhs, x0)[0] ** 2),
+            argnums=(0, 1),
+        )(b, b)
+    np.testing.assert_array_equal(np.asarray(grad_b), 2 * np.asarray(b))
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    np.testing.assert_array_equal(
+        np.asarray(grad_A_local.data), -2 * np.asarray(b) ** 2
+    )
+    np.testing.assert_array_equal(np.asarray(grad_b_warm), 4 * np.asarray(b))
+    np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(np.asarray(b)))
+
+    x_once, _ = jaxamg.solve_sharded(A_local, b, comm=comm, mesh=mesh)
+    np.testing.assert_array_equal(np.asarray(x_once), np.asarray(b))
+    assert len(transpose_calls) == 2
+
+
+def test_sharded_solver_validates_matrix_partition(monkeypatch):
+    mesh, b = _single_device_array(np.ones(4, dtype=np.float32))
+    monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
+
+    with pytest.raises(ValueError, match="expected shape"):
+        jaxamg.make_sharded_solver(
+            SimpleNamespace(shape=(3, 4)),
+            b,
+            comm=object(),
+            mesh=mesh,
+        )

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -121,6 +121,85 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     assert len(transpose_calls) == 2
 
 
+def test_sharded_solver_supports_batched_rhs(monkeypatch):
+    values = np.arange(1, 9, dtype=np.float32).reshape(4, 2)
+    mesh = jax.make_mesh((1,), ("rank",), devices=[jax.devices()[0]])
+    comm = SimpleNamespace(
+        Get_size=lambda: 1,
+        Get_rank=lambda: 0,
+        allgather=lambda value: [value],
+    )
+    b = jaxamg.make_sharded_vector(values, comm=comm, mesh=mesh, global_size=4)
+    A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
+    halo_plan = SimpleNamespace(
+        n_ghost=0,
+        col_to_combined=np.arange(4, dtype=np.int32),
+        send_ids_2d=np.zeros((1, 1), dtype=np.int32),
+        recv_ghost_slot_2d=np.zeros((1, 1), dtype=np.int32),
+    )
+
+    monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
+    monkeypatch.setattr(
+        sharding_module,
+        "cache_mpi_metadata",
+        lambda *args, **kwargs: {
+            "lrank": 0,
+            "recvcounts_tuple": (4,),
+            "max_nnz": 4,
+            "halo_plan": halo_plan,
+        },
+    )
+    monkeypatch.setattr(sharding_module, "with_cache", lambda A, **kwargs: A)
+    monkeypatch.setattr(sharding_module, "to_bcsr_matrix", lambda A, **kwargs: A)
+    monkeypatch.setattr(
+        sharding_module,
+        "_transpose_distributed_matrix",
+        lambda A, *args: (A, np.arange(len(A.data), dtype=np.int32)),
+    )
+
+    def fake_solve(A, rhs, x0=None, **kwargs):
+        x = A.data * rhs
+        if x0 is not None:
+            x = x + x0
+        return x, {
+            "iterations": jnp.asarray(2.0),
+            "residual": jnp.asarray(1e-6, dtype=rhs.dtype),
+            "status": jnp.asarray(0.0),
+            "residual_history": jnp.asarray([1.0, 0.1, 1e-6], dtype=rhs.dtype),
+        }
+
+    monkeypatch.setattr(sharding_module, "solve", fake_solve)
+    solver = jaxamg.make_sharded_solver(A_local, b, comm=comm, mesh=mesh)
+
+    with jax.set_mesh(mesh):
+        x, info = jax.jit(solver)(b)
+        grad_A_data, grad_b = jax.jit(
+            jax.grad(
+                lambda matrix_data, rhs: jnp.sum(
+                    solver(rhs, A_data=matrix_data)[0] ** 2
+                ),
+                argnums=(0, 1),
+            )
+        )(solver.A_data, b)
+        grad_b_warm, grad_x0 = jax.grad(
+            lambda rhs, x0: jnp.sum(solver(rhs, x0)[0] ** 2),
+            argnums=(0, 1),
+        )(b, b)
+
+    np.testing.assert_array_equal(np.asarray(x), values)
+    np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), values)
+    assert info["iterations"].shape == (1, 2)
+    assert info["residual_history"].shape == (1, 2, 3)
+    np.testing.assert_array_equal(np.asarray(grad_b), 2 * values)
+    np.testing.assert_array_equal(np.asarray(grad_b_warm), 4 * values)
+    np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(values))
+
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    np.testing.assert_array_equal(
+        np.asarray(grad_A_local.data), -2 * np.sum(values**2, axis=1)
+    )
+
+
 def test_sharded_solver_validates_matrix_partition(monkeypatch):
     mesh, b = _single_device_array(np.ones(4, dtype=np.float32))
     monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -107,8 +107,11 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     monkeypatch.setattr(sharding_module, "solve", fake_solve)
 
+    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm)
     # Omit mesh to exercise inference from b.sharding.
-    solver = jaxamg.make_sharded_solver(A_local, b, comm=comm)
+    solver = jaxamg.make_sharded_solver(matrix, b, comm=comm)
+    assert solver.matrix is matrix
+    assert solver.A_data is matrix.data
     x, info = solver(b)
     np.testing.assert_array_equal(np.asarray(x), np.asarray(b))
     np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), np.asarray(b))
@@ -137,8 +140,12 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
         )(b, b)
     np.testing.assert_array_equal(np.asarray(grad_b), 2 * np.asarray(b))
     grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_from_matrix = matrix.local_matrix(grad_A_data)
     np.testing.assert_array_equal(
         np.asarray(grad_A_local.data), -2 * np.asarray(b) ** 2
+    )
+    np.testing.assert_array_equal(
+        np.asarray(grad_A_from_matrix.data), np.asarray(grad_A_local.data)
     )
     np.testing.assert_array_equal(np.asarray(grad_b_warm), 4 * np.asarray(b))
     np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(np.asarray(b)))

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -194,7 +194,7 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     np.testing.assert_array_equal(np.asarray(info["iterations"]), [2])
     assert info["residual_history"].shape == (1, 3)
 
-    x_jit, _ = jax.jit(lambda matrix_data, rhs: solver(rhs, A_data=matrix_data))(
+    x_jit, _ = jax.jit(lambda matrix_data, rhs: solver(rhs, A=matrix_data))(
         matrix.data, b
     )
     np.testing.assert_array_equal(np.asarray(x_jit), np.asarray(b))
@@ -202,17 +202,17 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     # Multiple RHS use the same public batching path as the ordinary solver:
     # vmap a solver that accepts one vector at a time.
     batched_b = jnp.stack((b, 2 * b))
-    batched_x = jax.vmap(lambda rhs: solver(rhs, A_data=matrix.data)[0])(batched_b)
+    batched_x = jax.vmap(lambda rhs: solver(rhs, A=matrix.data)[0])(batched_b)
     np.testing.assert_array_equal(np.asarray(batched_x), np.asarray(batched_b))
 
-    with pytest.raises(ValueError, match="A_data must be passed explicitly"):
+    with pytest.raises(ValueError, match="A must be passed explicitly"):
         jax.jit(solver).lower(b)
 
     # A traced x0 with a concrete RHS must not embed the cached matrix values.
-    with pytest.raises(ValueError, match="A_data must be passed explicitly"):
+    with pytest.raises(ValueError, match="A must be passed explicitly"):
         jax.jit(lambda guess: solver(b, guess)).lower(b)
 
-    x_updated, _ = solver(b, A_data=2 * matrix.data)
+    x_updated, _ = solver(b, A=2 * matrix.data)
     np.testing.assert_array_equal(np.asarray(x_updated), 2 * np.asarray(b))
 
     x_warm, _ = solver(b, b)
@@ -220,14 +220,14 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     with jax.set_mesh(mesh):
         grad_b = jax.grad(
-            lambda data, rhs: jnp.sum(solver(rhs, A_data=data)[0] ** 2),
+            lambda data, rhs: jnp.sum(solver(rhs, A=data)[0] ** 2),
             argnums=1,
         )(matrix.data, b)
-        grad_A_data = jax.grad(lambda data: jnp.sum(solver(b, A_data=data)[0] ** 2))(
+        grad_A_data = jax.grad(lambda data: jnp.sum(solver(b, A=data)[0] ** 2))(
             matrix.data
         )
         grad_b_warm, grad_x0 = jax.grad(
-            lambda data, rhs, x0: jnp.sum(solver(rhs, x0, A_data=data)[0] ** 2),
+            lambda data, rhs, x0: jnp.sum(solver(rhs, x0, A=data)[0] ** 2),
             argnums=(1, 2),
         )(matrix.data, b, b)
     np.testing.assert_array_equal(np.asarray(grad_b), 2 * np.asarray(b))
@@ -239,6 +239,29 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(np.asarray(b)))
 
     assert len(transpose_calls) == 1
+
+    # A matrix with traced values through ``A=``: d/dscale = sum(dL/dA.data
+    # * data), with dL/dA.data = -2 b**2 as asserted above.
+    def scaled_matrix(scale):
+        return jsp.BCSR(
+            (scale * A_local.data, A_local.indices, A_local.indptr),
+            shape=A_local.shape,
+        )
+
+    def scaled_loss(scale):
+        return jnp.sum(solver(b, A=scaled_matrix(scale))[0] ** 2)
+
+    with jax.set_mesh(mesh):
+        grad_scale = jax.grad(scaled_loss)(1.0)
+        grad_scale_jit = jax.jit(jax.grad(scaled_loss))(1.0)
+        x_scaled, _ = solver(b, A=scaled_matrix(3.0))
+    expected = -2 * float(jnp.sum(b**2))
+    assert float(grad_scale) == pytest.approx(expected)
+    assert float(grad_scale_jit) == pytest.approx(expected)
+    np.testing.assert_array_equal(np.asarray(x_scaled), 3 * np.asarray(b))
+
+    with pytest.raises(ValueError, match="sparsity structure"):
+        solver(b, A=jsp.BCSR.fromdense(jnp.ones((4, 4), dtype=jnp.float32)))
 
     # Stats: written after a direct call, rejected under a transform, and a
     # solver created without save_stats warns about incomplete output.
@@ -254,7 +277,7 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     with pytest.raises(ValueError, match="direct solver call"):
         jax.jit(
-            lambda rhs: stats_solver(rhs, A_data=matrix.data, save_stats_file="s.txt")
+            lambda rhs: stats_solver(rhs, A=matrix.data, save_stats_file="s.txt")
         ).lower(b)
 
     with pytest.warns(UserWarning, match="save_stats=True"):

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -32,6 +32,16 @@ def _single_device_array(values):
     return mesh, jax.device_put(jnp.asarray(values), sharding)
 
 
+def _single_rank_transpose_plan(A):
+    nnz = len(A.data)
+    return sharding_module._TransposeValuePlan(
+        np.arange(nnz, dtype=np.int32),
+        np.arange(nnz, dtype=np.int32),
+        np.zeros((1, 1), dtype=np.int32),
+        np.full((1, 1), nnz, dtype=np.int32),
+    )
+
+
 def test_make_sharded_vector_constructs_default_mesh():
     comm = SimpleNamespace(
         Get_size=lambda: 1,
@@ -109,7 +119,7 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     def fake_transpose(A, *args):
         transpose_calls.append(A)
-        return A, np.arange(len(A.data), dtype=np.int32)
+        return A, _single_rank_transpose_plan(A)
 
     monkeypatch.setattr(
         sharding_module, "_transpose_distributed_matrix", fake_transpose
@@ -140,8 +150,13 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     np.testing.assert_array_equal(np.asarray(info["iterations"]), [2])
     assert info["residual_history"].shape == (1, 3)
 
-    x_jit, _ = jax.jit(solver)(b)
+    x_jit, _ = jax.jit(lambda matrix_data, rhs: solver(rhs, A_data=matrix_data))(
+        matrix.data, b
+    )
     np.testing.assert_array_equal(np.asarray(x_jit), np.asarray(b))
+
+    with pytest.raises(ValueError, match="A_data must be passed explicitly"):
+        jax.jit(solver).lower(b)
 
     x_updated, _ = solver(b, A_data=2 * matrix.data)
     np.testing.assert_array_equal(np.asarray(x_updated), 2 * np.asarray(b))
@@ -150,14 +165,17 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     np.testing.assert_array_equal(np.asarray(x_warm), 2 * np.asarray(b))
 
     with jax.set_mesh(mesh):
-        grad_b = jax.grad(lambda rhs: jnp.sum(solver(rhs)[0] ** 2))(b)
+        grad_b = jax.grad(
+            lambda data, rhs: jnp.sum(solver(rhs, A_data=data)[0] ** 2),
+            argnums=1,
+        )(matrix.data, b)
         grad_A_data = jax.grad(lambda data: jnp.sum(solver(b, A_data=data)[0] ** 2))(
             matrix.data
         )
         grad_b_warm, grad_x0 = jax.grad(
-            lambda rhs, x0: jnp.sum(solver(rhs, x0)[0] ** 2),
-            argnums=(0, 1),
-        )(b, b)
+            lambda data, rhs, x0: jnp.sum(solver(rhs, x0, A_data=data)[0] ** 2),
+            argnums=(1, 2),
+        )(matrix.data, b, b)
     np.testing.assert_array_equal(np.asarray(grad_b), 2 * np.asarray(b))
     grad_A_local = matrix.local_matrix(grad_A_data)
     np.testing.assert_array_equal(
@@ -202,7 +220,7 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
     monkeypatch.setattr(
         sharding_module,
         "_transpose_distributed_matrix",
-        lambda A, *args: (A, np.arange(len(A.data), dtype=np.int32)),
+        lambda A, *args: (A, _single_rank_transpose_plan(A)),
     )
 
     def fake_solve(A, rhs, x0=None, **kwargs):
@@ -221,7 +239,9 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
     solver = jaxamg.make_sharded_solver(matrix, b)
 
     with jax.set_mesh(mesh):
-        x, info = jax.jit(solver)(b)
+        x, info = jax.jit(lambda matrix_data, rhs: solver(rhs, A_data=matrix_data))(
+            matrix.data, b
+        )
         grad_A_data, grad_b = jax.jit(
             jax.grad(
                 lambda matrix_data, rhs: jnp.sum(
@@ -231,9 +251,9 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
             )
         )(matrix.data, b)
         grad_b_warm, grad_x0 = jax.grad(
-            lambda rhs, x0: jnp.sum(solver(rhs, x0)[0] ** 2),
-            argnums=(0, 1),
-        )(b, b)
+            lambda data, rhs, x0: jnp.sum(solver(rhs, x0, A_data=data)[0] ** 2),
+            argnums=(1, 2),
+        )(matrix.data, b, b)
 
     np.testing.assert_array_equal(np.asarray(x), values)
     np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), values)

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -351,3 +351,13 @@ def test_shard_autotuning_warning(monkeypatch):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         sharding_module._check_shard_autotuning()
+
+
+def test_make_sharded_vector_normalizes_dtype_and_rejects_empty_ranks():
+    comm = SimpleNamespace(Get_size=lambda: 1, allgather=lambda value: [value])
+
+    b = jaxamg.make_sharded_vector(np.arange(4), comm=comm)
+    assert b.dtype == jnp.float32
+
+    with pytest.raises(ValueError, match="at least one row"):
+        jaxamg.make_sharded_vector(np.zeros(0, dtype=np.float32), comm=comm)

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -23,7 +23,11 @@ def _single_device_array(values):
 def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     mesh, b = _single_device_array(np.arange(4, dtype=np.float32))
     A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
-    comm = SimpleNamespace(Get_size=lambda: 1, allgather=lambda value: [value])
+    comm = SimpleNamespace(
+        Get_size=lambda: 1,
+        Get_rank=lambda: 0,
+        allgather=lambda value: [value],
+    )
     halo_plan = SimpleNamespace(
         n_ghost=0,
         col_to_combined=np.arange(4, dtype=np.int32),
@@ -80,6 +84,9 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     solver = jaxamg.make_sharded_solver(A_local, b, comm=comm)
     x, info = solver(b)
     np.testing.assert_array_equal(np.asarray(x), np.asarray(b))
+    np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), np.asarray(b))
+    assert solver.global_size == 4
+    assert solver.local_size == 4
     np.testing.assert_array_equal(np.asarray(info["iterations"]), [2])
     assert info["residual_history"].shape == (1, 3)
 
@@ -117,11 +124,16 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 def test_sharded_solver_validates_matrix_partition(monkeypatch):
     mesh, b = _single_device_array(np.ones(4, dtype=np.float32))
     monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
+    comm = SimpleNamespace(
+        Get_size=lambda: 1,
+        Get_rank=lambda: 0,
+        allgather=lambda value: [value],
+    )
 
-    with pytest.raises(ValueError, match="expected shape"):
+    with pytest.raises(ValueError, match="row counts"):
         jaxamg.make_sharded_solver(
             SimpleNamespace(shape=(3, 4)),
             b,
-            comm=object(),
+            comm=comm,
             mesh=mesh,
         )

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -237,6 +237,27 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     assert len(transpose_calls) == 1
 
+    # Stats: written after a direct call, rejected under a transform, and a
+    # solver created without save_stats warns about incomplete output.
+    stats_calls = []
+    monkeypatch.setattr(
+        sharding_module,
+        "_capture_and_save_stats",
+        lambda path, comm=None: stats_calls.append(path),
+    )
+    stats_solver = jaxamg.make_sharded_solver(matrix, b, save_stats=True)
+    stats_solver(b, save_stats_file="stats.txt")
+    assert stats_calls == ["stats.txt"]
+
+    with pytest.raises(ValueError, match="direct solver call"):
+        jax.jit(
+            lambda rhs: stats_solver(rhs, A_data=matrix.data, save_stats_file="s.txt")
+        ).lower(b)
+
+    with pytest.warns(UserWarning, match="save_stats=True"):
+        solver(b, save_stats_file="warned.txt")
+    assert stats_calls == ["stats.txt", "warned.txt"]
+
 
 def test_sharded_matrix_validates_partition(monkeypatch):
     mesh, b = _single_device_array(np.ones(4, dtype=np.float32))

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -34,11 +34,20 @@ def _single_device_array(values):
 
 def _single_rank_transpose_plan(A):
     nnz = len(A.data)
-    return sharding_module._TransposeValuePlan(
+    return sharding_module._TransposePlan(
         np.arange(nnz, dtype=np.int32),
         np.arange(nnz, dtype=np.int32),
         np.zeros((1, 1), dtype=np.int32),
         np.full((1, 1), nnz, dtype=np.int32),
+        np.asarray(A.indices),
+        np.asarray(A.indptr),
+        nnz,
+    )
+
+
+def _single_rank_transpose_structure(A):
+    return sharding_module._CSRStructure(
+        A.indices, A.indptr, tuple(A.shape), len(A.data)
     )
 
 
@@ -82,13 +91,20 @@ def test_sharded_inputs_preserve_device_arrays(monkeypatch):
 def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     mesh, b = _single_device_array(np.arange(4, dtype=np.float32))
     A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
+    allgather_calls = []
+
+    def allgather(value):
+        allgather_calls.append(value)
+        return [value]
+
     comm = SimpleNamespace(
         Get_size=lambda: 1,
         Get_rank=lambda: 0,
-        allgather=lambda value: [value],
+        allgather=allgather,
     )
     halo_plan = SimpleNamespace(
         n_ghost=0,
+        max_n_ghost=0,
         col_to_combined=np.arange(4, dtype=np.int32),
         send_ids_2d=np.zeros((1, 1), dtype=np.int32),
         recv_ghost_slot_2d=np.zeros((1, 1), dtype=np.int32),
@@ -97,12 +113,18 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
     monkeypatch.setattr(
         sharding_module,
-        "cache_mpi_metadata",
-        lambda *args, **kwargs: {
+        "build_halo_plan",
+        lambda *args, **kwargs: halo_plan,
+    )
+    monkeypatch.setattr(
+        sharding_module,
+        "_build_mpi_cache",
+        lambda config, comm, nglobal, row_counts, max_nnz, nnz_out, plan, **kwargs: {
             "lrank": 99,
-            "recvcounts_tuple": (4,),
-            "max_nnz": 4,
-            "halo_plan": halo_plan,
+            "recvcounts_tuple": row_counts,
+            "max_nnz": max_nnz,
+            "nnz_out": nnz_out,
+            "halo_plan": plan,
         },
     )
     monkeypatch.setattr(
@@ -110,16 +132,20 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
         "with_cache",
         lambda A, **kwargs: A,
     )
-    monkeypatch.setattr(
-        sharding_module,
-        "to_bcsr_matrix",
-        lambda A, **kwargs: A,
-    )
+    normalization_calls = []
+
+    def fake_to_bcsr(A, **kwargs):
+        normalization_calls.append(A)
+        return A
+
+    monkeypatch.setattr(sharding_module, "to_bcsr_matrix", fake_to_bcsr)
     transpose_calls = []
 
-    def fake_transpose(A, *args):
-        transpose_calls.append(A)
-        return A, _single_rank_transpose_plan(A)
+    def fake_transpose(*args):
+        transpose_calls.append(A_local)
+        return _single_rank_transpose_structure(A_local), _single_rank_transpose_plan(
+            A_local
+        )
 
     monkeypatch.setattr(
         sharding_module, "_transpose_distributed_matrix", fake_transpose
@@ -142,6 +168,8 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm)
     # Omit mesh to exercise inference from b.sharding.
     solver = jaxamg.make_sharded_solver(matrix, b)
+    assert len(allgather_calls) == 2
+    assert len(normalization_calls) == 1
     x, info = solver(b)
     np.testing.assert_array_equal(np.asarray(x), np.asarray(b))
     np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), np.asarray(b))
@@ -199,6 +227,7 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
     A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
     halo_plan = SimpleNamespace(
         n_ghost=0,
+        max_n_ghost=0,
         col_to_combined=np.arange(4, dtype=np.int32),
         send_ids_2d=np.zeros((1, 1), dtype=np.int32),
         recv_ghost_slot_2d=np.zeros((1, 1), dtype=np.int32),
@@ -207,12 +236,18 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
     monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
     monkeypatch.setattr(
         sharding_module,
-        "cache_mpi_metadata",
-        lambda *args, **kwargs: {
+        "build_halo_plan",
+        lambda *args, **kwargs: halo_plan,
+    )
+    monkeypatch.setattr(
+        sharding_module,
+        "_build_mpi_cache",
+        lambda config, comm, nglobal, row_counts, max_nnz, nnz_out, plan, **kwargs: {
             "lrank": 0,
-            "recvcounts_tuple": (4,),
-            "max_nnz": 4,
-            "halo_plan": halo_plan,
+            "recvcounts_tuple": row_counts,
+            "max_nnz": max_nnz,
+            "nnz_out": nnz_out,
+            "halo_plan": plan,
         },
     )
     monkeypatch.setattr(sharding_module, "with_cache", lambda A, **kwargs: A)
@@ -220,7 +255,10 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
     monkeypatch.setattr(
         sharding_module,
         "_transpose_distributed_matrix",
-        lambda A, *args: (A, _single_rank_transpose_plan(A)),
+        lambda *args: (
+            _single_rank_transpose_structure(A_local),
+            _single_rank_transpose_plan(A_local),
+        ),
     )
 
     def fake_solve(A, rhs, x0=None, **kwargs):

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,4 +1,5 @@
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import jax
 import jax.experimental.sparse as jsp
@@ -12,6 +13,17 @@ import jaxamg.sharding as sharding_module
 pytestmark = pytest.mark.skipif(
     not hasattr(jax, "shard_map"), reason="jax.shard_map is unavailable"
 )
+
+
+def test_sharding_comm_defaults_to_world(monkeypatch):
+    default_comm = object()
+    mpi4py = ModuleType("mpi4py")
+    mpi4py.MPI = SimpleNamespace(COMM_WORLD=default_comm)
+    monkeypatch.setitem(sys.modules, "mpi4py", mpi4py)
+
+    explicit_comm = object()
+    assert sharding_module._resolve_comm(None) is default_comm
+    assert sharding_module._resolve_comm(explicit_comm) is explicit_comm
 
 
 def _single_device_array(values):

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -141,6 +141,9 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
             "max_nnz": max_nnz,
             "nnz_out": nnz_out,
             "halo_plan": plan,
+            "row_indices": kwargs.get("row_indices"),
+            # max_iters matching fake_solve's three residual-history entries.
+            "config_str": '{"solver": {"max_iters": 2}}',
         },
     )
     monkeypatch.setattr(

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -56,7 +56,10 @@ def test_make_sharded_vector_constructs_default_mesh():
     b = jaxamg.make_sharded_vector(values, comm=comm, global_size=4)
 
     assert isinstance(b.sharding, jax.NamedSharding)
-    assert b.sharding.mesh.size == jax.device_count()
+    # The default mesh holds one device per MPI rank, so extra local devices
+    # (e.g. on a multi-GPU workstation) do not invalidate a small communicator.
+    assert b.sharding.mesh.size == 1
+    assert b.sharding.mesh.devices.flat[0] == jax.devices()[0]
     assert b.sharding.spec == jax.P("rank")
     np.testing.assert_array_equal(np.asarray(b), values)
 
@@ -201,6 +204,10 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     with pytest.raises(ValueError, match="A_data must be passed explicitly"):
         jax.jit(solver).lower(b)
+
+    # A traced x0 with a concrete RHS must not embed the cached matrix values.
+    with pytest.raises(ValueError, match="A_data must be passed explicitly"):
+        jax.jit(lambda guess: solver(b, guess)).lower(b)
 
     x_updated, _ = solver(b, A_data=2 * matrix.data)
     np.testing.assert_array_equal(np.asarray(x_updated), 2 * np.asarray(b))

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -47,6 +47,28 @@ def test_make_sharded_vector_constructs_default_mesh():
     np.testing.assert_array_equal(np.asarray(b), values)
 
 
+def test_sharded_inputs_preserve_device_arrays(monkeypatch):
+    mesh, local_values = _single_device_array(np.arange(4, dtype=np.float32))
+    A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))
+    comm = SimpleNamespace(
+        Get_size=lambda: 1,
+        Get_rank=lambda: 0,
+        allgather=lambda value: [value],
+    )
+    monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
+
+    with jax.transfer_guard_device_to_host("disallow"):
+        b = jaxamg.make_sharded_vector(
+            local_values, comm=comm, mesh=mesh, global_size=4
+        )
+        matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
+
+    assert b.addressable_shards[0].device == next(iter(local_values.devices()))
+    assert matrix.data.addressable_shards[0].device == next(
+        iter(A_local.data.devices())
+    )
+
+
 def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     mesh, b = _single_device_array(np.arange(4, dtype=np.float32))
     A_local = jsp.BCSR.fromdense(jnp.eye(4, dtype=jnp.float32))

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -264,6 +264,15 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     with pytest.raises(ValueError, match="sparsity structure"):
         solver(b, A=jsp.BCSR.fromdense(jnp.ones((4, 4), dtype=jnp.float32)))
+    # Same nnz, different column indices.
+    with pytest.raises(ValueError, match="sparsity structure"):
+        solver(b, A=jsp.BCSR.fromdense(jnp.fliplr(jnp.eye(4, dtype=jnp.float32))))
+    with pytest.raises(ValueError, match="concrete"):
+        jax.jit(
+            lambda idx, rhs: solver(
+                rhs, A=jsp.BCSR((A_local.data, idx, A_local.indptr), shape=(4, 4))
+            )[0]
+        )(A_local.indices, b)
 
     # Stats: written after a direct call, rejected under a transform, and a
     # solver created without save_stats warns about incomplete output.

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -131,9 +131,7 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
 
     matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm)
     # Omit mesh to exercise inference from b.sharding.
-    solver = jaxamg.make_sharded_solver(matrix, b, comm=comm)
-    assert solver.matrix is matrix
-    assert solver.A_data is matrix.data
+    solver = jaxamg.make_sharded_solver(matrix, b)
     x, info = solver(b)
     np.testing.assert_array_equal(np.asarray(x), np.asarray(b))
     np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), np.asarray(b))
@@ -145,7 +143,7 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     x_jit, _ = jax.jit(solver)(b)
     np.testing.assert_array_equal(np.asarray(x_jit), np.asarray(b))
 
-    x_updated, _ = solver(b, A_data=2 * solver.A_data)
+    x_updated, _ = solver(b, A_data=2 * matrix.data)
     np.testing.assert_array_equal(np.asarray(x_updated), 2 * np.asarray(b))
 
     x_warm, _ = solver(b, b)
@@ -154,27 +152,21 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     with jax.set_mesh(mesh):
         grad_b = jax.grad(lambda rhs: jnp.sum(solver(rhs)[0] ** 2))(b)
         grad_A_data = jax.grad(lambda data: jnp.sum(solver(b, A_data=data)[0] ** 2))(
-            solver.A_data
+            matrix.data
         )
         grad_b_warm, grad_x0 = jax.grad(
             lambda rhs, x0: jnp.sum(solver(rhs, x0)[0] ** 2),
             argnums=(0, 1),
         )(b, b)
     np.testing.assert_array_equal(np.asarray(grad_b), 2 * np.asarray(b))
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
-    grad_A_from_matrix = matrix.local_matrix(grad_A_data)
+    grad_A_local = matrix.local_matrix(grad_A_data)
     np.testing.assert_array_equal(
         np.asarray(grad_A_local.data), -2 * np.asarray(b) ** 2
-    )
-    np.testing.assert_array_equal(
-        np.asarray(grad_A_from_matrix.data), np.asarray(grad_A_local.data)
     )
     np.testing.assert_array_equal(np.asarray(grad_b_warm), 4 * np.asarray(b))
     np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(np.asarray(b)))
 
-    x_once, _ = jaxamg.solve_sharded(A_local, b, comm=comm, mesh=mesh)
-    np.testing.assert_array_equal(np.asarray(x_once), np.asarray(b))
-    assert len(transpose_calls) == 2
+    assert len(transpose_calls) == 1
 
 
 def test_sharded_solver_supports_batched_rhs(monkeypatch):
@@ -225,7 +217,8 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
         }
 
     monkeypatch.setattr(sharding_module, "solve", fake_solve)
-    solver = jaxamg.make_sharded_solver(A_local, b, comm=comm, mesh=mesh)
+    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
+    solver = jaxamg.make_sharded_solver(matrix, b)
 
     with jax.set_mesh(mesh):
         x, info = jax.jit(solver)(b)
@@ -236,7 +229,7 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
                 ),
                 argnums=(0, 1),
             )
-        )(solver.A_data, b)
+        )(matrix.data, b)
         grad_b_warm, grad_x0 = jax.grad(
             lambda rhs, x0: jnp.sum(solver(rhs, x0)[0] ** 2),
             argnums=(0, 1),
@@ -250,13 +243,13 @@ def test_sharded_solver_supports_batched_rhs(monkeypatch):
     np.testing.assert_array_equal(np.asarray(grad_b_warm), 4 * values)
     np.testing.assert_array_equal(np.asarray(grad_x0), np.zeros_like(values))
 
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_local = matrix.local_matrix(grad_A_data)
     np.testing.assert_array_equal(
         np.asarray(grad_A_local.data), -2 * np.sum(values**2, axis=1)
     )
 
 
-def test_sharded_solver_validates_matrix_partition(monkeypatch):
+def test_sharded_matrix_validates_partition(monkeypatch):
     mesh, b = _single_device_array(np.ones(4, dtype=np.float32))
     monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
     comm = SimpleNamespace(
@@ -266,9 +259,16 @@ def test_sharded_solver_validates_matrix_partition(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="row counts"):
-        jaxamg.make_sharded_solver(
+        jaxamg.make_sharded_matrix(
             SimpleNamespace(shape=(3, 4)),
             b,
             comm=comm,
             mesh=mesh,
         )
+
+
+def test_sharded_solver_requires_sharded_matrix():
+    _, b = _single_device_array(np.ones(4, dtype=np.float32))
+
+    with pytest.raises(TypeError, match="make_sharded_matrix"):
+        jaxamg.make_sharded_solver(jnp.eye(4), b)  # type: ignore[arg-type]

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -39,8 +39,6 @@ def _single_rank_transpose_plan(A):
         np.arange(nnz, dtype=np.int32),
         np.zeros((1, 1), dtype=np.int32),
         np.full((1, 1), nnz, dtype=np.int32),
-        np.asarray(A.indices),
-        np.asarray(A.indptr),
         nnz,
     )
 
@@ -109,12 +107,17 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
         send_ids_2d=np.zeros((1, 1), dtype=np.int32),
         recv_ghost_slot_2d=np.zeros((1, 1), dtype=np.int32),
     )
+    halo_plan_calls = []
+
+    def fake_build_halo_plan(*args, **kwargs):
+        halo_plan_calls.append(args)
+        return halo_plan
 
     monkeypatch.setattr(sharding_module, "_validate_runtime", lambda *args: None)
     monkeypatch.setattr(
         sharding_module,
         "build_halo_plan",
-        lambda *args, **kwargs: halo_plan,
+        fake_build_halo_plan,
     )
     monkeypatch.setattr(
         sharding_module,
@@ -170,6 +173,7 @@ def test_make_sharded_solver_preserves_global_array_contract(monkeypatch):
     solver = jaxamg.make_sharded_solver(matrix, b)
     assert len(allgather_calls) == 2
     assert len(normalization_calls) == 1
+    assert len(halo_plan_calls) == 1
     x, info = solver(b)
     np.testing.assert_array_equal(np.asarray(x), np.asarray(b))
     np.testing.assert_array_equal(np.asarray(solver.local_vector(x)), np.asarray(b))

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -14,7 +14,8 @@ import jaxamg.sharding as sharding_module
 from jaxamg.mpi_utils import TransposePlan
 
 pytestmark = pytest.mark.skipif(
-    not hasattr(jax, "shard_map"), reason="jax.shard_map is unavailable"
+    not sharding_module.has_supported_jax(),
+    reason="the sharding interface requires JAX 0.9 or newer",
 )
 
 

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -1,0 +1,226 @@
+"""Multi-GPU integration tests for the additive JAX sharding interface.
+
+Run this module separately from the ordinary MPI suite because JAX distributed
+must see every participating GPU in every process::
+
+    CUDA_VISIBLE_DEVICES=0,1 \
+      mpirun -n 2 python -m pytest --only-mpi tests/test_sharding_mpi.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import jax
+import jax.experimental.sparse as jsp
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+_SHARDING_TEST = any("test_sharding_mpi.py" in arg for arg in sys.argv[1:])
+if _SHARDING_TEST:
+    from mpi4py import MPI
+
+    _SHARDING_TEST = MPI.COMM_WORLD.Get_size() > 1
+    if _SHARDING_TEST:
+        # This must precede calls that can initialize the XLA backend.
+        jax.distributed.initialize(cluster_detection_method="mpi4py")
+
+import jaxamg  # noqa: E402
+from jaxamg.matrices import tridiagonal_matrix_distributed  # noqa: E402
+
+pytestmark = [
+    pytest.mark.mpi(min_size=2),
+    pytest.mark.sharding,
+    pytest.mark.skipif(
+        not _SHARDING_TEST,
+        reason="run this module separately under mpirun with at least two ranks",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def sharding_context():
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    nranks = comm.Get_size()
+    mesh = jax.make_mesh((nranks,), ("rank",))
+
+    yield comm, rank, nranks, mesh
+
+    comm.Barrier()
+    jaxamg.finalize()
+    comm.Barrier()
+    jax.config.update("jax_logging_level", "ERROR")
+    jax.distributed.shutdown()
+
+
+def _global_vector(
+    local_values: np.ndarray, global_size: int, mesh: jax.sharding.Mesh
+) -> jax.Array:
+    sharding = jax.NamedSharding(mesh, jax.P("rank"))
+    return jax.make_array_from_process_local_data(
+        sharding, local_values, global_shape=(global_size,)
+    )
+
+
+def _gather_global(array: jax.Array, comm: MPI.Comm) -> np.ndarray:
+    local = np.asarray(array.addressable_shards[0].data)
+    return np.concatenate(comm.allgather(local))
+
+
+def _local_status(info: dict[str, jax.Array]) -> int:
+    status = np.asarray(info["status"].addressable_shards[0].data)
+    return int(status.item())
+
+
+def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
+    """Exercise dynamic values and unequal local nnz across A and A transpose."""
+    comm, rank, nranks, mesh = sharding_context
+    n_local = 4
+    n_global = n_local * nranks
+    row_start = rank * n_local
+
+    # Structurally nonsymmetric: diagonal plus a dense first column. Rank zero
+    # has one fewer entry, exercising packed-value padding as well.
+    data: list[float] = []
+    indices: list[int] = []
+    indptr = [0]
+    for global_row in range(row_start, row_start + n_local):
+        if global_row:
+            data.append(-0.25)
+            indices.append(0)
+        data.append(4.0)
+        indices.append(global_row)
+        indptr.append(len(data))
+
+    A_local = jsp.BCSR(
+        (
+            jnp.asarray(data, dtype=jnp.float32),
+            jnp.asarray(indices, dtype=jnp.int32),
+            jnp.asarray(indptr, dtype=jnp.int32),
+        ),
+        shape=(n_local, n_global),
+    )
+    b_local = np.arange(row_start + 1, row_start + n_local + 1, dtype=np.float32)
+    b = _global_vector(b_local, n_global, mesh)
+    solver = jaxamg.make_sharded_solver(
+        A_local,
+        b,
+        comm=comm,
+        mesh=mesh,
+        config={
+            "solver": "GMRES",
+            "preconditioner": {"solver": "JACOBI_L1"},
+            "communicator": "MPI_DIRECT",
+            "max_iters": 100,
+            "tolerance": 1e-8,
+        },
+    )
+
+    # Change every real matrix value after setup. Padding is also changed but
+    # must remain disconnected from both the solve and its gradient.
+    A_data = solver.A_data + jnp.asarray(0.1, dtype=solver.A_data.dtype)
+
+    def loss(matrix_data, rhs):
+        x, _ = solver(rhs, A_data=matrix_data)
+        return jnp.sum(x**2)
+
+    x, info = solver(b, A_data=A_data)
+    with jax.set_mesh(mesh):
+        grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(A_data, b)
+    x.block_until_ready()
+    grad_A_data.block_until_ready()
+    grad_b.block_until_ready()
+
+    x_global = _gather_global(x, comm)
+    grad_b_global = _gather_global(grad_b, comm)
+    A_global = 4.1 * np.eye(n_global, dtype=np.float64)
+    A_global[1:, 0] = -0.15
+    b_global = np.arange(1, n_global + 1, dtype=np.float64)
+    x_ref = np.linalg.solve(A_global, b_global)
+    adjoint_ref = np.linalg.solve(A_global.T, 2.0 * x_ref)
+
+    np.testing.assert_allclose(x_global, x_ref, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
+
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    local_rows = np.repeat(
+        np.arange(row_start, row_start + n_local), np.diff(np.asarray(indptr))
+    )
+    grad_A_ref = -adjoint_ref[local_rows] * x_ref[np.asarray(indices, dtype=np.int64)]
+    np.testing.assert_allclose(
+        np.asarray(grad_A_local.data), grad_A_ref, rtol=1e-5, atol=1e-6
+    )
+
+    packed_gradient = np.asarray(grad_A_data.addressable_shards[0].data)
+    np.testing.assert_array_equal(packed_gradient[len(data) :], 0)
+    assert _local_status(info) == 0
+
+
+def test_sharded_symmetric_warm_start_gradients(sharding_context):
+    """Cover the symmetric optimization and zero x0 cotangent."""
+    comm, rank, nranks, mesh = sharding_context
+    n_local = 4
+    n_global = n_local * nranks
+    A_local, row_start, row_end = tridiagonal_matrix_distributed(
+        n_global, rank, nranks, diagonal_value=4.0, dtype=jnp.float32
+    )
+    b_local = np.linspace(row_start + 1.0, row_end, n_local, dtype=np.float32)
+    x0_local = np.full(n_local, 0.25, dtype=np.float32)
+    b = _global_vector(b_local, n_global, mesh)
+    x0 = _global_vector(x0_local, n_global, mesh)
+    solver = jaxamg.make_sharded_solver(
+        A_local,
+        b,
+        comm=comm,
+        mesh=mesh,
+        is_symmetric=True,
+        config={
+            "solver": "CG",
+            "preconditioner": {"solver": "JACOBI_L1"},
+            "communicator": "MPI_DIRECT",
+            "max_iters": 100,
+            "tolerance": 1e-8,
+        },
+    )
+
+    def loss(matrix_data, rhs, guess):
+        x, _ = solver(rhs, guess, A_data=matrix_data)
+        return jnp.sum(x**2)
+
+    x, info = solver(b, x0, A_data=solver.A_data)
+    with jax.set_mesh(mesh):
+        grad_A_data, grad_b, grad_x0 = jax.grad(loss, argnums=(0, 1, 2))(
+            solver.A_data, b, x0
+        )
+    x.block_until_ready()
+    grad_A_data.block_until_ready()
+    grad_b.block_until_ready()
+    grad_x0.block_until_ready()
+
+    x_global = _gather_global(x, comm)
+    grad_b_global = _gather_global(grad_b, comm)
+    grad_x0_global = _gather_global(grad_x0, comm)
+    A_global = 4.0 * np.eye(n_global, dtype=np.float64)
+    A_global += np.diag(-np.ones(n_global - 1), 1)
+    A_global += np.diag(-np.ones(n_global - 1), -1)
+    b_global = np.arange(1, n_global + 1, dtype=np.float64)
+    x_ref = np.linalg.solve(A_global, b_global)
+    adjoint_ref = np.linalg.solve(A_global.T, 2.0 * x_ref)
+
+    np.testing.assert_allclose(x_global, x_ref, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(grad_x0_global, 0)
+
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    row_indices = np.repeat(
+        np.arange(row_start, row_end), np.diff(np.asarray(A_local.indptr))
+    )
+    grad_A_ref = (
+        -adjoint_ref[row_indices] * x_ref[np.asarray(A_local.indices, dtype=np.int64)]
+    )
+    np.testing.assert_allclose(
+        np.asarray(grad_A_local.data), grad_A_ref, rtol=1e-5, atol=1e-6
+    )
+    assert _local_status(info) == 0

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -33,11 +33,15 @@ from jaxamg.matrices import (  # noqa: E402
     tridiagonal_matrix_distributed,
 )
 from jaxamg.mpi_utils import get_partition_info, partition_operator  # noqa: E402
-from jaxamg.sharding import ShardedSolve  # noqa: E402
+from jaxamg.sharding import ShardedSolve, has_supported_jax  # noqa: E402
 
 pytestmark = [
     pytest.mark.mpi(min_size=2),
     pytest.mark.sharding,
+    pytest.mark.skipif(
+        not has_supported_jax(),
+        reason="the sharding interface requires JAX 0.9 or newer",
+    ),
     pytest.mark.skipif(
         not _SHARDING_TEST,
         reason="run this module separately under mpirun with at least two ranks",

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -28,6 +28,7 @@ if _SHARDING_TEST:
 
 import jaxamg  # noqa: E402
 from jaxamg.matrices import tridiagonal_matrix_distributed  # noqa: E402
+from jaxamg.sharding import ShardedSolve  # noqa: E402
 
 pytestmark = [
     pytest.mark.mpi(min_size=2),
@@ -66,6 +67,13 @@ def _global_vector(
 
 def _gather_global(array: jax.Array, comm: MPI.Comm) -> np.ndarray:
     local = np.asarray(array.addressable_shards[0].data)
+    return np.concatenate(comm.allgather(local))
+
+
+def _gather_unpadded(
+    array: jax.Array, solver: ShardedSolve, comm: MPI.Comm
+) -> np.ndarray:
+    local = np.asarray(solver.local_vector(array))
     return np.concatenate(comm.allgather(local))
 
 
@@ -252,4 +260,84 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
     np.testing.assert_allclose(
         np.asarray(grad_A_local.data), grad_A_ref, rtol=1e-5, atol=1e-6
     )
+    assert _local_status(info) == 0
+
+
+@pytest.mark.mpi(min_size=3)
+def test_sharded_uneven_row_partitions(sharding_context):
+    """Exercise padded vectors for a global size not divisible by rank count."""
+    comm, rank, nranks, mesh = sharding_context
+    n_global = 4 * nranks + 1
+    A_local, row_start, row_end = tridiagonal_matrix_distributed(
+        n_global, rank, nranks, diagonal_value=4.0, dtype=jnp.float32
+    )
+    n_local = row_end - row_start
+    b_local = np.arange(row_start + 1, row_end + 1, dtype=np.float32)
+    x0_local = np.full(n_local, 0.25, dtype=np.float32)
+    b = jaxamg.make_sharded_vector(b_local, comm=comm, mesh=mesh, global_size=n_global)
+    x0 = jaxamg.make_sharded_vector(
+        x0_local, comm=comm, mesh=mesh, global_size=n_global
+    )
+    solver = jaxamg.make_sharded_solver(
+        A_local,
+        b,
+        comm=comm,
+        mesh=mesh,
+        config={
+            "solver": "GMRES",
+            "preconditioner": {"solver": "JACOBI_L1"},
+            "communicator": "MPI_DIRECT",
+            "max_iters": 100,
+            "tolerance": 1e-8,
+        },
+    )
+    A_data = solver.A_data + jnp.asarray(0.05, solver.A_data.dtype)
+
+    def loss(matrix_data, rhs, guess):
+        x, _ = solver(rhs, guess, A_data=matrix_data)
+        return jnp.sum(x**2)
+
+    with jax.set_mesh(mesh):
+        compiled_solve = jax.jit(
+            lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
+        )
+        compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
+        x, info = compiled_solve(A_data, b, x0)
+        grad_A_data, grad_b, grad_x0 = compiled_grad(A_data, b, x0)
+    x.block_until_ready()
+    grad_A_data.block_until_ready()
+    grad_b.block_until_ready()
+    grad_x0.block_until_ready()
+
+    x_global = _gather_unpadded(x, solver, comm)
+    grad_b_global = _gather_unpadded(grad_b, solver, comm)
+    grad_x0_global = _gather_unpadded(grad_x0, solver, comm)
+    A_global = 4.05 * np.eye(n_global, dtype=np.float64)
+    A_global += np.diag(-0.95 * np.ones(n_global - 1), 1)
+    A_global += np.diag(-0.95 * np.ones(n_global - 1), -1)
+    b_global = np.arange(1, n_global + 1, dtype=np.float64)
+    x_ref = np.linalg.solve(A_global, b_global)
+    adjoint_ref = np.linalg.solve(A_global.T, 2.0 * x_ref)
+
+    np.testing.assert_allclose(x_global, x_ref, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
+    np.testing.assert_array_equal(grad_x0_global, 0)
+
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    row_indices = np.repeat(
+        np.arange(row_start, row_end), np.diff(np.asarray(A_local.indptr))
+    )
+    grad_A_ref = (
+        -adjoint_ref[row_indices] * x_ref[np.asarray(A_local.indices, dtype=np.int64)]
+    )
+    np.testing.assert_allclose(
+        np.asarray(grad_A_local.data), grad_A_ref, rtol=1e-5, atol=1e-6
+    )
+
+    x_physical = np.asarray(x.addressable_shards[0].data)
+    grad_b_physical = np.asarray(grad_b.addressable_shards[0].data)
+    np.testing.assert_array_equal(x_physical[n_local:], 0)
+    np.testing.assert_array_equal(grad_b_physical[n_local:], 0)
+    assert solver.global_size == n_global
+    assert solver.local_size == n_local
     assert _local_status(info) == 0

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -154,17 +154,20 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
     with jax.transfer_guard_device_to_host("disallow"):
         b = jaxamg.make_sharded_vector(b_local_device, mesh=mesh, global_size=n_global)
         matrix = jaxamg.make_sharded_matrix(A_local, b)
-    solver = jaxamg.make_sharded_solver(
-        matrix,
-        b,
-        config={
-            "solver": "GMRES",
-            "preconditioner": {"solver": "JACOBI_L1"},
-            "communicator": "MPI_DIRECT",
-            "max_iters": 100,
-            "tolerance": 1e-8,
-        },
-    )
+    # Rank-local transpose and halo constants must remain local even when the
+    # surrounding application keeps an explicit global mesh active.
+    with jax.set_mesh(mesh):
+        solver = jaxamg.make_sharded_solver(
+            matrix,
+            b,
+            config={
+                "solver": "GMRES",
+                "preconditioner": {"solver": "JACOBI_L1"},
+                "communicator": "MPI_DIRECT",
+                "max_iters": 100,
+                "tolerance": 1e-8,
+            },
+        )
 
     # Change every real matrix value after setup. Padding is also changed but
     # must remain disconnected from both the solve and its gradient.
@@ -174,21 +177,18 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
         x, _ = solver(rhs, A_data=matrix_data)
         return jnp.sum(x**2)
 
-    def cached_loss(rhs):
-        x, _ = solver(rhs)
-        return jnp.sum(x**2)
-
     with jax.set_mesh(mesh):
         compiled_solve = jax.jit(
             lambda matrix_data, rhs: solver(rhs, A_data=matrix_data)
         )
-        compiled_cached_solve = jax.jit(solver)
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1)))
-        compiled_cached_grad = jax.jit(jax.grad(cached_loss))
+        compiled_cached_grad = jax.jit(jax.grad(loss, argnums=1))
         x, info = compiled_solve(A_data, b)
-        x_cached, _ = compiled_cached_solve(b)
         grad_A_data, grad_b = compiled_grad(A_data, b)
-        grad_b_cached = compiled_cached_grad(b)
+        grad_b_cached = compiled_cached_grad(matrix.data, b)
+    # The cached-value convenience remains efficient for a direct call; only
+    # enclosing JAX transforms require an explicit matrix-data operand.
+    x_cached, _ = solver(b)
     x.block_until_ready()
     x_cached.block_until_ready()
     grad_A_data.block_until_ready()

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -27,8 +27,12 @@ if _SHARDING_TEST:
         jax.distributed.initialize(cluster_detection_method="mpi4py")
 
 import jaxamg  # noqa: E402
-from jaxamg.matrices import tridiagonal_matrix_distributed  # noqa: E402
-from jaxamg.mpi_utils import get_partition_info  # noqa: E402
+from jaxamg.matrices import (  # noqa: E402
+    poisson_operator,
+    rhs_ones,
+    tridiagonal_matrix_distributed,
+)
+from jaxamg.mpi_utils import get_partition_info, partition_operator  # noqa: E402
 from jaxamg.sharding import ShardedSolve  # noqa: E402
 
 pytestmark = [
@@ -174,13 +178,11 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
     A_data = matrix.data + jnp.asarray(0.1, dtype=matrix.data.dtype)
 
     def loss(matrix_data, rhs):
-        x, _ = solver(rhs, A_data=matrix_data)
+        x, _ = solver(rhs, A=matrix_data)
         return jnp.sum(x**2)
 
     with jax.set_mesh(mesh):
-        compiled_solve = jax.jit(
-            lambda matrix_data, rhs: solver(rhs, A_data=matrix_data)
-        )
+        compiled_solve = jax.jit(lambda matrix_data, rhs: solver(rhs, A=matrix_data))
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1)))
         compiled_cached_grad = jax.jit(jax.grad(loss, argnums=1))
         x, info = compiled_solve(A_data, b)
@@ -260,17 +262,17 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
     )
 
     def loss(matrix_data, rhs, guess):
-        x, _ = solver(rhs, guess, A_data=matrix_data)
+        x, _ = solver(rhs, guess, A=matrix_data)
         return jnp.sum(x**2)
 
     with jax.set_mesh(mesh):
         compiled_solve = jax.jit(
-            lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
+            lambda matrix_data, rhs, guess: solver(rhs, guess, A=matrix_data)
         )
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
         compiled_vmap = jax.jit(
             lambda matrix_data, rhs_batch: jax.vmap(
-                lambda rhs: solver(rhs, A_data=matrix_data)[0]
+                lambda rhs: solver(rhs, A=matrix_data)[0]
             )(rhs_batch)
         )
         x, info = compiled_solve(matrix.data, b, x0)
@@ -350,12 +352,12 @@ def test_sharded_uneven_row_partitions(sharding_context):
     A_data = matrix.data + jnp.asarray(0.05, matrix.data.dtype)
 
     def loss(matrix_data, rhs, guess):
-        x, _ = solver(rhs, guess, A_data=matrix_data)
+        x, _ = solver(rhs, guess, A=matrix_data)
         return jnp.sum(x**2)
 
     with jax.set_mesh(mesh):
         compiled_solve = jax.jit(
-            lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
+            lambda matrix_data, rhs, guess: solver(rhs, guess, A=matrix_data)
         )
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
         x, info = compiled_solve(A_data, b, x0)
@@ -462,13 +464,11 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     )
 
     def loss(matrix_data, rhs):
-        x, _ = solver(rhs, A_data=matrix_data)
+        x, _ = solver(rhs, A=matrix_data)
         return jnp.sum(x**2)
 
     with jax.set_mesh(mesh):
-        compiled_solve = jax.jit(
-            lambda matrix_data, rhs: solver(rhs, A_data=matrix_data)
-        )
+        compiled_solve = jax.jit(lambda matrix_data, rhs: solver(rhs, A=matrix_data))
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1)))
         x, info = compiled_solve(matrix.data, b)
         grad_A_data, grad_b = compiled_grad(matrix.data, b)
@@ -515,3 +515,88 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     assert solver.global_size == n_global
     assert solver.local_size == n_local
     assert _local_status(info) == 0
+
+
+def test_sharded_operator_parameter_gradients(sharding_context):
+    """``solver(rhs, A=operator)``: eager and compiled gradients of a parameter
+    the operator closes over match the MPI interface's allreduced gradient."""
+    comm, rank, nranks, mesh = sharding_context
+    grid = 8
+    n_global = grid * grid
+    row_start, row_end, n_local = get_partition_info(n_global, rank, nranks)
+    config = {
+        "solver": "PBICGSTAB",
+        "preconditioner": {"solver": "JACOBI_L1"},
+        "communicator": "MPI_DIRECT",
+        "max_iters": 200,
+        "tolerance": 1e-12,
+    }
+
+    def local_operator(skew):
+        operator, _, _ = partition_operator(
+            poisson_operator(skew), n_global, rank, nranks
+        )
+        return operator
+
+    b_local = rhs_ones(n_local)
+    b = jaxamg.make_sharded_vector(b_local, comm=comm, mesh=mesh, global_size=n_global)
+    coloring = jaxamg.cache_coloring(local_operator(0.0), shape=(n_local, n_global))
+    matrix = jaxamg.make_sharded_matrix(
+        jaxamg.with_cache(local_operator(0.0), coloring=coloring),
+        b,
+        comm=comm,
+        mesh=mesh,
+    )
+    solver = jaxamg.make_sharded_solver(matrix, b, config=config)
+
+    true_skew = 3.0
+    with jax.set_mesh(mesh):
+        x_target, info = solver(b, A=local_operator(true_skew))
+    assert _local_status(info) == 0
+
+    def loss(skew, rhs, target):
+        x, _ = solver(rhs, A=local_operator(skew))
+        return jnp.sum((x - target) ** 2) / n_global
+
+    # Reference: the MPI interface's rank-local loss, reduced by hand as in
+    # the MPI demo.
+    mpi_cache = jaxamg.cache_mpi_metadata(
+        config,
+        comm,
+        n_global,
+        (row_start, row_end),
+        jaxamg.with_cache(local_operator(0.0), coloring=coloring),
+    )
+    target_local = np.asarray(solver.local_vector(x_target))
+
+    def loss_local(skew):
+        operator = jaxamg.with_cache(
+            local_operator(skew), coloring=coloring, mpi=mpi_cache
+        )
+        x, _ = jaxamg.solve(operator, b_local)
+        return jnp.sum((x - target_local) ** 2) / n_global
+
+    skew = 1.0
+    reference_loss = comm.allreduce(float(loss_local(skew)), op=MPI.SUM)
+    reference_grad = comm.allreduce(float(jax.grad(loss_local)(skew)), op=MPI.SUM)
+    assert reference_grad != 0.0
+
+    with jax.set_mesh(mesh):
+        eager_loss, eager_grad = jax.value_and_grad(loss)(skew, b, x_target)
+        compiled_loss, compiled_grad = jax.jit(jax.value_and_grad(loss))(
+            skew, b, x_target
+        )
+    for value, grad in ((eager_loss, eager_grad), (compiled_loss, compiled_grad)):
+        assert float(value) == pytest.approx(reference_loss, rel=1e-4)
+        assert float(grad) == pytest.approx(reference_grad, rel=1e-4)
+
+    # A value that differs across ranks cannot be closed over (its cotangent
+    # would be summed). Detected under jit; a use that leaves the operator's
+    # output sharded fails earlier in JAX's sharding checks.
+    def sharded_closure(coefficients, rhs):
+        base = local_operator(1.0)
+        return solver(rhs, A=lambda v: base(v) * jnp.mean(coefficients))[0]
+
+    with jax.set_mesh(mesh):
+        with pytest.raises(ValueError, match="identical on every rank"):
+            jax.jit(sharded_closure).lower(b, b)

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -154,7 +154,6 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
     solver = jaxamg.make_sharded_solver(
         A_local,
         b,
-        comm=comm,
         mesh=mesh,
         config={
             "solver": "GMRES",
@@ -313,7 +312,7 @@ def test_sharded_uneven_row_partitions(sharding_context):
     n_local = row_end - row_start
     b_local = np.arange(row_start + 1, row_end + 1, dtype=np.float32)
     x0_local = np.full(n_local, 0.25, dtype=np.float32)
-    b = jaxamg.make_sharded_vector(b_local, comm=comm, mesh=mesh, global_size=n_global)
+    b = jaxamg.make_sharded_vector(b_local, mesh=mesh, global_size=n_global)
     x0 = jaxamg.make_sharded_vector(
         x0_local, comm=comm, mesh=mesh, global_size=n_global
     )
@@ -394,7 +393,7 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     )
     n_local = row_end - row_start
     b_local = np.linspace(row_start + 1.0, row_end, n_local, dtype=np.float32)
-    b = jaxamg.make_sharded_vector(b_local, comm=comm, mesh=mesh, global_size=n_global)
+    b = jaxamg.make_sharded_vector(b_local, mesh=mesh, global_size=n_global)
     solver = jaxamg.make_sharded_solver(
         A_local,
         b,

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -600,3 +600,93 @@ def test_sharded_operator_parameter_gradients(sharding_context):
     with jax.set_mesh(mesh):
         with pytest.raises(ValueError, match="identical on every rank"):
             jax.jit(sharded_closure).lower(b, b)
+
+
+@pytest.mark.parametrize("symmetric", [False, True])
+def test_sharded_nullspace(sharding_context, symmetric, monkeypatch):
+    """Singular finite-volume Poisson on a stretched grid (nonsymmetric
+    volume-normalized form, or the symmetric flux form): eager and compiled
+    solves and RHS gradients against the pseudo-inverse."""
+    comm, rank, nranks, mesh = sharding_context
+    jax.config.update("jax_enable_x64", True)
+    try:
+        from jaxamg.matrices import poisson_matrix_stretched
+        from jaxamg.mpi_utils import partition_csr_matrix
+        from jaxamg.utils import to_scipy
+
+        A_global, V_global = poisson_matrix_stretched(
+            24, 16, 1.08, normalize=not symmetric, dtype=jnp.float64
+        )
+        n = A_global.shape[0]
+        V_np = np.ones(n) if symmetric else np.asarray(V_global)
+        rng = np.random.default_rng(0)
+        b_global = rng.standard_normal(n)
+        b_global -= (V_np @ b_global) / V_np.sum()  # consistent RHS
+        w_global = rng.standard_normal(n) + 0.5
+
+        A_local, row_start, row_end = partition_csr_matrix(A_global, rank, nranks)
+        rows = slice(row_start, row_end)
+        bases = {"nullspace": "constant"}
+        if not symmetric:
+            bases["transpose_nullspace"] = jnp.asarray(V_np[rows])
+        b = jaxamg.make_sharded_vector(b_global[rows], comm=comm, mesh=mesh)
+        w = jaxamg.make_sharded_vector(w_global[rows], comm=comm, mesh=mesh)
+        A = jaxamg.make_sharded_matrix(
+            jaxamg.with_cache(A_local, **bases), b, comm=comm, mesh=mesh
+        )
+        solver = jaxamg.make_sharded_solver(
+            A, b, config={"tolerance": 1e-10, "max_iters": 300}, is_symmetric=symmetric
+        )
+
+        def loss(rhs, A_data, weights):
+            return jnp.sum(weights * solver(rhs, A=A_data)[0])
+
+        # Bases were validated at creation; tracing must not validate again
+        # (that would be a host collective inside the trace).
+        import jaxamg.jaxamg as core
+
+        validations = []
+        monkeypatch.setattr(
+            core, "validate_basis", lambda *args: validations.append(args)
+        )
+        with jax.set_mesh(mesh):
+            jax.jit(loss).lower(b, A.data, w)
+            jax.jit(lambda rhs, x0, A_data: solver(rhs, x0, A=A_data)[0]).lower(
+                b, b, A.data
+            )
+            jax.jit(jax.grad(loss)).lower(b, A.data, w)
+        monkeypatch.undo()
+        assert validations == []
+
+        x, info = solver(b)
+        assert _local_status(info) == 0
+        inconsistency = np.asarray(info["rhs_inconsistency"].addressable_shards[0].data)
+        assert inconsistency.item() < 1e-12
+
+        # Scaling A preserves both null spaces: d(w·x)/ds = -w·x at s = 1.
+        def scaled_loss(scale, rhs, A_data, weights):
+            return loss(rhs, scale * A_data, weights)
+
+        with jax.set_mesh(mesh):
+            g_eager = jax.grad(loss)(b, A.data, w)
+            g_jit = jax.jit(jax.grad(loss))(b, A.data, w)
+            wx, ds_eager = jax.value_and_grad(scaled_loss)(1.0, b, A.data, w)
+            ds_jit = jax.jit(jax.grad(scaled_loss))(1.0, b, A.data, w)
+        np.testing.assert_allclose(float(ds_eager), -float(wx), rtol=1e-6)
+        np.testing.assert_allclose(float(ds_jit), -float(wx), rtol=1e-6)
+
+        x_np = _gather_unpadded(x, solver, comm)
+        g1 = _gather_unpadded(g_eager, solver, comm)
+        g2 = _gather_unpadded(g_jit, solver, comm)
+        if rank == 0:
+            A_dense = to_scipy(A_global).toarray().astype(np.float64)
+            assert abs(x_np.mean()) < 1e-10 * np.linalg.norm(x_np)
+            assert np.linalg.norm(A_dense @ x_np - b_global) < 1e-7 * np.linalg.norm(
+                b_global
+            )
+            g_ref = np.linalg.pinv(A_dense).T @ w_global
+            atol = 1e-8 * np.linalg.norm(g_ref)
+            np.testing.assert_allclose(g1, g_ref, rtol=1e-6, atol=atol)
+            np.testing.assert_allclose(g2, g_ref, rtol=1e-6, atol=atol)
+    finally:
+        jax.config.update("jax_enable_x64", False)

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -154,7 +154,6 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
     solver = jaxamg.make_sharded_solver(
         A_local,
         b,
-        mesh=mesh,
         config={
             "solver": "GMRES",
             "preconditioner": {"solver": "JACOBI_L1"},
@@ -312,7 +311,7 @@ def test_sharded_uneven_row_partitions(sharding_context):
     n_local = row_end - row_start
     b_local = np.arange(row_start + 1, row_end + 1, dtype=np.float32)
     x0_local = np.full(n_local, 0.25, dtype=np.float32)
-    b = jaxamg.make_sharded_vector(b_local, mesh=mesh, global_size=n_global)
+    b = jaxamg.make_sharded_vector(b_local, global_size=n_global)
     x0 = jaxamg.make_sharded_vector(
         x0_local, comm=comm, mesh=mesh, global_size=n_global
     )
@@ -393,7 +392,7 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     )
     n_local = row_end - row_start
     b_local = np.linspace(row_start + 1.0, row_end, n_local, dtype=np.float32)
-    b = jaxamg.make_sharded_vector(b_local, mesh=mesh, global_size=n_global)
+    b = jaxamg.make_sharded_vector(b_local, global_size=n_global)
     solver = jaxamg.make_sharded_solver(
         A_local,
         b,

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -168,7 +168,6 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
 
     # Change every real matrix value after setup. Padding is also changed but
     # must remain disconnected from both the solve and its gradient.
-    assert solver.A_data is matrix.data
     A_data = matrix.data + jnp.asarray(0.1, dtype=matrix.data.dtype)
 
     def loss(matrix_data, rhs):
@@ -246,11 +245,10 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
     x0_local = np.full(n_local, 0.25, dtype=np.float32)
     b = _global_vector(b_local, n_global, mesh)
     x0 = _global_vector(x0_local, n_global, mesh)
+    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
     solver = jaxamg.make_sharded_solver(
-        A_local,
+        matrix,
         b,
-        comm=comm,
-        mesh=mesh,
         is_symmetric=True,
         config={
             "solver": "CG",
@@ -270,8 +268,8 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
             lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
         )
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
-        x, info = compiled_solve(solver.A_data, b, x0)
-        grad_A_data, grad_b, grad_x0 = compiled_grad(solver.A_data, b, x0)
+        x, info = compiled_solve(matrix.data, b, x0)
+        grad_A_data, grad_b, grad_x0 = compiled_grad(matrix.data, b, x0)
     x.block_until_ready()
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()
@@ -291,7 +289,7 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
     np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
     np.testing.assert_array_equal(grad_x0_global, 0)
 
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_local = matrix.local_matrix(grad_A_data)
     row_indices = np.repeat(
         np.arange(row_start, row_end), np.diff(np.asarray(A_local.indptr))
     )
@@ -321,11 +319,10 @@ def test_sharded_uneven_row_partitions(sharding_context):
     x0 = jaxamg.make_sharded_vector(
         x0_local, comm=comm, mesh=mesh, global_size=n_global
     )
+    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
     solver = jaxamg.make_sharded_solver(
-        A_local,
+        matrix,
         b,
-        comm=comm,
-        mesh=mesh,
         config={
             "solver": "GMRES",
             "preconditioner": {"solver": "JACOBI_L1"},
@@ -334,7 +331,7 @@ def test_sharded_uneven_row_partitions(sharding_context):
             "tolerance": 1e-8,
         },
     )
-    A_data = solver.A_data + jnp.asarray(0.05, solver.A_data.dtype)
+    A_data = matrix.data + jnp.asarray(0.05, matrix.data.dtype)
 
     def loss(matrix_data, rhs, guess):
         x, _ = solver(rhs, guess, A_data=matrix_data)
@@ -366,7 +363,7 @@ def test_sharded_uneven_row_partitions(sharding_context):
     np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
     np.testing.assert_array_equal(grad_x0_global, 0)
 
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_local = matrix.local_matrix(grad_A_data)
     row_indices = np.repeat(
         np.arange(row_start, row_end), np.diff(np.asarray(A_local.indptr))
     )
@@ -399,11 +396,10 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     n_local = row_end - row_start
     b_local = np.linspace(row_start + 1.0, row_end, n_local, dtype=np.float32)
     b = jaxamg.make_sharded_vector(b_local, global_size=n_global)
+    matrix = jaxamg.make_sharded_matrix(A_local, b)
     solver = jaxamg.make_sharded_solver(
-        A_local,
+        matrix,
         b,
-        comm=comm,
-        mesh=mesh,
         is_symmetric=is_symmetric,
         block_dim=block_dim,
         config={
@@ -424,8 +420,8 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
             lambda matrix_data, rhs: solver(rhs, A_data=matrix_data)
         )
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1)))
-        x, info = compiled_solve(solver.A_data, b)
-        grad_A_data, grad_b = compiled_grad(solver.A_data, b)
+        x, info = compiled_solve(matrix.data, b)
+        grad_A_data, grad_b = compiled_grad(matrix.data, b)
     x.block_until_ready()
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()
@@ -444,7 +440,7 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
         atol=1e-6,
     )
 
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_local = matrix.local_matrix(grad_A_data)
     local_rows = np.repeat(
         np.arange(row_start, row_end), np.diff(np.asarray(A_local.indptr))
     )
@@ -508,11 +504,10 @@ def test_sharded_batched_rhs_gradients(sharding_context):
     x0 = jaxamg.make_sharded_vector(
         x0_local, comm=comm, mesh=mesh, global_size=n_global
     )
+    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
     solver = jaxamg.make_sharded_solver(
-        A_local,
+        matrix,
         b,
-        comm=comm,
-        mesh=mesh,
         config={
             "solver": "FGMRES",
             "preconditioner": {"solver": "JACOBI_L1"},
@@ -521,7 +516,7 @@ def test_sharded_batched_rhs_gradients(sharding_context):
             "tolerance": 1e-8,
         },
     )
-    A_data = solver.A_data + jnp.asarray(0.05, solver.A_data.dtype)
+    A_data = matrix.data + jnp.asarray(0.05, matrix.data.dtype)
 
     def loss(matrix_data, rhs, guess):
         x, _ = solver(rhs, guess, A_data=matrix_data)
@@ -565,7 +560,7 @@ def test_sharded_batched_rhs_gradients(sharding_context):
         _gather_unpadded(grad_x0, solver, comm), np.zeros_like(b_reference)
     )
 
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_local = matrix.local_matrix(grad_A_data)
     grad_A_reference = -np.sum(
         adjoint_reference[local_rows]
         * x_reference[np.asarray(A_local.indices, dtype=np.int64)],

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -465,3 +465,122 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     assert solver.global_size == n_global
     assert solver.local_size == n_local
     assert _local_status(info) == 0
+
+
+def test_sharded_batched_rhs_gradients(sharding_context):
+    """Solve multiple RHS columns and accumulate their shared matrix VJP."""
+    comm, rank, nranks, mesh = sharding_context
+    nrhs = 3
+    n_global = 4 * nranks + 1
+    template, row_start, row_end = tridiagonal_matrix_distributed(
+        n_global, rank, nranks, diagonal_value=4.0, dtype=jnp.float32
+    )
+    n_local = row_end - row_start
+    local_rows = np.repeat(
+        np.arange(row_start, row_end), np.diff(np.asarray(template.indptr))
+    )
+    local_columns = np.asarray(template.indices)
+    local_values = np.where(
+        local_columns < local_rows,
+        -0.75,
+        np.where(local_columns > local_rows, -1.25, 4.0),
+    ).astype(np.float32)
+    A_local = jsp.BCSR(
+        (jnp.asarray(local_values), template.indices, template.indptr),
+        shape=template.shape,
+    )
+
+    local_indices = np.arange(row_start, row_end, dtype=np.float32)
+    b_local = np.stack(
+        (
+            local_indices + 1.0,
+            1.0 + 0.1 * local_indices,
+            2.0 - 0.05 * local_indices,
+        ),
+        axis=1,
+    )
+    x0_local = np.full((n_local, nrhs), 0.1, dtype=np.float32)
+    b = jaxamg.make_sharded_vector(b_local, comm=comm, mesh=mesh, global_size=n_global)
+    x0 = jaxamg.make_sharded_vector(
+        x0_local, comm=comm, mesh=mesh, global_size=n_global
+    )
+    solver = jaxamg.make_sharded_solver(
+        A_local,
+        b,
+        comm=comm,
+        mesh=mesh,
+        config={
+            "solver": "FGMRES",
+            "preconditioner": {"solver": "JACOBI_L1"},
+            "communicator": "MPI_DIRECT",
+            "max_iters": 100,
+            "tolerance": 1e-8,
+        },
+    )
+    A_data = solver.A_data + jnp.asarray(0.05, solver.A_data.dtype)
+
+    def loss(matrix_data, rhs, guess):
+        x, _ = solver(rhs, guess, A_data=matrix_data)
+        return jnp.sum(x**2)
+
+    with jax.set_mesh(mesh):
+        compiled_solve = jax.jit(
+            lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
+        )
+        compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
+        x, info = compiled_solve(A_data, b, x0)
+        grad_A_data, grad_b, grad_x0 = compiled_grad(A_data, b, x0)
+    x.block_until_ready()
+    grad_A_data.block_until_ready()
+    grad_b.block_until_ready()
+    grad_x0.block_until_ready()
+
+    A_reference = 4.05 * np.eye(n_global, dtype=np.float64)
+    A_reference += np.diag(-1.20 * np.ones(n_global - 1), 1)
+    A_reference += np.diag(-0.70 * np.ones(n_global - 1), -1)
+    global_indices = np.arange(n_global, dtype=np.float64)
+    b_reference = np.stack(
+        (
+            global_indices + 1.0,
+            1.0 + 0.1 * global_indices,
+            2.0 - 0.05 * global_indices,
+        ),
+        axis=1,
+    )
+    x_reference = np.linalg.solve(A_reference, b_reference)
+    adjoint_reference = np.linalg.solve(A_reference.T, 2.0 * x_reference)
+    x_global = _gather_unpadded(x, solver, comm)
+    np.testing.assert_allclose(x_global, x_reference, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(
+        _gather_unpadded(grad_b, solver, comm),
+        adjoint_reference,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    np.testing.assert_array_equal(
+        _gather_unpadded(grad_x0, solver, comm), np.zeros_like(b_reference)
+    )
+
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_reference = -np.sum(
+        adjoint_reference[local_rows]
+        * x_reference[np.asarray(A_local.indices, dtype=np.int64)],
+        axis=1,
+    )
+    np.testing.assert_allclose(
+        np.asarray(grad_A_local.data),
+        grad_A_reference,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+    x_physical = np.asarray(x.addressable_shards[0].data)
+    grad_b_physical = np.asarray(grad_b.addressable_shards[0].data)
+    grad_A_physical = np.asarray(grad_A_data.addressable_shards[0].data)
+    np.testing.assert_array_equal(x_physical[n_local:], 0)
+    np.testing.assert_array_equal(grad_b_physical[n_local:], 0)
+    np.testing.assert_array_equal(grad_A_physical[len(A_local.data) :], 0)
+    assert info["iterations"].shape == (nranks, nrhs)
+    assert info["residual_history"].shape[:2] == (nranks, nrhs)
+    local_status = np.asarray(info["status"].addressable_shards[0].data)
+    np.testing.assert_array_equal(local_status, 0)

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -151,8 +151,9 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
     )
     b_local = np.arange(row_start + 1, row_start + n_local + 1, dtype=np.float32)
     b = _global_vector(b_local, n_global, mesh)
+    matrix = jaxamg.make_sharded_matrix(A_local, b)
     solver = jaxamg.make_sharded_solver(
-        A_local,
+        matrix,
         b,
         config={
             "solver": "GMRES",
@@ -165,7 +166,8 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
 
     # Change every real matrix value after setup. Padding is also changed but
     # must remain disconnected from both the solve and its gradient.
-    A_data = solver.A_data + jnp.asarray(0.1, dtype=solver.A_data.dtype)
+    assert solver.A_data is matrix.data
+    A_data = matrix.data + jnp.asarray(0.1, dtype=matrix.data.dtype)
 
     def loss(matrix_data, rhs):
         x, _ = solver(rhs, A_data=matrix_data)
@@ -216,7 +218,7 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
     )
     np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
 
-    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    grad_A_local = matrix.local_matrix(grad_A_data)
     local_rows = np.repeat(
         np.arange(row_start, row_start + n_local), np.diff(np.asarray(indptr))
     )

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -126,12 +126,26 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
         x, _ = solver(rhs, A_data=matrix_data)
         return jnp.sum(x**2)
 
-    x, info = solver(b, A_data=A_data)
+    def cached_loss(rhs):
+        x, _ = solver(rhs)
+        return jnp.sum(x**2)
+
     with jax.set_mesh(mesh):
-        grad_A_data, grad_b = jax.grad(loss, argnums=(0, 1))(A_data, b)
+        compiled_solve = jax.jit(
+            lambda matrix_data, rhs: solver(rhs, A_data=matrix_data)
+        )
+        compiled_cached_solve = jax.jit(solver)
+        compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1)))
+        compiled_cached_grad = jax.jit(jax.grad(cached_loss))
+        x, info = compiled_solve(A_data, b)
+        x_cached, _ = compiled_cached_solve(b)
+        grad_A_data, grad_b = compiled_grad(A_data, b)
+        grad_b_cached = compiled_cached_grad(b)
     x.block_until_ready()
+    x_cached.block_until_ready()
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()
+    grad_b_cached.block_until_ready()
 
     x_global = _gather_global(x, comm)
     grad_b_global = _gather_global(grad_b, comm)
@@ -142,6 +156,19 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
     adjoint_ref = np.linalg.solve(A_global.T, 2.0 * x_ref)
 
     np.testing.assert_allclose(x_global, x_ref, rtol=1e-5, atol=1e-6)
+    A_cached_global = 4.0 * np.eye(n_global, dtype=np.float64)
+    A_cached_global[1:, 0] = -0.25
+    x_cached_ref = np.linalg.solve(A_cached_global, b_global)
+    adjoint_cached_ref = np.linalg.solve(A_cached_global.T, 2.0 * x_cached_ref)
+    np.testing.assert_allclose(
+        _gather_global(x_cached, comm), x_cached_ref, rtol=1e-5, atol=1e-6
+    )
+    np.testing.assert_allclose(
+        _gather_global(grad_b_cached, comm),
+        adjoint_cached_ref,
+        rtol=1e-5,
+        atol=1e-6,
+    )
     np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
 
     grad_A_local = solver.local_matrix_gradient(grad_A_data)
@@ -189,11 +216,13 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
         x, _ = solver(rhs, guess, A_data=matrix_data)
         return jnp.sum(x**2)
 
-    x, info = solver(b, x0, A_data=solver.A_data)
     with jax.set_mesh(mesh):
-        grad_A_data, grad_b, grad_x0 = jax.grad(loss, argnums=(0, 1, 2))(
-            solver.A_data, b, x0
+        compiled_solve = jax.jit(
+            lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
         )
+        compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
+        x, info = compiled_solve(solver.A_data, b, x0)
+        grad_A_data, grad_b, grad_x0 = compiled_grad(solver.A_data, b, x0)
     x.block_until_ready()
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -268,12 +268,17 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
             lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
         )
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
+        compiled_vmap = jax.jit(
+            jax.vmap(lambda rhs: solver(rhs, A_data=matrix.data)[0])
+        )
         x, info = compiled_solve(matrix.data, b, x0)
         grad_A_data, grad_b, grad_x0 = compiled_grad(matrix.data, b, x0)
+        x_batched = compiled_vmap(jnp.stack((b, 2 * b)))
     x.block_until_ready()
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()
     grad_x0.block_until_ready()
+    x_batched.block_until_ready()
 
     x_global = _gather_global(x, comm)
     grad_b_global = _gather_global(grad_b, comm)
@@ -286,6 +291,15 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
     adjoint_ref = np.linalg.solve(A_global.T, 2.0 * x_ref)
 
     np.testing.assert_allclose(x_global, x_ref, rtol=1e-5, atol=1e-6)
+    x_batched_global = np.concatenate(
+        comm.allgather(np.asarray(x_batched.addressable_shards[0].data)), axis=1
+    )
+    np.testing.assert_allclose(
+        x_batched_global,
+        np.stack((x_ref, 2 * x_ref)),
+        rtol=1e-5,
+        atol=1e-6,
+    )
     np.testing.assert_allclose(grad_b_global, adjoint_ref, rtol=1e-5, atol=1e-6)
     np.testing.assert_array_equal(grad_x0_global, 0)
 
@@ -465,121 +479,3 @@ def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     assert solver.global_size == n_global
     assert solver.local_size == n_local
     assert _local_status(info) == 0
-
-
-def test_sharded_batched_rhs_gradients(sharding_context):
-    """Solve multiple RHS columns and accumulate their shared matrix VJP."""
-    comm, rank, nranks, mesh = sharding_context
-    nrhs = 3
-    n_global = 4 * nranks + 1
-    template, row_start, row_end = tridiagonal_matrix_distributed(
-        n_global, rank, nranks, diagonal_value=4.0, dtype=jnp.float32
-    )
-    n_local = row_end - row_start
-    local_rows = np.repeat(
-        np.arange(row_start, row_end), np.diff(np.asarray(template.indptr))
-    )
-    local_columns = np.asarray(template.indices)
-    local_values = np.where(
-        local_columns < local_rows,
-        -0.75,
-        np.where(local_columns > local_rows, -1.25, 4.0),
-    ).astype(np.float32)
-    A_local = jsp.BCSR(
-        (jnp.asarray(local_values), template.indices, template.indptr),
-        shape=template.shape,
-    )
-
-    local_indices = np.arange(row_start, row_end, dtype=np.float32)
-    b_local = np.stack(
-        (
-            local_indices + 1.0,
-            1.0 + 0.1 * local_indices,
-            2.0 - 0.05 * local_indices,
-        ),
-        axis=1,
-    )
-    x0_local = np.full((n_local, nrhs), 0.1, dtype=np.float32)
-    b = jaxamg.make_sharded_vector(b_local, comm=comm, mesh=mesh, global_size=n_global)
-    x0 = jaxamg.make_sharded_vector(
-        x0_local, comm=comm, mesh=mesh, global_size=n_global
-    )
-    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
-    solver = jaxamg.make_sharded_solver(
-        matrix,
-        b,
-        config={
-            "solver": "FGMRES",
-            "preconditioner": {"solver": "JACOBI_L1"},
-            "communicator": "MPI_DIRECT",
-            "max_iters": 100,
-            "tolerance": 1e-8,
-        },
-    )
-    A_data = matrix.data + jnp.asarray(0.05, matrix.data.dtype)
-
-    def loss(matrix_data, rhs, guess):
-        x, _ = solver(rhs, guess, A_data=matrix_data)
-        return jnp.sum(x**2)
-
-    with jax.set_mesh(mesh):
-        compiled_solve = jax.jit(
-            lambda matrix_data, rhs, guess: solver(rhs, guess, A_data=matrix_data)
-        )
-        compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
-        x, info = compiled_solve(A_data, b, x0)
-        grad_A_data, grad_b, grad_x0 = compiled_grad(A_data, b, x0)
-    x.block_until_ready()
-    grad_A_data.block_until_ready()
-    grad_b.block_until_ready()
-    grad_x0.block_until_ready()
-
-    A_reference = 4.05 * np.eye(n_global, dtype=np.float64)
-    A_reference += np.diag(-1.20 * np.ones(n_global - 1), 1)
-    A_reference += np.diag(-0.70 * np.ones(n_global - 1), -1)
-    global_indices = np.arange(n_global, dtype=np.float64)
-    b_reference = np.stack(
-        (
-            global_indices + 1.0,
-            1.0 + 0.1 * global_indices,
-            2.0 - 0.05 * global_indices,
-        ),
-        axis=1,
-    )
-    x_reference = np.linalg.solve(A_reference, b_reference)
-    adjoint_reference = np.linalg.solve(A_reference.T, 2.0 * x_reference)
-    x_global = _gather_unpadded(x, solver, comm)
-    np.testing.assert_allclose(x_global, x_reference, rtol=1e-5, atol=1e-6)
-    np.testing.assert_allclose(
-        _gather_unpadded(grad_b, solver, comm),
-        adjoint_reference,
-        rtol=1e-5,
-        atol=1e-6,
-    )
-    np.testing.assert_array_equal(
-        _gather_unpadded(grad_x0, solver, comm), np.zeros_like(b_reference)
-    )
-
-    grad_A_local = matrix.local_matrix(grad_A_data)
-    grad_A_reference = -np.sum(
-        adjoint_reference[local_rows]
-        * x_reference[np.asarray(A_local.indices, dtype=np.int64)],
-        axis=1,
-    )
-    np.testing.assert_allclose(
-        np.asarray(grad_A_local.data),
-        grad_A_reference,
-        rtol=1e-5,
-        atol=1e-6,
-    )
-
-    x_physical = np.asarray(x.addressable_shards[0].data)
-    grad_b_physical = np.asarray(grad_b.addressable_shards[0].data)
-    grad_A_physical = np.asarray(grad_A_data.addressable_shards[0].data)
-    np.testing.assert_array_equal(x_physical[n_local:], 0)
-    np.testing.assert_array_equal(grad_b_physical[n_local:], 0)
-    np.testing.assert_array_equal(grad_A_physical[len(A_local.data) :], 0)
-    assert info["iterations"].shape == (nranks, nrhs)
-    assert info["residual_history"].shape[:2] == (nranks, nrhs)
-    local_status = np.asarray(info["status"].addressable_shards[0].data)
-    np.testing.assert_array_equal(local_status, 0)

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -399,6 +399,40 @@ def test_sharded_uneven_row_partitions(sharding_context):
     assert _local_status(info) == 0
 
 
+def test_sharded_save_stats_file(sharding_context, tmp_path):
+    """A direct call with save_stats_file writes formatted stats on rank zero."""
+    comm, rank, nranks, mesh = sharding_context
+    n_local = 4
+    n_global = n_local * nranks
+    A_local, row_start, row_end = tridiagonal_matrix_distributed(
+        n_global, rank, nranks, diagonal_value=4.0, dtype=jnp.float32
+    )
+    b_local = np.ones(n_local, dtype=np.float32)
+    b = _global_vector(b_local, n_global, mesh)
+    matrix = jaxamg.make_sharded_matrix(A_local, b, comm=comm, mesh=mesh)
+    solver = jaxamg.make_sharded_solver(
+        matrix,
+        b,
+        is_symmetric=True,
+        save_stats=True,
+        config={
+            "solver": "CG",
+            "preconditioner": {"solver": "AMG"},
+            "communicator": "MPI_DIRECT",
+            "max_iters": 100,
+            "tolerance": 1e-8,
+        },
+    )
+
+    stats_file = tmp_path / "sharded_stats.txt"
+    x, info = solver(b, save_stats_file=stats_file)
+    assert _local_status(info) == 0
+    if rank == 0:
+        content = stats_file.read_text()
+        assert "SOLVER ITERATIONS" in content
+    comm.Barrier()
+
+
 @pytest.mark.parametrize("is_symmetric", [True, False])
 def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
     """Cover block solves and VJPs with uneven block-aligned partitions."""

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -269,11 +269,13 @@ def test_sharded_symmetric_warm_start_gradients(sharding_context):
         )
         compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1, 2)))
         compiled_vmap = jax.jit(
-            jax.vmap(lambda rhs: solver(rhs, A_data=matrix.data)[0])
+            lambda matrix_data, rhs_batch: jax.vmap(
+                lambda rhs: solver(rhs, A_data=matrix_data)[0]
+            )(rhs_batch)
         )
         x, info = compiled_solve(matrix.data, b, x0)
         grad_A_data, grad_b, grad_x0 = compiled_grad(matrix.data, b, x0)
-        x_batched = compiled_vmap(jnp.stack((b, 2 * b)))
+        x_batched = compiled_vmap(matrix.data, jnp.stack((b, 2 * b)))
     x.block_until_ready()
     grad_A_data.block_until_ready()
     grad_b.block_until_ready()

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -150,8 +150,10 @@ def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
         shape=(n_local, n_global),
     )
     b_local = np.arange(row_start + 1, row_start + n_local + 1, dtype=np.float32)
-    b = _global_vector(b_local, n_global, mesh)
-    matrix = jaxamg.make_sharded_matrix(A_local, b)
+    b_local_device = jnp.asarray(b_local)
+    with jax.transfer_guard_device_to_host("disallow"):
+        b = jaxamg.make_sharded_vector(b_local_device, mesh=mesh, global_size=n_global)
+        matrix = jaxamg.make_sharded_matrix(A_local, b)
     solver = jaxamg.make_sharded_solver(
         matrix,
         b,
@@ -312,8 +314,10 @@ def test_sharded_uneven_row_partitions(sharding_context):
     )
     n_local = row_end - row_start
     b_local = np.arange(row_start + 1, row_end + 1, dtype=np.float32)
+    b_local_device = jnp.asarray(b_local)
     x0_local = np.full(n_local, 0.25, dtype=np.float32)
-    b = jaxamg.make_sharded_vector(b_local, global_size=n_global)
+    with jax.transfer_guard_device_to_host("disallow"):
+        b = jaxamg.make_sharded_vector(b_local_device, global_size=n_global)
     x0 = jaxamg.make_sharded_vector(
         x0_local, comm=comm, mesh=mesh, global_size=n_global
     )

--- a/tests/test_sharding_mpi.py
+++ b/tests/test_sharding_mpi.py
@@ -28,6 +28,7 @@ if _SHARDING_TEST:
 
 import jaxamg  # noqa: E402
 from jaxamg.matrices import tridiagonal_matrix_distributed  # noqa: E402
+from jaxamg.mpi_utils import get_partition_info  # noqa: E402
 from jaxamg.sharding import ShardedSolve  # noqa: E402
 
 pytestmark = [
@@ -80,6 +81,44 @@ def _gather_unpadded(
 def _local_status(info: dict[str, jax.Array]) -> int:
     status = np.asarray(info["status"].addressable_shards[0].data)
     return int(status.item())
+
+
+def _distributed_block_system(
+    n_blocks: int,
+    rank: int,
+    nranks: int,
+    *,
+    symmetric: bool,
+) -> tuple[jsp.BCSR, np.ndarray, int, int]:
+    """Build a block-aligned local partition and its small dense reference."""
+    import scipy.sparse
+
+    block_dim = 2
+    lower = -np.ones(n_blocks - 1, dtype=np.float32)
+    upper = lower if symmetric else -1.25 * np.ones_like(lower)
+    node_matrix = scipy.sparse.diags(
+        (lower, 4.0 * np.ones(n_blocks, dtype=np.float32), upper),
+        offsets=(-1, 0, 1),
+        format="csr",
+    )
+    coupling = np.array(
+        [[2.0, 0.25], [0.25 if symmetric else 0.5, 1.5]], dtype=np.float32
+    )
+    A_global = scipy.sparse.kron(node_matrix, coupling, format="csr")
+
+    block_start, block_end, _ = get_partition_info(n_blocks, rank, nranks)
+    row_start = block_start * block_dim
+    row_end = block_end * block_dim
+    A_partition = A_global[row_start:row_end]
+    A_local = jsp.BCSR(
+        (
+            jnp.asarray(A_partition.data, dtype=jnp.float32),
+            jnp.asarray(A_partition.indices, dtype=jnp.int32),
+            jnp.asarray(A_partition.indptr, dtype=jnp.int32),
+        ),
+        shape=A_partition.shape,
+    )
+    return A_local, A_global.toarray(), row_start, row_end
 
 
 def test_sharded_nonsymmetric_matrix_and_rhs_gradients(sharding_context):
@@ -338,6 +377,91 @@ def test_sharded_uneven_row_partitions(sharding_context):
     grad_b_physical = np.asarray(grad_b.addressable_shards[0].data)
     np.testing.assert_array_equal(x_physical[n_local:], 0)
     np.testing.assert_array_equal(grad_b_physical[n_local:], 0)
+    assert solver.global_size == n_global
+    assert solver.local_size == n_local
+    assert _local_status(info) == 0
+
+
+@pytest.mark.parametrize("is_symmetric", [True, False])
+def test_sharded_block_matrix_gradients(sharding_context, is_symmetric):
+    """Cover block solves and VJPs with uneven block-aligned partitions."""
+    comm, rank, nranks, mesh = sharding_context
+    block_dim = 2
+    n_blocks = 2 * nranks + 1
+    n_global = block_dim * n_blocks
+    A_local, A_global, row_start, row_end = _distributed_block_system(
+        n_blocks, rank, nranks, symmetric=is_symmetric
+    )
+    n_local = row_end - row_start
+    b_local = np.linspace(row_start + 1.0, row_end, n_local, dtype=np.float32)
+    b = jaxamg.make_sharded_vector(b_local, comm=comm, mesh=mesh, global_size=n_global)
+    solver = jaxamg.make_sharded_solver(
+        A_local,
+        b,
+        comm=comm,
+        mesh=mesh,
+        is_symmetric=is_symmetric,
+        block_dim=block_dim,
+        config={
+            "solver": "FGMRES",
+            "preconditioner": {"solver": "BLOCK_JACOBI"},
+            "communicator": "MPI_DIRECT",
+            "max_iters": 200,
+            "tolerance": 1e-8,
+        },
+    )
+
+    def loss(matrix_data, rhs):
+        x, _ = solver(rhs, A_data=matrix_data)
+        return jnp.sum(x**2)
+
+    with jax.set_mesh(mesh):
+        compiled_solve = jax.jit(
+            lambda matrix_data, rhs: solver(rhs, A_data=matrix_data)
+        )
+        compiled_grad = jax.jit(jax.grad(loss, argnums=(0, 1)))
+        x, info = compiled_solve(solver.A_data, b)
+        grad_A_data, grad_b = compiled_grad(solver.A_data, b)
+    x.block_until_ready()
+    grad_A_data.block_until_ready()
+    grad_b.block_until_ready()
+
+    b_global = np.arange(1, n_global + 1, dtype=np.float64)
+    A_reference = np.asarray(A_global, dtype=np.float64)
+    x_reference = np.linalg.solve(A_reference, b_global)
+    adjoint_reference = np.linalg.solve(A_reference.T, 2.0 * x_reference)
+    np.testing.assert_allclose(
+        _gather_unpadded(x, solver, comm), x_reference, rtol=1e-5, atol=1e-6
+    )
+    np.testing.assert_allclose(
+        _gather_unpadded(grad_b, solver, comm),
+        adjoint_reference,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+    grad_A_local = solver.local_matrix_gradient(grad_A_data)
+    local_rows = np.repeat(
+        np.arange(row_start, row_end), np.diff(np.asarray(A_local.indptr))
+    )
+    grad_A_reference = (
+        -adjoint_reference[local_rows]
+        * x_reference[np.asarray(A_local.indices, dtype=np.int64)]
+    )
+    np.testing.assert_allclose(
+        np.asarray(grad_A_local.data),
+        grad_A_reference,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+    x_physical = np.asarray(x.addressable_shards[0].data)
+    grad_b_physical = np.asarray(grad_b.addressable_shards[0].data)
+    grad_A_physical = np.asarray(grad_A_data.addressable_shards[0].data)
+    np.testing.assert_array_equal(x_physical[n_local:], 0)
+    np.testing.assert_array_equal(grad_b_physical[n_local:], 0)
+    np.testing.assert_array_equal(grad_A_physical[len(A_local.data) :], 0)
+    assert n_local % block_dim == 0
     assert solver.global_size == n_global
     assert solver.local_size == n_local
     assert _local_status(info) == 0

--- a/tests/test_sparsity_cache.py
+++ b/tests/test_sparsity_cache.py
@@ -9,8 +9,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from jaxamg.matrices import poisson3d_operator
+from jaxamg import sparsity
+from jaxamg.matrices import poisson3d_operator, poisson_operator
 from jaxamg.sparsity import (
+    _PROBE_BATCH_BYTES,
+    _probe_batch_size,
     _verify_recovery,
     cache_coloring,
     get_column_coloring,
@@ -384,3 +387,48 @@ class TestMaterializeAutodiff:
 
         g = jax.grad(loss)(2.0)
         assert np.isfinite(float(g)) and float(g) != 0.0
+
+
+class TestProbeBatching:
+    """One-hot probing runs in device-memory-budgeted batches, so an operator
+    partitioned from a global one (global apply, then row slice) never forms an
+    n_global x n_global buffer -- and the batch size never changes the result."""
+
+    def test_batch_size_from_budget(self):
+        assert _probe_batch_size(16, 16, 4) == 16  # small problem: one batch
+        assert _probe_batch_size(10**9, 10**9, 8) == 1  # never below one probe
+        # One rank's half of a 512x512 Poisson grid under x64: the batch stays
+        # within the budget instead of an n_global-wide (n_global^2) basis.
+        m, n = 262144, 131072
+        b = _probe_batch_size(m, n, 8)
+        assert 1 <= b < m
+        assert b * (4 * m + 8 * (2 * m + n)) <= _PROBE_BATCH_BYTES
+
+    def test_pattern_independent_of_batch_size(self, monkeypatch):
+        # A row block of a global operator, probed in one batch and in several
+        # uneven batches: identical (rows, cols) arrays -- the column-major
+        # (col, row) order of the dense pattern -- so the budget only sets the
+        # work per step.
+        grid = 6
+        n_global = grid * grid
+        row_start, row_end = 11, 29
+        n_local = row_end - row_start
+        global_op = poisson_operator(skew=1.0)
+        local_op = lambda x: global_op(x)[row_start:row_end]
+        shape = (n_local, n_global)
+
+        monkeypatch.setattr(sparsity, "_PROBE_BATCH_BYTES", 2**40)
+        assert _probe_batch_size(n_global, n_local, 4) == n_global
+        rows_1, cols_1 = probe_sparsity_pattern(local_op, shape)
+
+        per_probe = 4 * n_global + 4 * (2 * n_global + n_local)  # float32 output
+        monkeypatch.setattr(sparsity, "_PROBE_BATCH_BYTES", 5 * per_probe)
+        assert _probe_batch_size(n_global, n_local, 4) == 5  # 36 cols -> 8 batches
+        rows_5, cols_5 = probe_sparsity_pattern(local_op, shape)
+
+        np.testing.assert_array_equal(rows_5, rows_1)
+        np.testing.assert_array_equal(cols_5, cols_1)
+        J = np.asarray(jax.jacfwd(local_op)(jnp.ones(n_global)))
+        c_ref, r_ref = np.nonzero(J.T)
+        np.testing.assert_array_equal(rows_1, r_ref)
+        np.testing.assert_array_equal(cols_1, c_ref)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -239,3 +239,18 @@ class TestTracingFallback:
         n = 12
         op = lambda x: jnp.ones(n) * (x @ x)
         assert trace_sparsity_pattern(op, (n, n)) is None
+
+
+class TestHostDevice:
+    def test_host_device_is_this_process_cpu(self):
+        # Host-side constant folds must bind on THIS process's CPU device. Under
+        # jax.distributed, jax.devices("cpu")[0] is process 0's and not addressable
+        # on the other ranks; binding on it silently turned every fold into
+        # _UNKNOWN and bailed the whole trace there (e.g. "conv with non-constant
+        # kernel") to one-hot probing.
+        from jaxamg import sparsity_tracing
+
+        dev = sparsity_tracing._host_device()
+        assert dev.platform == "cpu"
+        assert dev in jax.local_devices(backend="cpu")
+        assert sparsity_tracing._host_device() is dev  # resolved once, cached


### PR DESCRIPTION
This PR adds an experimental sharding interface (`make_sharded_solver`, `make_sharded_matrix`, `make_sharded_vector`) that runs the distributed AmgX solve under `shard_map`, keeping the RHS and solution as row-sharded JAX global arrays. It complements the MPI interface rather than replacing it.

Supports block matrices, uneven partitions, batched RHS, singular systems, JIT, and gradients w.r.t. matrix values and RHS.
